### PR TITLE
Sol2: Add includes_lua option to be able to ship a custom Lua library

### DIFF
--- a/packages/s/sol2/xmake.lua
+++ b/packages/s/sol2/xmake.lua
@@ -8,7 +8,15 @@ package("sol2")
 
     add_versions("v3.2.1", "b10f88dc1246f74a10348faef7d2c06e2784693307df74dcd87c4641cf6a6828")
 
-    add_deps("cmake", "lua")
+    add_configs("includes_lua", {description = "Should this package includes the Lua package (set to false if you're shipping a custom Lua)", default = true, type = "boolean"})
+
+    add_deps("cmake")
+
+    on_load(function (package)
+        if package:config("includes_lua") then
+            package:add("deps", "lua")
+        end
+    end)
 
     on_install("linux", "macosx", "windows", function (package)
         local configs = {}


### PR DESCRIPTION
In the case of Lua, it's not uncommon to ship a custom Lua library (to update the langage a bit for example), but sol2 forces the lua dependency, this adds an option to disable the default lua shipping.

