### PR TITLE
Add nana 1.7.4

### DIFF
--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -7,23 +7,34 @@ package("nana")
              "https://github.com/cnjinhao/nana.git")
     add_versions("1.6.2", "5f5cb791dff292e27bfa29d850b93f809a0d91d6044ea7e22ce7ae76a5d8b24e")
     add_versions("1.7.2", "e2efb3b7619e4ef3b6de93f8afc70ff477ec6cabf4f9740f0d786904c790613f")
+    add_versions("1.7.4", "56f7b1ed006c750fccf8ef15ab1e83f96751f2dfdcb68d93e5f712a6c9b58bcb")
 
     if is_plat("linux", "windows") then
         add_deps("cmake >=3.12")
     end
 
     if is_plat("windows") then
-        add_syslinks("ole32", "shell32", "user32", "kernel32", "user32", "gdi32", "winspool", "comdlg32", "advapi32")
+        add_syslinks("ole32", "shell32", "kernel32", "user32", "gdi32", "winspool", "comdlg32", "advapi32")
+        add_defines("_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING")
     elseif is_plat("linux") then
         add_syslinks("pthread", "X11", "Xft", "fontconfig")
     end
 
     on_install("linux", "windows", function (package)
+        if is_plat("windows") then
+            local file_name = path.join(os.curdir(), "source", "system", "split_string.cpp")
+            io.gsub(file_name, " and ", " && ")
+        end
+
         local configs = {"-DNANA_CMAKE_ENABLE_JPEG=OFF", "-DNANA_CMAKE_ENABLE_PNG=OFF"}
         if is_plat("linux") then
             table.insert(configs, "-DNANA_CMAKE_NANA_FILESYSTEM_FORCE=ON")
         end
         import("package.tools.cmake").install(package, configs)
+
+        if is_plat("windows") then
+            os.cp("include", package:installdir())
+        end
     end)
 
     on_test(function (package)


### PR DESCRIPTION
Adds version 1.7.4 of **nana** to the repository. Every version below 1.7.3 is not compatible with windows so I added this version. I had to write this code
```lua
if is_plat("windows") then
            local file_name = path.join(os.curdir(), "source", "system", "split_string.cpp")
            local contents = io.readfile(file_name)
            contents = contents:gsub(" and ", " && ")
            io.writefile(file_name, contents)
        end
```

because a patch somehow didn't work.