### PR TITLE
luajit - add lua.hpp to includefiles

### DIFF
--- a/packages/l/luajit/port/xmake.lua
+++ b/packages/l/luajit/port/xmake.lua
@@ -181,6 +181,7 @@ target("luajit")
     add_defines("_FILE_OFFSET_BITS=64", "LARGEFILE_SOURCE", {public = true})
     add_undefines("_FORTIFY_SOURCE", {public = true})
     add_headerfiles("src/*.h", {prefixdir = "luajit"})
+    add_headerfiles("src/lua.hpp", {prefixdir = "luajit"})
     add_files("src/ljamalg.c")
     add_files("src/lib_base.c",
               "src/lib_math.c",


### PR DESCRIPTION
The `lua.hpp` include was missing from the package, this just adds it.