### PR TITLE
libusb: Use on_fetch instead of add_extsources to fix a priority issue

### DIFF
--- a/packages/l/libusb/xmake.lua
+++ b/packages/l/libusb/xmake.lua
@@ -22,10 +22,12 @@ package("libusb")
     end
 
     -- it will be provided in xmake v2.5.2
-    if add_extsources then
-        if is_plat("macosx", "linux") then
-            add_extsources("pkgconfig::libusb-1.0")
-        end
+    if on_fetch then
+        on_fetch("linux", "macosx", function(package, opt)
+            if opt.system then
+                return find_package("pkgconfig::libusb-1.0")
+            end
+        end)
     end
 
     add_includedirs("include", "include/libusb-1.0")


### PR DESCRIPTION
With add_extsources, xmake will first try to find pkgconfig::libusb before falling back on pkgconfig::libusb-1.0.

The problem here is that pkgconfig::libusb is the old libusb library (0.1), not the one referred by this package.
Using on_fetch fixes this (as it's called before xmake tries to find it by name).

Maybe this should be extended with other packages managers (would `return find_package("libusb-1.0")` work?)