### PR TITLE
libusb: Add support for windows, version 1.0.24 and fix includes

### DIFF
--- a/packages/l/libusb/xmake.lua
+++ b/packages/l/libusb/xmake.lua
@@ -12,6 +12,8 @@ package("libusb")
         add_deps("autoconf", "automake", "libtool", "pkg-config")
     end
 
+    add_includedirs("include", "include/libusb-1.0")
+
     on_install("windows", function (package)
         os.cd("msvc")
 

--- a/packages/l/libusb/xmake.lua
+++ b/packages/l/libusb/xmake.lua
@@ -21,7 +21,7 @@ package("libusb")
         local mode = package:debug() and "Debug" or "Release"
 
         import("core.tool.toolchain")
-        local vs = toolchain.load("msvc"):config("vs") or "2019"
+        local vs = string.match(toolchain.load("msvc"):config("vs") or "2019", "(vs%d+)")
         local configs = {"libusb_" .. vs .. " .sln"}
         table.insert(configs, "/property:Configuration=" .. mode)
         table.insert(configs, "/property:Platform=" .. arch)

--- a/packages/l/libusb/xmake.lua
+++ b/packages/l/libusb/xmake.lua
@@ -5,18 +5,41 @@ package("libusb")
 
     set_urls("https://github.com/libusb/libusb/archive/$(version).tar.gz",
              "https://github.com/libusb/libusb.git")
+    add_versions("v1.0.24", "b7724c272dfc5713dce88ff717efd60f021ca5b7c8e30f08ebb2c42d2eea08ae")
     add_versions("v1.0.23", "02620708c4eea7e736240a623b0b156650c39bfa93a14bcfa5f3e05270313eba")
 
     if not is_host("windows") then
         add_deps("autoconf", "automake", "libtool", "pkg-config")
     end
 
-    add_includedirs("include/libusb-1.0")
+    on_install("windows", function (package)
+        os.cd("msvc")
+
+        local configs = {"libusb_2019.sln"}
+        local arch = package:is_arch("x86") and "Win32" or "x64"
+        local mode = package:debug() and "Debug" or "Release"
+
+        table.insert(configs, "/property:Configuration=" .. mode)
+        table.insert(configs, "/property:Platform=" .. arch)
+        --table.insert(configs, "-t:" .. (package:config("shared") and "libusb-1_0%20_dll_" or "libusb-1_0%20_static_"))
+
+        import("package.tools.msbuild").build(package, configs)
+
+        os.cd("..")
+
+        os.vcp("libusb/*.h", package:installdir("include/libusb-1.0"))
+        if (package:config("shared")) then
+            os.vcp(path.join(arch, mode, "dll/libusb-1.0.dll"), package:installdir("lib"))
+            os.vcp(path.join(arch, mode, "dll/libusb-1.0.lib"), package:installdir("lib"))
+        else
+            os.vcp(path.join(arch, mode, "lib/libusb-1.0.lib"), package:installdir("lib"))
+        end
+    end)
 
     on_install("macosx", "linux", function (package)
         import("package.tools.autoconf").install(package)
     end)
 
     on_test(function (package)
-        assert(package:has_cfuncs("libusb_init", {includes = "libusb.h"}))
+        assert(package:has_cfuncs("libusb_init", {includes = "libusb-1.0/libusb.h"}))
     end)

--- a/packages/l/libusb/xmake.lua
+++ b/packages/l/libusb/xmake.lua
@@ -21,8 +21,8 @@ package("libusb")
         local mode = package:debug() and "Debug" or "Release"
 
         import("core.tool.toolchain")
-        local vs = string.match(toolchain.load("msvc"):config("vs") or "", "^(%d+)") or "2019"
-        local configs = {"libusb_" .. vs .. " .sln"}
+        local vs = toolchain.load("msvc"):config("vs") or "2019"
+        local configs = {"libusb_" .. vs .. ".sln"}
         table.insert(configs, "/property:Configuration=" .. mode)
         table.insert(configs, "/property:Platform=" .. arch)
         --table.insert(configs, "-t:" .. (package:config("shared") and "libusb-1_0%20_dll_" or "libusb-1_0%20_static_"))

--- a/packages/l/libusb/xmake.lua
+++ b/packages/l/libusb/xmake.lua
@@ -15,17 +15,17 @@ package("libusb")
     on_install("windows", function (package)
         os.cd("msvc")
 
-        local configs = {"libusb_2019.sln"}
         local arch = package:is_arch("x86") and "Win32" or "x64"
         local mode = package:debug() and "Debug" or "Release"
 
+        import("core.tool.toolchain")
+        local vs = toolchain.load("msvc"):config("vs") or "2019"
+        local configs = {"libusb_" .. vs .. " .sln"}
         table.insert(configs, "/property:Configuration=" .. mode)
         table.insert(configs, "/property:Platform=" .. arch)
         --table.insert(configs, "-t:" .. (package:config("shared") and "libusb-1_0%20_dll_" or "libusb-1_0%20_static_"))
 
         import("package.tools.msbuild").build(package, configs)
-
-        os.cd("..")
 
         os.vcp("libusb/*.h", package:installdir("include/libusb-1.0"))
         if (package:config("shared")) then

--- a/packages/l/libusb/xmake.lua
+++ b/packages/l/libusb/xmake.lua
@@ -21,7 +21,7 @@ package("libusb")
         local mode = package:debug() and "Debug" or "Release"
 
         import("core.tool.toolchain")
-        local vs = string.match(toolchain.load("msvc"):config("vs") or "2019", "(vs%d+)")
+        local vs = string.match(toolchain.load("msvc"):config("vs") or "", "^(%d+)") or "2019"
         local configs = {"libusb_" .. vs .. " .sln"}
         table.insert(configs, "/property:Configuration=" .. mode)
         table.insert(configs, "/property:Platform=" .. arch)


### PR DESCRIPTION
I need help with this:
- I need to select the right libusb_*.sln depending on the most recent VS installed.
- What was the purpose of the add_includedirs directive? From what I saw in debian packages you should include libusb-1.0/libusb.h to use it.
- I couldn't find a way to build only the shared or static library so for now I build both and then copy the right files.