### PR TITLE
libcurl: Disable testing build

### DIFF
--- a/packages/l/libcurl/xmake.lua
+++ b/packages/l/libcurl/xmake.lua
@@ -22,7 +22,8 @@ package("libcurl")
     end
 
     on_install("windows", function (package)
-        import("package.tools.cmake").install(package)
+        local configs = { "-DBUILD_TESTING=OFF" }
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_install("macosx", "linux", "iphoneos", function (package)

--- a/packages/l/libcurl/xmake.lua
+++ b/packages/l/libcurl/xmake.lua
@@ -22,7 +22,7 @@ package("libcurl")
     end
 
     on_install("windows", function (package)
-        local configs = { "-DBUILD_TESTING=OFF" }
+        local configs = {"-DBUILD_TESTING=OFF"}
         import("package.tools.cmake").install(package, configs)
     end)
 


### PR DESCRIPTION
Currently libcurl is built with tests, which can be long and can break installation (7.64.1 doesn't build with msvc because of an empty test file).

This PR disables libcurl test building.