### PR TITLE
Fix SFML check (check only system module as other can be disabled)

### DIFF
--- a/packages/s/sfml/xmake.lua
+++ b/packages/s/sfml/xmake.lua
@@ -123,9 +123,8 @@ package("sfml")
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
             void test(int args, char** argv) {
-                sf::RenderWindow window(sf::VideoMode(200, 200), "SFML works!");
-                sf::CircleShape shape(100.f);
-                shape.setFillColor(sf::Color::Green);
+                sf::Clock c;
+                c.restart();
             }
-        ]]}, {includes = "SFML/Graphics.hpp"}))
+        ]]}, {includes = "SFML/System.hpp"}))
     end)


### PR DESCRIPTION
If the graphics module is disabled, like this:

```lua
add_requires("sfml", {configs={graphics = false}})
```

the installation check will fail. This PR updates it to check the system library, as it's always included.