### PR TITLE
fix: volk xmake file get two on_install funciton

### DIFF
--- a/packages/v/volk/xmake.lua
+++ b/packages/v/volk/xmake.lua
@@ -14,10 +14,6 @@ package("volk")
     end
 
     on_install("windows", "linux", "macosx", function (package)
-        import("package.tools.cmake").install(package)
-    end)
-
-    on_install("windows", "linux", "macosx", function (package)
         local configs = {}
         if package:config("shared") then
             table.insert(configs, "--enable-shared=yes")


### PR DESCRIPTION
volk xmake get two on_install function, delete unused function.

log: fix packages/v/volk/xmake.lua

