### PR TITLE
Sol2 Disable test if includes_lua is set to false

### DIFF
--- a/packages/s/sol2/xmake.lua
+++ b/packages/s/sol2/xmake.lua
@@ -24,15 +24,17 @@ package("sol2")
     end)
 
     on_test(function (package)
-        assert(package:check_cxxsnippets({test = [[
-            #include <sol/sol.hpp>
-            #include <cassert>
-            void test() {
-                sol::state lua;
-                int x = 0;
-                lua.set_function("beep", [&x]{ ++x; });
-                lua.script("beep()");
-                assert(x == 1);
-            }
-        ]]}, {configs = {languages = "c++17"}}))
+        if package:config("includes_lua") then
+            assert(package:check_cxxsnippets({test = [[
+                #include <sol/sol.hpp>
+                #include <cassert>
+                void test() {
+                    sol::state lua;
+                    int x = 0;
+                    lua.set_function("beep", [&x]{ ++x; });
+                    lua.script("beep()");
+                    assert(x == 1);
+                }
+            ]]}, {configs = {languages = "c++17"}}))
+        end
     end)


### PR DESCRIPTION
sol2 test will fail if includes_lua is set to false, even though it would be valid to use it in a application like this:
```lua
add_requires("sol2", {config = {includes_lua = false}})

-- This is the lua library, patched by the user and bundled with the application as a static library
target("custom_lua")
    set_kind("static")
    add_files("src/custom_lua/*.c")

-- This is the application
target("app")
    set_kind("binary")
    add_files("src/app/*.cpp")
    add_deps("custom_lua")
    add_packages("sol2")
```