### PR TITLE
add lodepng and libtorch

### DIFF
--- a/packages/l/libtorch/xmake.lua
+++ b/packages/l/libtorch/xmake.lua
@@ -16,14 +16,14 @@ package("libtorch")
     add_includedirs("include/torch/csrc/api/include")
 
     -- prevent the link to the libraries found automatically
-    add_links()
+    add_links("")
     on_load("windows|x64", "macosx", "linux", function (package)
         import("detect.sdks.find_cuda")
 
         -- ensure that git core.longpaths is enabled
         os.vrun("git config --global core.longpaths true")
 
-        local libnames = {"torch"}
+        local libnames = {"torch", "torch_cpu"}
         local cuda = find_cuda()
         if not package:is_plat("macosx") then
             local mkl = find_package("mkl")
@@ -31,18 +31,16 @@ package("libtorch")
             if cuda ~= nil then
                 package:add("deps", cuda)
                 table.insert(libnames, "torch_cuda")
-            else
-                table.insert(libnames, "torch_cpu")
             end
-        else
-            table.insert(libnames, "torch_cpu")
         end
         table.insert(libnames, "c10")
         if cuda ~= nil then
             table.insert(libnames, "c10_cuda")
             package:add("deps", cuda)
             package:add("deps", find_package("nvtx"))
-            package:add("links", "nvrtc", "cudnn", "cufft", "curand", "cublas", "cudart_static")
+            for _, lib in ipairs({"nvrtc", "cudnn", "cufft", "curand", "cublas", "cudart_static"}) do
+                package:add("links", lib)
+            end
             if package:is_plat("windows") then
                 package:addenv("PATH", cuda.bindir)
             end

--- a/packages/l/libtorch/xmake.lua
+++ b/packages/l/libtorch/xmake.lua
@@ -1,0 +1,121 @@
+package("libtorch")
+
+    set_homepage("https://pytorch.org/")
+    set_description("An open source machine learning framework that accelerates the path from research prototyping to production deployment.")
+    set_license("BSD-3-Clause")
+
+    add_urls("https://github.com/pytorch/pytorch.git")
+    add_versions("v1.8.0", "37c1f4a7fef115d719104e871d0cf39434aa9d56")
+
+    add_configs("python", {description = "Build python interface.", default = false, type = "boolean"})
+
+    add_deps("cmake", {kind = "binary"})
+    add_deps("python 3.x", {kind = "binary", system = false})
+    add_deps("libuv")
+    add_includedirs("include")
+    add_includedirs("include/torch/csrc/api/include")
+
+    -- prevent the link to the libraries found automatically
+    add_links()
+    on_load("windows|x64", "macosx", "linux", function (package)
+        import("lib.detect.find_package")
+        import("detect.sdks.find_cuda")
+
+        -- ensure that git core.longpaths is enabled
+        os.vrun("git config --global core.longpaths true")
+
+        local libnames = {"torch"}
+        local cuda = find_cuda()
+        if not package:is_plat("macosx") then
+            local mkl = find_package("mkl")
+            package:add("deps", mkl ~= nil and find_package("mkl") or "openblas")
+            if cuda ~= nil then
+                package:add("deps", cuda)
+                table.insert(libnames, "torch_cuda")
+            else
+                table.insert(libnames, "torch_cpu")
+            end
+        else
+            table.insert(libnames, "torch_cpu")
+        end
+        table.insert(libnames, "c10")
+        if cuda ~= nil then
+            table.insert(libnames, "c10_cuda")
+        end
+        local suffix = ""
+        if not package:is_plat("windows") and package:config("shared") then
+            package:add("ldflags", "-Wl,-rpath," .. package:installdir("lib"))
+            if package:is_plat("linux") then
+                suffix = ".so"
+            elseif package:is_plat("macosx") then
+                suffix = ".dylib"
+            end
+            for _, lib in ipairs(libnames) do
+                package:add("ldflags", (package:is_plat("linux") and "-Wl,--no-as-needed," or "") .. package:installdir("lib", "lib") .. lib .. suffix)
+            end
+        else
+            for _, lib in ipairs(libnames) do
+                package:add("links", lib)
+            end
+        end
+    end)
+
+    on_install("windows|x64", "macosx", "linux", function (package)
+        import("package.tools.cmake")
+        import("lib.detect.find_package")
+
+        -- git issue
+        os.vrun("git submodule sync")
+        os.vrun("git submodule update --init --recursive")
+
+        -- some patches to the third-party cmake files
+        io.replace("cmake/Modules/FindMKL.cmake", "MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL \"Intel\"", "FALSE", {plain = true})
+        io.replace("third_party/fbgemm/CMakeLists.txt", "PRIVATE FBGEMM_STATIC", "PUBLIC FBGEMM_STATIC", {plain = true})
+        io.gsub("third_party/protobuf/cmake/install.cmake", "install%(DIRECTORY.-%)", "")
+        io.replace("third_party/ideep/mkl-dnn/src/CMakeLists.txt", "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}", "${CMAKE_INSTALL_LIBDIR}", {plain = true})
+        if package:is_plat("windows") then
+            io.replace("cmake/Modules/FindOpenBLAS.cmake", "NAMES openblas PATHS", "NAMES libopenblas PATHS", {plain = true})
+            if package:config("vs_runtime"):startswith("MD") then
+                io.replace("third_party/fbgemm/CMakeLists.txt", "MT", "MD", {plain = true})
+            end
+        end
+
+        -- prepare python
+        os.vrun("python -m pip install typing_extensions pyyaml")
+        local configs = {"-DUSE_MPI=OFF"}
+        if package:config("python") then
+            table.insert(configs, "-DBUILD_PYTHON=ON")
+            os.vrun("python -m pip install numpy")
+        else
+            table.insert(configs, "-DBUILD_PYTHON=OFF")
+        end
+
+        -- prepare for installation
+        local envs = cmake.buildenvs(package)
+        if not package:is_plat("macosx") then
+            local mkl = find_package("mkl")
+            if mkl then
+                table.insert(configs, "-DBLAS=MKL")
+                local mkl_dir = path.directory(mkl.includedirs[1])
+                table.insert(configs, "-DINTEL_MKL_DIR=" .. mkl_dir)
+            else
+                table.insert(configs, "-DBLAS=OpenBLAS")
+                envs.OpenBLAS_HOME = package:dep("openblas"):installdir()
+            end
+        end
+        envs.libuv_ROOT = package:dep("libuv"):installdir()
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        table.insert(configs, "-DCAFFE2_USE_MSVC_STATIC_RUNTIME=" .. (package:config("vs_runtime"):startswith("MT") and "ON" or "OFF"))
+        cmake.install(package, configs, {envs = envs})
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            void test() {
+                auto a = torch::ones(3);
+                auto b = torch::tensor({1, 2, 3});
+                auto c = torch::dot(a, b);
+            }
+        ]]}, {configs = {languages = "c++14"}, includes = "torch/torch.h"}))
+    end)

--- a/packages/l/lodepng/xmake.lua
+++ b/packages/l/lodepng/xmake.lua
@@ -1,0 +1,22 @@
+package("lodepng")
+
+    set_homepage("https://lodev.org/lodepng/")
+    set_description("PNG encoder and decoder in C and C++.")
+    set_license("zlib")
+
+    add_urls("https://github.com/lvandeve/lodepng.git")
+
+    on_install(function (package)
+        io.writefile("xmake.lua", [[
+            add_rules("mode.debug", "mode.release")
+            target("lodepng")
+                set_kind("static")
+                add_files("lodepng.cpp")
+                add_headerfiles("lodepng.h")
+        ]])
+        import("package.tools.xmake").install(package, {mode = package:debug() and "debug" or "release"})
+    end)
+
+    on_test(function (package)
+        assert(package:has_cxxfuncs("lodepng_decode_memory", {includes = "lodepng.h"}))
+    end)

--- a/packages/l/lodepng/xmake.lua
+++ b/packages/l/lodepng/xmake.lua
@@ -10,11 +10,17 @@ package("lodepng")
         io.writefile("xmake.lua", [[
             add_rules("mode.debug", "mode.release")
             target("lodepng")
-                set_kind("static")
+                set_kind("$(kind)")
                 add_files("lodepng.cpp")
                 add_headerfiles("lodepng.h")
         ]])
-        import("package.tools.xmake").install(package, {mode = package:debug() and "debug" or "release"})
+        local configs = {}
+        if package:config("shared") then
+            configs.kind = "shared"
+        elseif not package:is_plat("windows", "mingw") and package:config("pic") ~= false then
+            configs.cxflags = "-fPIC"
+        end
+        import("package.tools.xmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/n/ninja/xmake.lua
+++ b/packages/n/ninja/xmake.lua
@@ -8,19 +8,22 @@ package("ninja")
         set_urls("https://github.com/ninja-build/ninja/releases/download/v$(version)/ninja-win.zip")
         add_versions("1.9.0", "2d70010633ddaacc3af4ffbd21e22fae90d158674a09e132e06424ba3ab036e9")
         add_versions("1.10.1", "5d1211ea003ec9760ad7f5d313ebf0b659d4ffafa221187d2b4444bc03714a33")
+        add_versions("1.10.2", "bbde850d247d2737c5764c927d1071cbb1f1957dcabda4a130fa8547c12c695f")
     elseif is_host("macosx") then
         set_urls("https://github.com/ninja-build/ninja/releases/download/v$(version)/ninja-mac.zip")
         add_versions("1.9.0", "26d32a79f786cca1004750f59e545199bf110e21e300d3c2424c1fddd78f28ab")
         add_versions("1.10.1", "0bd650190d4405c15894055e349d9b59d5690b0389551d757c5ed2d3841972d1")
+        add_versions("1.10.2", "6fa359f491fac7e5185273c6421a000eea6a2f0febf0ac03ac900bd4d80ed2a5")
     elseif is_host("linux") then
         add_urls("https://github.com/ninja-build/ninja/archive/v$(version).tar.gz",
                  "https://github.com/ninja-build/ninja.git")
         add_versions("1.9.0", "5d7ec75828f8d3fd1a0c2f31b5b0cea780cdfe1031359228c428c1a48bfcd5b9")
         add_versions("1.10.1", "a6b6f7ac360d4aabd54e299cc1d8fa7b234cd81b9401693da21221c62569a23e")
+        add_versions("1.10.2", "ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed")
     end
 
     if is_host("linux") then
-        add_deps("python2", {kind = "binary"})
+        add_deps(package:version():ge("1.10.0") and "python" or "python2", {kind = "binary"})
     end
 
     on_install("@windows", "@msys", "@cygwin", function (package)
@@ -32,7 +35,7 @@ package("ninja")
     end)
 
     on_install("@linux", function (package)
-        os.vrun("python2 configure.py --bootstrap")
+        os.vrun("python configure.py --bootstrap")
         os.cp("./ninja", package:installdir("bin"))
     end)
 

--- a/packages/n/ninja/xmake.lua
+++ b/packages/n/ninja/xmake.lua
@@ -22,9 +22,9 @@ package("ninja")
         add_versions("1.10.2", "ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed")
     end
 
-    if is_host("linux") then
-        add_deps(package:version():ge("1.10.0") and "python" or "python2", {kind = "binary"})
-    end
+    on_load("linux", function (package)
+        package:add("deps", package:version():ge("1.10.0") and "python" or "python2", {kind = "binary"})
+    end)
 
     on_install("@windows", "@msys", "@cygwin", function (package)
         os.cp("./ninja.exe", package:installdir("bin"))

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -19,6 +19,8 @@ package("openblas")
 
     if is_plat("linux") then
         add_syslinks("pthread")
+    elseif is_plat("windows") then
+        add_links("libopenblas")
     end
 
     on_install("windows|x64", function (package)


### PR DESCRIPTION
python 3.x设置了kind=binary，但python在linux上依赖的ffi、ssl、zlib还是导出给了libtorch，很奇怪；

git submodules相关代码为了前向兼容，以后可以删掉