### PR TITLE
Add tclap package

### DIFF
--- a/packages/t/tclap/xmake.lua
+++ b/packages/t/tclap/xmake.lua
@@ -6,15 +6,14 @@ package("tclap")
     set_urls("https://netcologne.dl.sourceforge.net/project/tclap/tclap-$(version).tar.bz2")
     add_versions("1.4.0-rc1", "33e18c7828f76a9e5f2a00afe575156520e383693059ca9bc34ff562927e20c6")
 
-    -- NOTE it could be useful to patch CMakeLists.txt
-    -- in order to avoid building examples
-
-    -- python3 is required by the tests module
-    add_deps("cmake", "python 3.*")
+    add_deps("cmake")
 
     on_install(function (package)
-        -- We don't want to build the doc
-        local configs = {"-DBUILD_DOC=false"}
+        io.replace("CMakeLists.txt", "add_subdirectory(docs)", "", {plain = true})
+        io.replace("CMakeLists.txt", "add_subdirectory(examples)", "", {plain = true})
+        io.replace("CMakeLists.txt", "add_subdirectory(tests)", "", {plain = true})
+
+        local configs = {}
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/t/tclap/xmake.lua
+++ b/packages/t/tclap/xmake.lua
@@ -1,0 +1,28 @@
+package("tclap")
+    set_homepage("https://sourceforge.net/projects/tclap/")
+    set_description("This is a simple templatized C++ library for parsing command line arguments.")
+    set_license("MIT")
+
+    set_urls("https://netcologne.dl.sourceforge.net/project/tclap/tclap-$(version).tar.bz2")
+    add_versions("1.4.0-rc1", "33e18c7828f76a9e5f2a00afe575156520e383693059ca9bc34ff562927e20c6")
+
+    -- NOTE it could be useful to patch CMakeLists.txt
+    -- in order to avoid building examples
+
+    -- python3 is required by the tests module
+    add_deps("cmake", "python 3.*")
+
+    on_install(function (package)
+        -- We don't want to build the doc
+        local configs = {"-DBUILD_DOC=false"}
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            #include <tclap/CmdLine.h>
+            void test() {
+                TCLAP::CmdLine cmd("Test", ' ', "0.9");
+            }
+        ]]}, {configs = {languages = "c++98"}}))
+    end)


### PR DESCRIPTION
This commit adds tclap, a templatized C++ library for parsing commandline arguments.

I'm not sure if `-DBUILD_DOC=false` really disable documentation building since I don't have doxygen installed on my machine.
I don't know how to patch the CMakeLists.txt file, but it would be good to avoid useless computation by building examples.

I have tested it and added python3 as a dependency (I don't know if this information is relevant but here it is: I've got python 3.9.2 installed on my machine, the latest in the repo is 3.8.5, and so xmake downloaded python 3.8.5) because it is required to run the tests.

I don't know, maybe we don't want the tests to run, and in this case, we could later patch the CMakeLists.txt file by removing the following lines:
```
add_subdirectory(docs)
add_subdirectory(examples)
add_subdirectory(tests)
```
If we do that, we could remove the `-DBUILD_DOC=false` line in the package script.