### PR TITLE
libuv: fix windows and linux links

### DIFF
--- a/packages/l/libuv/xmake.lua
+++ b/packages/l/libuv/xmake.lua
@@ -24,9 +24,13 @@ package("libuv")
     end
 
     on_load("windows", function (package)
-        package:add("links", "uv_a")
+        package:add("links", "uv" .. (package:config("shared") and "" or "_a"))
         package:add("syslinks", "advapi32", "iphlpapi", "psapi", "user32", "userenv", "ws2_32", "kernel32", "gdi32", "winspool", "shell32", "ole32", "oleaut32", "uuid", "comdlg32")
     end)
+
+    if is_plat("linux") then
+        add_syslinks("pthread")
+    end
 
     on_install("windows", function (package)
         import("package.tools.cmake").install(package)


### PR DESCRIPTION
Here's a clean PR with the description scope linux syslink call instead of following what was already there with the windows links.