### PR TITLE
Update Vulkan-Headers version and regular version name

### DIFF
--- a/packages/v/vulkan-headers/xmake.lua
+++ b/packages/v/vulkan-headers/xmake.lua
@@ -4,8 +4,9 @@ package("vulkan-headers")
     set_description("Vulkan Header files and API registry")
     set_license("Apache-2.0")
 
-    add_urls("https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-$(version).tar.gz", {version = function (version) return version:gsub("%+", ".") end})
-    add_versions("1.2.154+0", "a0528ade4dd3bd826b960ba4ccabc62e92ecedc3c70331b291e0a7671b3520f9")
+    add_urls("https://github.com/KhronosGroup/Vulkan-Headers/archive/$(version).tar.gz")
+    add_versions("v1.2.154", "b636f0ace2c2b8a7dbdfddf16c53c1f49a4b39d6da562727bfea00b5ec447537")
+    add_versions("v1.2.162", "deab1a7a28ad3e0a7a0a1c4cd9c54758dce115a5f231b7205432d2bbbfb4d456")
 
     add_deps("cmake")
 


### PR DESCRIPTION
Now the Vulkan-Headers version name is vx.x.xxx, update to it.
And the newer version is v1.2.162

log: change pacages/v/vulkan-headers


