### PR TITLE
libcurl: Link to ws2_32 on Windows

### DIFF
--- a/packages/l/libcurl/xmake.lua
+++ b/packages/l/libcurl/xmake.lua
@@ -21,6 +21,8 @@ package("libcurl")
         add_frameworks("Security", "CoreFoundation")
     elseif is_plat("linux") then
         add_syslinks("pthread")
+    elseif is_plat("windows", "mingw") then
+        add_syslinks("ws2_32")
     end
 
     on_load("windows", function (package)


### PR DESCRIPTION
I just ran into an issue with libcurl where it was lacking ws2_32 link on Windows, this fixes it.