### PR TITLE
add package openvdb & rewrite glfw package as well as fix some previous packages

### DIFF
--- a/packages/b/blosc/xmake.lua
+++ b/packages/b/blosc/xmake.lua
@@ -24,7 +24,16 @@ package("blosc")
             table.insert(configs, "-DBUILD_SHARED=OFF")
             table.insert(configs, "-DBUILD_STATIC=ON")
         end
-        import("package.tools.cmake").install(package, configs)
+        import("package.tools.cmake").install(package, configs, {buildir = "build"})
+        if is_host("windows") then
+            local version = package:version()
+            if version:le("1.10") and not package:config("shared") then
+                os.rm(package:installdir(lib) .. "/blosc.lib")
+            elseif package:config("shared") then
+                os.cp("build/install/bin", package:installdir())
+                package:addenv("PATH", "bin")
+            end
+        end
     end)
 
     on_test(function (package)

--- a/packages/b/blosc/xmake.lua
+++ b/packages/b/blosc/xmake.lua
@@ -25,10 +25,11 @@ package("blosc")
             table.insert(configs, "-DBUILD_STATIC=ON")
         end
         import("package.tools.cmake").install(package, configs, {buildir = "build"})
-        if is_host("windows") then
+        if package:is_plat("windows", "mingw") then
+            -- special concern for legacy versions which keep producing the shared library
             local version = package:version()
             if version:le("1.10") and not package:config("shared") then
-                os.rm(package:installdir(lib) .. "/blosc.lib")
+                os.rm(path.join(package:installdir("lib"), "blosc.lib"))
             elseif package:config("shared") then
                 os.cp("build/install/bin", package:installdir())
                 package:addenv("PATH", "bin")

--- a/packages/g/glew/xmake.lua
+++ b/packages/g/glew/xmake.lua
@@ -11,6 +11,8 @@ package("glew")
         add_versions("2.1.0", "2700383d4de2455f06114fbaf872684f15529d4bdc5cdea69b5fb0e9aa7763f1")
     end
 
+    add_configs("build_utils", {description = "Build utility binaries", default = false, type = "boolean"})
+
     if is_plat("windows", "mingw") then
         add_syslinks("glu32", "opengl32")
     else
@@ -25,7 +27,9 @@ package("glew")
 
     on_load(function (package)
         package:add("defines", "GLEW_BUILD")
-        if package:is_plat("windows", "mingw") then
+        if package:is_plat("windows") then
+            package:add("links", package:config("shared") and "glew32" or "glew32s")
+        elseif package:is_plat("mingw") then
             package:add("links", "glew32")
         end
     end)
@@ -37,11 +41,14 @@ package("glew")
     on_install("windows", function (package)
         os.cp("include", package:installdir())
         if is_arch("x64") then
-            os.cp("bin/Release/x64/*.dll", package:installdir("lib"))
+            os.cp("bin/Release/x64/*.dll", package:installdir("bin"))
             os.cp("lib/Release/x64/*.lib", package:installdir("lib"))
         else
-            os.cp("bin/Release/Win32/*.dll", package:installdir("lib"))
+            os.cp("bin/Release/Win32/*.dll", package:installdir("bin"))
             os.cp("lib/Release/Win32/*.lib", package:installdir("lib"))
+        end
+        if package:config("shared") then
+            package:addenv("PATH", "bin")
         end
     end)
 
@@ -72,9 +79,11 @@ package("glew")
         local configs = {}
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_UTILS=" .. (package:config("build_utils") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs, {buildir = "build"})
         if package:config("shared") then
-            os.cp("build/bin/*.dll", package:installdir("lib"))
+            os.cp("build/bin/*.dll", package:installdir("bin"))
+            package:addenv("PATH", "bin")
         end
     end)
 

--- a/packages/g/glew/xmake.lua
+++ b/packages/g/glew/xmake.lua
@@ -29,8 +29,6 @@ package("glew")
         package:add("defines", "GLEW_BUILD")
         if package:is_plat("windows") then
             package:add("links", package:config("shared") and "glew32" or "glew32s")
-        elseif package:is_plat("mingw") then
-            package:add("links", "glew32")
         end
     end)
 
@@ -82,7 +80,7 @@ package("glew")
         table.insert(configs, "-DBUILD_UTILS=" .. (package:config("build_utils") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs, {buildir = "build"})
         if package:config("shared") then
-            os.cp("build/bin/*.dll", package:installdir("bin"))
+            os.cp("build/install/bin", package:installdir())
             package:addenv("PATH", "bin")
         end
     end)

--- a/packages/g/glfw/xmake.lua
+++ b/packages/g/glfw/xmake.lua
@@ -54,18 +54,10 @@ package("glfw")
     end)
 
     on_test(function (package)
-        assert(package:check_csnippets([[
+        assert(package:check_csnippets({test = [[
             void test() {
                 glfwInit();
                 glfwTerminate();
             }
-<<<<<<< HEAD
-<<<<<<< HEAD
-        ]], {configs = {languages = "c11"}, includes = "GLFW/glfw3.h"}))
-=======
-        ]], {languages = "c11", includes = "GLFW/glfw3.h"}))
->>>>>>> cc78b65 (rewrite glfw/xmake.lua)
-=======
-        ]], {configs = {languages = "c11"}, includes = "GLFW/glfw3.h"}))
->>>>>>> 729104c (activate ci)
+        ]]}, {configs = {languages = "c11"}, includes = "GLFW/glfw3.h"}))
     end)

--- a/packages/g/glfw/xmake.lua
+++ b/packages/g/glfw/xmake.lua
@@ -3,108 +3,69 @@ package("glfw")
     set_homepage("https://www.glfw.org/")
     set_description("GLFW is an Open Source, multi-platform library for OpenGL, OpenGL ES and Vulkan application development.")
 
-    if is_plat("windows", "mingw") then
-        if is_arch("x64", "x86_64") then
-            set_urls("https://github.com/glfw/glfw/releases/download/$(version)/glfw-$(version).bin.WIN64.zip")
-            add_versions("3.3.2", "aa291d8dce27d9e6cd567dc56e3768dcefceb3ddb7a65fb4cc3ef35be2a7548c")
-        else
-            set_urls("https://github.com/glfw/glfw/releases/download/$(version)/glfw-$(version).bin.WIN32.zip")
-            add_versions("3.3.2", "a2a5f93884f728dfc1bcb090fbdbb1015f1c1898b35a50fa17c7ade6761102b1")
-        end
-    elseif is_plat("macosx") then
-        set_urls("https://github.com/glfw/glfw/releases/download/$(version)/glfw-$(version).bin.MACOS.zip")
-        add_versions("3.3.2", "e412c75f850c320192df491ec3bf623847fafa847b46ffd3bbd7478057148f5a")
-    elseif is_plat("linux") then
-        set_urls("https://github.com/glfw/glfw/releases/download/$(version)/glfw-$(version).zip")
-        add_versions("3.3.2", "08a33a512f29d7dbf78eab39bd7858576adcc95228c9efe8e4bc5f0f3261efc7")
-        add_deps("cmake")
-    end
+    add_urls("https://github.com/glfw/glfw/archive/$(version).tar.gz",
+             "https://github.com/glfw/glfw.git")
+    add_versions("3.3.2", "98768e12e615fbe9f3386f5bbfeb91b5a3b45a8c4c77159cef06b1f6ff749537")
 
-    add_configs("include_none", {description = "Adds the GLFW_INCLUDE_NONE Preprocessor Macro to disable all OpenGL includes inside GLFW", default = true, type = "boolean"})
+    add_configs("glfw_include", {description = "Choose submodules enabled in glfw", default = "none", type = "string", values = {"none", "vulkan", "glu", "glext", "es2", "es3"}})
+
+    add_deps("cmake")
 
     if is_plat("macosx") then
         add_frameworks("Cocoa", "IOKit")
+    elseif is_plat("windows") then
+        add_syslinks("user32", "shell32", "gdi32")
+    elseif is_plat("mingw@windows") then
+        add_syslinks("gdi32")
     elseif is_plat("linux") then
+        -- TODO: add wayland support
         add_deps("libx11", "libxrandr", "libxrender", "libxinerama", "libxcursor", "libxi", "libxext")
+        add_syslinks("dl", "pthread")
         add_defines("_GLFW_X11")
     end
 
     on_load(function (package)
-        if package:config("shared") then
-            if package:is_plat("windows", "mingw") then
-                package:add("defines", "GLFW_DLL")
-                package:add("links", "glfw3dll")
-            elseif package:is_plat("macosx") then
-                package:add("links", "glfw")
-            end
-        else
-            if package:is_plat("windows", "mingw") then
-                package:add("links", "glfw3")
-                if package:is_plat("windows") then
-                    package:add("syslinks", "user32", "shell32")
-                end
-                package:add("syslinks", "gdi32")
-            elseif package:is_plat("macosx") then
-                package:add("links", "glfw3")
-            elseif package:is_plat("linux") then
-                package:add("syslinks", "dl", "pthread")
-            end
-        end
-
-        if package:config("include_none") then
-            package:add("defines", "GLFW_INCLUDE_NONE")
-        end
+        package:add("defines", "GLFW_INCLUDE_" .. package:config("glfw_include"):upper())
     end)
 
-    on_install("windows", function (package)
-        os.cp("include/*", package:installdir("include"))
-        local pathlist = os.args(package:build_getenv("cxx")):split('\\')
-        local msvc_ver = pathlist[table.getn(pathlist)-9]
-        os.cp("lib-vc"..msvc_ver.."/*.lib", package:installdir("lib"))
-        os.cp("lib-vc"..msvc_ver.."/*.dll", package:installdir("lib"))
-    end)
-
-    on_install("mingw", function (package)
-        os.cp("include/*", package:installdir("include"))
-        if is_arch("x64", "x86_64") then
-            os.cp("lib-mingw-w64/*.a", package:installdir("lib"))
-            os.cp("lib-mingw-w64/*.dll", package:installdir("lib"))
-        else
-            os.cp("lib-mingw/*.a", package:installdir("lib"))
-            os.cp("lib-mingw/*.dll", package:installdir("lib"))
-        end
-    end)
-
-    on_install("macosx", function (package)
-        os.cp("include/*", package:installdir("include"))
-        os.cp("lib-macos/*.a", package:installdir("lib"))
-        os.cp("lib-macos/*.dylib", package:installdir("lib"))
-    end)
-
-    on_install("linux", function (package)
-        local configs = {}
-        table.insert(configs, "-DGLFW_BUILD_DOCS=OFF")
-        table.insert(configs, "-DGLFW_BUILD_TESTS=OFF")
-        table.insert(configs, "-DGLFW_BUILD_EXAMPLES=OFF")
+    on_install("macosx", "windows", "linux", "mingw", function (package)
+        local configs = {"-DGLFW_BUILD_DOCS=OFF", "-DGLFW_BUILD_TESTS=OFF", "-DGLFW_BUILD_EXAMPLES=OFF"}
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        -- patch missing libxrender/includes
-        local cflags = {}
-        local fetchinfo = package:dep("libxrender"):fetch()
-        if fetchinfo then
-            for _, includedir in ipairs(fetchinfo.includedirs) do
-                table.insert(cflags, "-I" .. includedir)
+        if is_plat("windows") and vs_runtime and vs_runtime:startswith("MD") then
+            table.insert(configs, "-DUSE_MSVC_RUNTIME_LIBRARY_DLL")
+        elseif is_plat("linux") then
+            -- patch missing libxrender/includes
+            local cflags = {}
+            local fetchinfo = package:dep("libxrender"):fetch()
+            if fetchinfo then
+                for _, includedir in ipairs(fetchinfo.includedirs) do
+                    table.insert(cflags, "-I" .. includedir)
+                end
+            end
+            if #cflags > 0 then
+                table.insert(configs, "-DCMAKE_C_FLAGS=" .. table.concat(cflags, " "))
             end
         end
-        if #cflags > 0 then
-            table.insert(configs, "-DCMAKE_C_FLAGS=" .. table.concat(cflags, " "))
+        import("package.tools.cmake").install(package, configs, {buildir = "build"})
+        if is_host("windows") and package:config("shared") then
+            os.trycp("build/install/bin", package:installdir())
+            package:addenv("PATH", "bin")
         end
-        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)
-        local cxflags
-        if not package:config("shared") and package:is_plat("windows") then
-            cxflags = "/MD"
-        end
-        assert(package:has_cfuncs("glfwInit", {includes = "GLFW/glfw3.h", configs = {cxflags = cxflags}}))
+        assert(package:check_csnippets([[
+            void test() {
+                glfwInit();
+                glfwTerminate();
+            }
+<<<<<<< HEAD
+<<<<<<< HEAD
+        ]], {configs = {languages = "c11"}, includes = "GLFW/glfw3.h"}))
+=======
+        ]], {languages = "c11", includes = "GLFW/glfw3.h"}))
+>>>>>>> cc78b65 (rewrite glfw/xmake.lua)
+=======
+        ]], {configs = {languages = "c11"}, includes = "GLFW/glfw3.h"}))
+>>>>>>> 729104c (activate ci)
     end)

--- a/packages/g/glfw/xmake.lua
+++ b/packages/g/glfw/xmake.lua
@@ -11,11 +11,13 @@ package("glfw")
 
     add_deps("cmake")
 
-    if is_host("macosx") then
+    if is_plat("macosx") then
         add_frameworks("Cocoa", "IOKit")
-    elseif is_host("windows") then
+    elseif is_plat("windows") then
         add_syslinks("user32", "shell32", "gdi32")
-    elseif is_host("linux") then
+    elseif is_plat("mingw") then
+        add_syslinks("gdi32")
+    elseif is_plat("linux") then
         -- TODO: add wayland support
         add_deps("libx11", "libxrandr", "libxrender", "libxinerama", "libxcursor", "libxi", "libxext")
         add_syslinks("dl", "pthread")

--- a/packages/g/glfw/xmake.lua
+++ b/packages/g/glfw/xmake.lua
@@ -11,13 +11,11 @@ package("glfw")
 
     add_deps("cmake")
 
-    if is_plat("macosx") then
+    if is_host("macosx") then
         add_frameworks("Cocoa", "IOKit")
-    elseif is_plat("windows") then
+    elseif is_host("windows") then
         add_syslinks("user32", "shell32", "gdi32")
-    elseif is_plat("mingw@windows") then
-        add_syslinks("gdi32")
-    elseif is_plat("linux") then
+    elseif is_host("linux") then
         -- TODO: add wayland support
         add_deps("libx11", "libxrandr", "libxrender", "libxinerama", "libxcursor", "libxi", "libxext")
         add_syslinks("dl", "pthread")

--- a/packages/g/glfw/xmake.lua
+++ b/packages/g/glfw/xmake.lua
@@ -29,9 +29,9 @@ package("glfw")
     on_install("macosx", "windows", "linux", "mingw", function (package)
         local configs = {"-DGLFW_BUILD_DOCS=OFF", "-DGLFW_BUILD_TESTS=OFF", "-DGLFW_BUILD_EXAMPLES=OFF"}
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if is_plat("windows") and vs_runtime and vs_runtime:startswith("MD") then
+        if package:is_plat("windows") and vs_runtime and vs_runtime:startswith("MD") then
             table.insert(configs, "-DUSE_MSVC_RUNTIME_LIBRARY_DLL")
-        elseif is_plat("linux") then
+        elseif package:is_plat("linux") then
             -- patch missing libxrender/includes
             local cflags = {}
             local fetchinfo = package:dep("libxrender"):fetch()
@@ -45,7 +45,7 @@ package("glfw")
             end
         end
         import("package.tools.cmake").install(package, configs, {buildir = "build"})
-        if is_host("windows") and package:config("shared") then
+        if package:is_plat("windows", "mingw") and package:config("shared") then
             os.trycp("build/install/bin", package:installdir())
             package:addenv("PATH", "bin")
         end

--- a/packages/o/openvdb/xmake.lua
+++ b/packages/o/openvdb/xmake.lua
@@ -17,7 +17,7 @@ package("openvdb")
     add_configs("print", {description = "Command line binary for displaying information about OpenVDB files.", default = true, type = "boolean"})
     add_configs("lod", {description = "Command line binary for generating volume mipmaps from an OpenVDB grid.", default = false, type = "boolean"})
     add_configs("render", {description = "Command line binary for ray-tracing OpenVDB grids.", default = false, type = "boolean"})
-    add_configs("view", {description = "Command line binary for displaying OpenVDB grids in a GL viewport", default = true, type = "boolean"})
+    add_configs("view", {description = "Command line binary for displaying OpenVDB grids in a GL viewport.", default = false, type = "boolean"})
 
     on_load(function (package)
         if package:config("with_houdini") == "" then

--- a/packages/o/openvdb/xmake.lua
+++ b/packages/o/openvdb/xmake.lua
@@ -1,0 +1,85 @@
+package("openvdb")
+
+    set_homepage("https://www.openvdb.org/")
+    set_description("OpenVDB - Sparse volume data structure and tools")
+
+    add_urls("https://github.com/AcademySoftwareFoundation/openvdb/archive/v$(version).tar.gz",
+             "https://github.com/AcademySoftwareFoundation/openvdb.git")
+
+    add_versions("7.1.0", "0c3588c1ca6e647610738654ec2c6aaf41a203fd797f609fbeab1c9f7c3dc116")
+
+    add_deps("cmake")
+    add_deps("boost", {system = false, configs = {regex = true, system = true, iostreams = true}})
+
+    add_configs("with_houdini", {description = "Location of Houdini installation. Set to enable built with Houdini.", default = "", type = "string"})
+    add_configs("with_maya", {description = "Location of Maya installation. Set to enable built with Maya.", default = "", type = "string"})
+    add_configs("simd", {description = "SIMD acceleration architecture.", default = "None", type = "string", values = {"None", "SSE42", "AVX"}})
+    add_configs("print", {description = "Command line binary for displaying information about OpenVDB files.", default = true, type = "boolean"})
+    add_configs("lod", {description = "Command line binary for generating volume mipmaps from an OpenVDB grid.", default = false, type = "boolean"})
+    add_configs("render", {description = "Command line binary for ray-tracing OpenVDB grids.", default = false, type = "boolean"})
+    add_configs("view", {description = "Command line binary for displaying OpenVDB grids in a GL viewport", default = true, type = "boolean"})
+
+    on_load(function (package)
+        if package:config("with_houdini") == "" then
+            package:add("deps", "zlib")
+            package:add("deps", "blosc ~1.5.0", {configs = {shared = package:is_plat("linux")}})
+            package:add("deps", "openexr", {configs = {shared = package:is_plat("windows")}})
+            if package:config("with_maya") == "" then
+                package:add("deps", "tbb")
+            end
+        end
+        if package:config("view") then
+            package:add("deps", "glew")
+            package:add("deps", "glfw")
+        end
+    end)
+
+    on_install("macosx", "linux", "windows", function (package)
+        local configs = {"-DOPENVDB_BUILD_DOCS=OFF", "-DUSE_PKGCONFIG=OFF", "-DBoost_USE_STATIC_LIBS=ON", "-DUSE_CCACHE=OFF"}
+        if package:is_plat("windows") then
+            table.insert(configs, "-DBoost_USE_STATIC_RUNTIME=ON")
+        else
+            table.insert(configs, "-DBoost_USE_STATIC_RUNTIME=OFF")
+        end
+        if package:config("shared") then
+            table.insert(configs, "-DOPENVDB_CORE_SHARED=ON")
+            table.insert(configs, "-DOPENVDB_CORE_STATIC=OFF")
+        else
+            table.insert(configs, "-DOPENVDB_CORE_SHARED=OFF")
+            table.insert(configs, "-DOPENVDB_CORE_STATIC=ON")
+        end
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DOPENVDB_BUILD_VDB_LOD=" .. (package:config("lod") and "ON" or "OFF"))
+        table.insert(configs, "-DOPENVDB_BUILD_VDB_PRINT=" .. (package:config("print") and "ON" or "OFF"))
+        table.insert(configs, "-DOPENVDB_BUILD_VDB_RENDER=" .. (package:config("render") and "ON" or "OFF"))
+        table.insert(configs, "-DOPENVDB_BUILD_VDB_VIEW=" .. (package:config("view") and "ON" or "OFF"))
+        table.insert(configs, "-DOPENVDB_SIMD=" .. package:config("simd"))
+        if package:config("with_houdini") ~= "" then
+            table.insert(configs, "-DUSE_HOUDINI=ON")
+            table.insert(configs, "-DOPENVDB_BUILD_HOUDINI_PLUGIN=ON")
+            table.insert(configs, "-DHoudini_ROOT=" .. package:config("with_houdini"))
+        elseif package:config("with_maya") ~= "" then
+            table.insert(configs, "-DUSE_MAYA=ON")
+            table.insert(configs, "-DOPENVDB_BUILD_MAYA_PLUGIN=ON")
+            table.insert(configs, "-DMaya_ROOT=" .. package:config("with_maya"))
+        else
+            table.insert(configs, "-DUSE_BLOSC=ON")
+            table.insert(configs, "-DUSE_EXR=ON")
+        end
+        import("package.tools.cmake").install(package, configs, {buildir = "build"})
+        os.cp("build/install/bin", package:installdir())
+        package:addenv("PATH", "bin")
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            void test() {
+                openvdb::initialize();
+                openvdb::FloatGrid::Ptr grid = openvdb::tools::createLevelSetSphere<openvdb::FloatGrid>(
+                    /*radius=*/50.0, /*center=*/openvdb::Vec3f(1.5, 2, 3),
+                    /*voxel size=*/0.5, /*width=*/4.0
+                );
+            }
+        ]]}, {configs = {languages = "c++14"},
+              includes = {"openvdb/openvdb.h", "openvdb/tools/LevelSetSphere.h"}}))
+    end)

--- a/packages/p/pkg-config/xmake.lua
+++ b/packages/p/pkg-config/xmake.lua
@@ -6,7 +6,7 @@ package("pkg-config")
 
     if is_host("macosx", "linux") then
         add_urls("https://pkgconfig.freedesktop.org/releases/pkg-config-$(version).tar.gz")
-		add_urls("http://fco.it.distfiles.macports.org/mirrors/macports-distfiles/pkgconfig/pkg-config-$(version).tar.gz")
+        add_urls("http://fco.it.distfiles.macports.org/mirrors/macports-distfiles/pkgconfig/pkg-config-$(version).tar.gz")
         add_versions("0.29.2", "6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591")
     end
 

--- a/packages/p/pkg-config/xmake.lua
+++ b/packages/p/pkg-config/xmake.lua
@@ -6,7 +6,7 @@ package("pkg-config")
 
     if is_host("macosx", "linux") then
         add_urls("https://pkgconfig.freedesktop.org/releases/pkg-config-$(version).tar.gz")
-		add_urls("http://fco.it.distfiles.macports.org/mirrors/macports-distfiles/pkgconfig/pkg-config-$(version).tar.g")
+		add_urls("http://fco.it.distfiles.macports.org/mirrors/macports-distfiles/pkgconfig/pkg-config-$(version).tar.gz")
         add_versions("0.29.2", "6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591")
     end
 


### PR DESCRIPTION
在windows上的处理比较麻烦，windows下动态链接库.dll文件会生成在/bin下，并且由于windows上没有linux -rpath这样的功能，必须把bin加入path才能在运行时搜索到这些dll文件。感觉如果cmake.install可以针对windows特殊处理下，然后主程序有一个类似windeployqt的应用，自动搜索用到的dll并复制到可执行文件的文件夹，编写包的时候一致性会好很多