### PR TITLE
libuv: fix shared lib name on windows

### DIFF
--- a/packages/l/libuv/xmake.lua
+++ b/packages/l/libuv/xmake.lua
@@ -28,6 +28,10 @@ package("libuv")
         package:add("syslinks", "advapi32", "iphlpapi", "psapi", "user32", "userenv", "ws2_32", "kernel32", "gdi32", "winspool", "shell32", "ole32", "oleaut32", "uuid", "comdlg32")
     end)
 
+    on_load("linux", function (package)
+        package:add("syslinks", "pthread")
+    end)
+
     on_install("windows", function (package)
         import("package.tools.cmake").install(package)
         os.cp("include", package:installdir())

--- a/packages/l/libuv/xmake.lua
+++ b/packages/l/libuv/xmake.lua
@@ -24,7 +24,7 @@ package("libuv")
     end
 
     on_load("windows", function (package)
-        package:add("links", "uv_a")
+        package:add("links", "uv" .. (package:config("shared") and "" or "_a"))
         package:add("syslinks", "advapi32", "iphlpapi", "psapi", "user32", "userenv", "ws2_32", "kernel32", "gdi32", "winspool", "shell32", "ole32", "oleaut32", "uuid", "comdlg32")
     end)
 


### PR DESCRIPTION
`uv` is the .lib that is associated with the DLL for libuv.
