### PR TITLE
libcurl: Disable LDAP support on Windows too

### DIFF
--- a/packages/l/libcurl/xmake.lua
+++ b/packages/l/libcurl/xmake.lua
@@ -22,7 +22,7 @@ package("libcurl")
     elseif is_plat("linux") then
         add_syslinks("pthread")
     elseif is_plat("windows", "mingw") then
-        add_syslinks("ws2_32")
+        add_syslinks("winmm", "wldap32", "ws2_32")
     end
 
     on_load("windows", function (package)

--- a/packages/l/libcurl/xmake.lua
+++ b/packages/l/libcurl/xmake.lua
@@ -22,7 +22,7 @@ package("libcurl")
     elseif is_plat("linux") then
         add_syslinks("pthread")
     elseif is_plat("windows", "mingw") then
-        add_syslinks("wldap32", "ws2_32")
+        add_syslinks("ws2_32")
     end
 
     on_load("windows", function (package)

--- a/packages/l/libcurl/xmake.lua
+++ b/packages/l/libcurl/xmake.lua
@@ -22,7 +22,7 @@ package("libcurl")
     elseif is_plat("linux") then
         add_syslinks("pthread")
     elseif is_plat("windows", "mingw") then
-        add_syslinks("winmm", "wldap32", "ws2_32")
+        add_syslinks("wldap32", "ws2_32")
     end
 
     on_load("windows", function (package)

--- a/packages/l/libcurl/xmake.lua
+++ b/packages/l/libcurl/xmake.lua
@@ -35,6 +35,7 @@ package("libcurl")
         local configs = {"-DBUILD_TESTING=OFF"}
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.includes(configs, "-DCURL_DISABLE_LDAP=ON")
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/l/libcurl/xmake.lua
+++ b/packages/l/libcurl/xmake.lua
@@ -35,7 +35,7 @@ package("libcurl")
         local configs = {"-DBUILD_TESTING=OFF"}
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-        table.includes(configs, "-DCURL_DISABLE_LDAP=ON")
+        table.insert(configs, "-DCURL_DISABLE_LDAP=ON")
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/l/libcurl/xmake.lua
+++ b/packages/l/libcurl/xmake.lua
@@ -22,7 +22,7 @@ package("libcurl")
     elseif is_plat("linux") then
         add_syslinks("pthread")
     elseif is_plat("windows", "mingw") then
-        add_syslinks("ws2_32")
+        add_syslinks("advapi32", "winmm", "ws2_32")
     end
 
     on_load("windows", function (package)


### PR DESCRIPTION
LDAP support requires a link to wldap32.lib, as its support is disabled on Linux this disables it on Windows too.

Initiality I added wldap32 as a syslink but it failed the compilation, for some reasons I can't explain.
I also added advapi32 and winmm dependencies (from [here](https://github.com/curl/curl/blob/master/CMakeLists.txt#L310))