### PR TITLE
Add qdcae

### DIFF
--- a/packages/q/qdcae/patches/fix.patch
+++ b/packages/q/qdcae/patches/fix.patch
@@ -1,0 +1,68 @@
+diff --git a/qd/cae/dyna_cpp/dyna/binout/lsda/l2amain.c b/qd/cae/dyna_cpp/dyna/binout/lsda/l2amain.c
+index 1d3b972..635187c 100644
+--- a/qd/cae/dyna_cpp/dyna/binout/lsda/l2amain.c
++++ b/qd/cae/dyna_cpp/dyna/binout/lsda/l2amain.c
+@@ -1,10 +1,16 @@
+ #include <ctype.h>
++#ifdef __APPLE__
++#include <stdlib.h>
++#else
+ #include <malloc.h>
++#endif
+ #include <math.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#if !defined _WIN32 && !defined WIN64 && !defined MPPWIN
+ #include <unistd.h>
++#endif
+ 
+ #include "l2a_version.h"
+ #include "lsda.h"
+@@ -192,7 +198,7 @@ main(int argc, char* argv[])
+   int target = 0;
+   int nopen, first, last;
+   char* toopen[1024];
+-#ifdef MPPWIN
++#if defined _WIN32 || defined WIN64 || defined MPPWIN
+   int optind = 1;
+ #else
+   extern int optind, opterr, optopt;
+@@ -206,7 +212,7 @@ main(int argc, char* argv[])
+   }
+ 
+   use_jobid = 0;
+-#ifdef MPPWIN
++#if defined _WIN32 || defined WIN64 || defined MPPWIN
+   for (i = 1; i < argc; i++) {
+     if (!strcmp(argv[i], "-h")) {
+       print_help(argv[0]);
+@@ -248,7 +254,7 @@ main(int argc, char* argv[])
+   */
+   nopen = 0;
+   for (i = optind; i < argc; i++) {
+-#ifdef MPPWIN
++#if defined _WIN32 || defined WIN64 || defined MPPWIN
+     if (!strcmp(argv[i], "-h"))
+       continue;
+     if (!strcmp(argv[i], "-j"))
+diff --git a/qd/cae/dyna_cpp/dyna/keyfile/ElementKeyword.hpp b/qd/cae/dyna_cpp/dyna/keyfile/ElementKeyword.hpp
+index 3affbb0..bbe6407 100644
+--- a/qd/cae/dyna_cpp/dyna/keyfile/ElementKeyword.hpp
++++ b/qd/cae/dyna_cpp/dyna/keyfile/ElementKeyword.hpp
+@@ -48,13 +48,13 @@ public:
+     T _id,
+     T _part_id,
+     const std::vector<int32_t>& _node_ids,
+-    const std::vector<std::string>& _additional_card_data = "");
++    const std::vector<std::string>& _additional_card_data = {});
+   template<typename T>
+   std::shared_ptr<Element> add_elementByNodeIndex(
+     T _id,
+     T _part_id,
+     const std::vector<size_t>& _node_indexes,
+-    const std::vector<std::string>& _additional_card_data = "");
++    const std::vector<std::string>& _additional_card_data = {});
+   std::vector<std::shared_ptr<Element>> get_elements();
+   std::string str() override;
+ };

--- a/packages/q/qdcae/xmake.lua
+++ b/packages/q/qdcae/xmake.lua
@@ -1,0 +1,48 @@
+package("qdcae")
+
+    set_homepage("https://github.com/qd-cae/qd-cae-python")
+    set_description("qd python (and C++) library for CAE (currently mostly LS-Dyna) ")
+
+    set_urls("https://github.com/qd-cae/qd-cae-python/archive/$(version).zip",
+             "https://github.com/qd-cae/qd-cae-python.git")
+    add_versions("0.8.9", "d5e838a7685d3407919c3e6ad33a17a8bfe376df26dbcc74a5368d8e8fd64c4c")
+    add_patches("0.8.9", path.join(os.scriptdir(), "patches", "fix.patch"), "b865ac7c0db7bd792aa536a9ca8b7d504b04cce7e7aea2073dbc00e276f5b8fc")
+
+    if is_plat("linux", "bsd") then
+        add_syslinks("pthread")
+    end
+
+    on_install("linux", "windows", "mingw", "bsd", function (package)
+        io.writefile("xmake.lua", [[
+        add_rules("mode.debug", "mode.release")
+        target("qdcae_dyna")
+            set_kind("$(kind)")
+            add_files("qd/cae/dyna_cpp/**.cpp", "qd/cae/dyna_cpp/**.c")
+            del_files("qd/cae/dyna_cpp/dyna/d3plot/ArrayD3plot.cpp",
+                      "qd/cae/dyna_cpp/dyna/d3plot/D3plotHeader.cpp",
+                      "qd/cae/dyna_cpp/dyna/d3plot/FemzipBuffer.cpp",
+                      "qd/cae/dyna_cpp/utility/HDF5_Utility.cpp",
+                      "qd/cae/dyna_cpp/python_api/*.cpp",
+                      "**test.cpp")
+            add_includedirs("qd/cae")
+
+            set_languages("c11", "cxx11")
+        ]])
+
+        local configs = {}
+        if package:config("shared") then
+            configs.kind = "shared"
+        end
+        import("package.tools.xmake").install(package, configs)
+        os.cp("qd/cae/dyna_cpp/**.h",   path.join(package:installdir(), "include"), {rootdir = "qd/cae"})
+        os.cp("qd/cae/dyna_cpp/**.hpp", path.join(package:installdir(), "include"), {rootdir = "qd/cae"})
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            void test(int argc, char** argv) {
+                qd::D3plot file("d3plot", std::string());
+            }
+        ]]}, {includes = "dyna_cpp/dyna/d3plot/D3plot.hpp", languages="cxx11"}))
+    end)
+


### PR DESCRIPTION
This adds the library [qd-cae-python](https://github.com/qd-cae/qd-cae-python). This generally is a python library, but because of its C++ backend it can be used as a C++ library.