### PR TITLE
Fix nana on linux

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -25,6 +25,7 @@ jobs:
           dnf -y upgrade git
           dnf -y install perl
           dnf -y install libffi-devel
+          dnf -y install zlib-devel
       - uses: actions/checkout@v1
       - uses: xmake-io/github-action-setup-xmake@v1
         with:

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -24,6 +24,7 @@ jobs:
           dnf -y install copr-cli make gcc-c++
           dnf -y upgrade git
           dnf -y install perl
+          dnf -y install libffi-devel
       - uses: actions/checkout@v1
       - uses: xmake-io/github-action-setup-xmake@v1
         with:

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -26,6 +26,7 @@ jobs:
           dnf -y install perl
           dnf -y install libffi-devel
           dnf -y install zlib-devel
+          dnf -y install libxft-dev
       - uses: actions/checkout@v1
       - uses: xmake-io/github-action-setup-xmake@v1
         with:

--- a/packages/n/nana/patches/1.7.4/cmake_policy_fix.patch
+++ b/packages/n/nana/patches/1.7.4/cmake_policy_fix.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ce1fdd2..7e6ce3e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,7 +21,8 @@
+ # https://cmake.org/cmake/help/v3.12/module/CMakeDependentOption.html?highlight=cmakedependentoption
+ # cmake 3.12 have more better modern c++ support
+ 
+-cmake_minimum_required(VERSION 3.12  FATAL_ERROR)
++cmake_minimum_required(VERSION 3.15  FATAL_ERROR)
++cmake_policy(SET CMP0091 NEW)
+ project(nana VERSION      1.7.3
+         DESCRIPTION "C++ GUI library"
+         HOMEPAGE_URL http://nanapro.org

--- a/packages/n/nana/patches/1.7.4/u8string_fix.patch
+++ b/packages/n/nana/patches/1.7.4/u8string_fix.patch
@@ -1,0 +1,44 @@
+diff --git a/source/detail/posix/xdnd_protocol.hpp b/source/detail/posix/xdnd_protocol.hpp
+index aa1ae43..d856869 100644
+--- a/source/detail/posix/xdnd_protocol.hpp
++++ b/source/detail/posix/xdnd_protocol.hpp
+@@ -156,7 +156,7 @@ namespace nana{
+ 				    	for(auto& file : data.files)
+ 				    	{
+ 				    		uri_list += "file://";
+-				    		uri_list += file.u8string();
++				    		uri_list += file.string();
+ 				    		uri_list += "\r\n";
+ 				    	}
+ 
+diff --git a/source/gui/filebox.cpp b/source/gui/filebox.cpp
+index 63586ab..28071d5 100644
+--- a/source/gui/filebox.cpp
++++ b/source/gui/filebox.cpp
+@@ -1013,7 +1013,7 @@ namespace nana
+ 				for(auto i = selection_.targets.cbegin(); i != selection_.targets.cend();)
+ 				{
+ 					std::filesystem::path p{*i};
+-					if(p.filename().u8string() == mfs.name)
++					if(p.filename().string() == mfs.name)
+ 					{
+ 						if(!selection_.is_deselect_delayed)
+ 						{
+@@ -1042,7 +1042,7 @@ namespace nana
+ 					if(!filename_string.empty())
+ 						filename_string += ' ';
+ 
+-					filename_string += "\"" + p.filename().u8string() + "\"";
++					filename_string += "\"" + p.filename().string() + "\"";
+ 				}
+ 			}
+ 
+@@ -1576,7 +1576,7 @@ namespace nana
+ 
+ 
+ 		if(!targets.empty())
+-			impl_->path = targets.front().parent_path().u8string();
++			impl_->path = targets.front().parent_path().string();
+ 		else
+ 			impl_->path.clear();
+ #endif

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -34,6 +34,7 @@ package("nana")
     end)
 
     on_install("linux", "windows", function (package)
+        -- The 'and' operator, which is an equivalent of '&&', is not supported by MSVC
         if package:is_plat("windows") then
             local file_name = path.join(os.curdir(), "source", "system", "split_string.cpp")
             io.gsub(file_name, " and ", " && ")
@@ -42,18 +43,6 @@ package("nana")
         local configs = {"-DNANA_CMAKE_ENABLE_JPEG=OFF", "-DNANA_CMAKE_ENABLE_PNG=OFF", "-DBUILD_SHARED_LIBS=OFF"}
         if package:config("nana_filesystem_force") then
             table.insert(configs, "-DNANA_CMAKE_NANA_FILESYSTEM_FORCE=ON")
-        end
-        if package:is_plat("windows") then
-            local cmake_vsr = "MultiThreaded"
-            local pvsr = package:config("vs_runtime")
-            if pvsr == "MTd" then
-                cmake_vsr = "MultiThreadedDebug"
-            elseif pvsr == "MD" then
-                cmake_vsr = "MultiThreadedDLL"
-            elseif pvsr == "MDd" then
-                cmake_vsr = "MultiThreadedDebugDLL"
-            end
-            table.insert(configs, "-DMSVC_RUNTIME_LIBRARY=" .. cmake_vsr)
         end
         import("package.tools.cmake").build(package, configs, {buildir = "build_xmake"})
 

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -20,7 +20,8 @@ package("nana")
         add_syslinks("ole32", "shell32", "kernel32", "user32", "gdi32", "winspool", "comdlg32", "advapi32")
         add_defines("_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING")
     elseif is_plat("linux") then
-        add_syslinks("pthread", "X11", "Xft", "fontconfig")
+        add_deps("libxcursor")
+        add_syslinks("pthread", "fontconfig", "Xft")
         add_links("nana")
     end
 

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -26,7 +26,6 @@ package("nana")
         add_deps("libxcursor")
         add_syslinks("pthread", "fontconfig", "Xft")
     end
-    add_links("nana")
 
     on_load("linux", "windows", function (package)
         if package:config("nana_filesystem_force") then

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -12,6 +12,8 @@ package("nana")
         add_patches("1.7.4", path.join(os.scriptdir(), "patches", "1.7.4", "u8string_fix.patch"), "c783588816664124ba3b4077e18696899c8389419a015773b5bfe988e3a73f6a")
     end
 
+    add_configs("nana_filesystem_force", {description = "Force nana filesystem over ISO and boost?", default = is_plat("linux"), type = "boolean"})
+
     if is_plat("linux", "windows") then
         add_deps("cmake >=3.12")
     end
@@ -25,6 +27,12 @@ package("nana")
     end
     add_links("nana")
 
+    on_load("linux", "windows", function (package)
+        if package:config("nana_filesystem_force") then
+            package:add("defines", "NANA_FILESYSTEM_FORCE")
+        end
+    end)
+
     on_install("linux", "windows", function (package)
         if package:is_plat("windows") then
             local file_name = path.join(os.curdir(), "source", "system", "split_string.cpp")
@@ -32,7 +40,7 @@ package("nana")
         end
 
         local configs = {"-DNANA_CMAKE_ENABLE_JPEG=OFF", "-DNANA_CMAKE_ENABLE_PNG=OFF", "-DBUILD_SHARED_LIBS=OFF"}
-        if package:is_plat("linux") then
+        if package:config("nana_filesystem_force") then
             table.insert(configs, "-DNANA_CMAKE_NANA_FILESYSTEM_FORCE=ON")
         end
         import("package.tools.cmake").build(package, configs, {buildir = "build_xmake"})

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -35,12 +35,10 @@ package("nana")
         if package:is_plat("linux") then
             table.insert(configs, "-DNANA_CMAKE_NANA_FILESYSTEM_FORCE=ON")
         end
-        import("package.tools.cmake").install(package, configs)
+        import("package.tools.cmake").build(package, configs, {buildir = "build_xmake"})
 
         os.cp("include", package:installdir())
-        if package:is_plat("linux") then
-            os.cp("**.a", package:installdir("lib"))
-        end
+        os.trycp(path.join("build_xmake", "*." .. (package:is_plat("windows") and "lib" or "a")), package:installdir("lib"))
     end)
 
     on_test(function (package)

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -47,7 +47,7 @@ package("nana")
 
         os.cp("include", package:installdir())
         if package:is_plat("windows") then
-            os.trycp(path.join("build_xmake", "src", "*", "*.lib"), package:installdir("lib"))
+            os.trycp(path.join("build_xmake", "*", "*.lib"), package:installdir("lib"))
         else
             os.trycp(path.join("build_xmake", "*.a"), package:installdir("lib"))
         end

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -22,8 +22,8 @@ package("nana")
     elseif is_plat("linux") then
         add_deps("libxcursor")
         add_syslinks("pthread", "fontconfig", "Xft")
-        add_links("nana")
     end
+    add_links("nana")
 
     on_install("linux", "windows", function (package)
         if package:is_plat("windows") then

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -38,7 +38,11 @@ package("nana")
         import("package.tools.cmake").build(package, configs, {buildir = "build_xmake"})
 
         os.cp("include", package:installdir())
-        os.trycp(path.join("build_xmake", "*." .. (package:is_plat("windows") and "lib" or "a")), package:installdir("lib"))
+        if package:is_plat("windows") then
+            os.trycp(path.join("build_xmake", "src", "*", "*.lib"), package:installdir("lib"))
+        else
+            os.trycp(path.join("build_xmake", "*.a"), package:installdir("lib"))
+        end
     end)
 
     on_test(function (package)

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -15,7 +15,7 @@ package("nana")
     add_configs("nana_filesystem_force", {description = "Force nana filesystem over ISO and boost?", default = is_plat("linux"), type = "boolean"})
 
     if is_plat("linux", "windows") then
-        add_deps("cmake >=3.12")
+        add_deps("cmake >=3.15")
     end
 
     if is_plat("windows") then
@@ -42,6 +42,18 @@ package("nana")
         local configs = {"-DNANA_CMAKE_ENABLE_JPEG=OFF", "-DNANA_CMAKE_ENABLE_PNG=OFF", "-DBUILD_SHARED_LIBS=OFF"}
         if package:config("nana_filesystem_force") then
             table.insert(configs, "-DNANA_CMAKE_NANA_FILESYSTEM_FORCE=ON")
+        end
+        if package:is_plat("windows") then
+            local cmake_vsr = "MultiThreaded"
+            local pvsr = package:config("vs_runtime")
+            if pvsr == "MTd" then
+                cmake_vsr = "MultiThreadedDebug"
+            elseif pvsr == "MD" then
+                cmake_vsr = "MultiThreadedDLL"
+            elseif pvsr == "MDd" then
+                cmake_vsr = "MultiThreadedDebugDLL"
+            end
+            table.insert(configs, "-DMSVC_RUNTIME_LIBRARY=" .. cmake_vsr)
         end
         import("package.tools.cmake").build(package, configs, {buildir = "build_xmake"})
 

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -31,7 +31,7 @@ package("nana")
             io.gsub(file_name, " and ", " && ")
         end
 
-        local configs = {"-DNANA_CMAKE_ENABLE_JPEG=OFF", "-DNANA_CMAKE_ENABLE_PNG=OFF"}
+        local configs = {"-DNANA_CMAKE_ENABLE_JPEG=OFF", "-DNANA_CMAKE_ENABLE_PNG=OFF", "-DBUILD_SHARED_LIBS=OFF"}
         if package:is_plat("linux") then
             table.insert(configs, "-DNANA_CMAKE_NANA_FILESYSTEM_FORCE=ON")
         end

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -8,6 +8,9 @@ package("nana")
     add_versions("1.6.2", "5f5cb791dff292e27bfa29d850b93f809a0d91d6044ea7e22ce7ae76a5d8b24e")
     add_versions("1.7.2", "e2efb3b7619e4ef3b6de93f8afc70ff477ec6cabf4f9740f0d786904c790613f")
     add_versions("1.7.4", "56f7b1ed006c750fccf8ef15ab1e83f96751f2dfdcb68d93e5f712a6c9b58bcb")
+    if is_plat("linux") then
+        add_patches("1.7.4", path.join(os.scriptdir(), "patches", "1.7.4", "u8string_fix.patch"), "c783588816664124ba3b4077e18696899c8389419a015773b5bfe988e3a73f6a")
+    end
 
     if is_plat("linux", "windows") then
         add_deps("cmake >=3.12")
@@ -18,6 +21,7 @@ package("nana")
         add_defines("_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING")
     elseif is_plat("linux") then
         add_syslinks("pthread", "X11", "Xft", "fontconfig")
+        add_links("nana")
     end
 
     on_install("linux", "windows", function (package)
@@ -32,8 +36,9 @@ package("nana")
         end
         import("package.tools.cmake").install(package, configs)
 
-        if is_plat("windows") then
-            os.cp("include", package:installdir())
+        os.cp("include", package:installdir())
+        if is_plat("linux") then
+            os.cp("**.a", package:installdir("lib"))
         end
     end)
 

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -26,19 +26,19 @@ package("nana")
     end
 
     on_install("linux", "windows", function (package)
-        if is_plat("windows") then
+        if package:is_plat("windows") then
             local file_name = path.join(os.curdir(), "source", "system", "split_string.cpp")
             io.gsub(file_name, " and ", " && ")
         end
 
         local configs = {"-DNANA_CMAKE_ENABLE_JPEG=OFF", "-DNANA_CMAKE_ENABLE_PNG=OFF"}
-        if is_plat("linux") then
+        if package:is_plat("linux") then
             table.insert(configs, "-DNANA_CMAKE_NANA_FILESYSTEM_FORCE=ON")
         end
         import("package.tools.cmake").install(package, configs)
 
         os.cp("include", package:installdir())
-        if is_plat("linux") then
+        if package:is_plat("linux") then
             os.cp("**.a", package:installdir("lib"))
         end
     end)

--- a/packages/n/nana/xmake.lua
+++ b/packages/n/nana/xmake.lua
@@ -8,6 +8,7 @@ package("nana")
     add_versions("1.6.2", "5f5cb791dff292e27bfa29d850b93f809a0d91d6044ea7e22ce7ae76a5d8b24e")
     add_versions("1.7.2", "e2efb3b7619e4ef3b6de93f8afc70ff477ec6cabf4f9740f0d786904c790613f")
     add_versions("1.7.4", "56f7b1ed006c750fccf8ef15ab1e83f96751f2dfdcb68d93e5f712a6c9b58bcb")
+    add_patches("1.7.4", path.join(os.scriptdir(), "patches", "1.7.4", "cmake_policy_fix.patch"), "237a60d12eb2760c1010043686b1938b03e18791003d8ddfc639f458f0c7467d")
     if is_plat("linux") then
         add_patches("1.7.4", path.join(os.scriptdir(), "patches", "1.7.4", "u8string_fix.patch"), "c783588816664124ba3b4077e18696899c8389419a015773b5bfe988e3a73f6a")
     end


### PR DESCRIPTION
Adds a patch which replaces ```u8string``` with ```string```. It also copies all headers and libraries and adds nana as a link.