### PR TITLE
Fix test of libsdl

### DIFF
--- a/packages/l/libsdl/xmake.lua
+++ b/packages/l/libsdl/xmake.lua
@@ -45,6 +45,5 @@ package("libsdl")
     end)
 
     on_test(function (package)
-        local configs = package:is_plat("windows") and {ldflags = "/SUBSYSTEM:CONSOLE"}
-        assert(package:has_cfuncs("SDL_Init", {includes = "SDL2/SDL.h", configs = configs}))
+        assert(package:has_cfuncs("SDL_Init", {includes = "SDL2/SDL.h", configs = {defines = "SDL_MAIN_HANDLED"}}))
     end)


### PR DESCRIPTION
This fixes the test of **libsdl**. ```SDL_MAIN_HANDLED``` has been added as a define. Previously there was the following line
```lua
local configs = package:is_plat("windows") and {ldflags = "/SUBSYSTEM:CONSOLE"}
```
Is this required in some way? On my Windows PC it runs fine without it.