### PR TITLE
Add ability to set user_config for ImGui at user's own risk

### DIFF
--- a/packages/i/imgui/xmake.lua
+++ b/packages/i/imgui/xmake.lua
@@ -11,23 +11,36 @@ package("imgui")
     add_versions("v1.80", "d7e4e1c7233409018437a646680316040e6977b9a635c02da93d172baad94ce9")
     add_versions("v1.79", "f1908501f6dc6db8a4d572c29259847f6f882684b10488d3a8d2da31744cd0a4")
     add_versions("v1.75", "1023227fae4cf9c8032f56afcaea8902e9bfaad6d9094d6e48fb8f3903c7b866")
+    
+    add_configs("user_config", {description = "Use user config (disables test!)", default = nil, type = "string"})
 
     if is_plat("windows", "mingw") then
         add_syslinks("Imm32")
     end
 
     on_install("macosx", "linux", "windows", "mingw", "android", "iphoneos", function (package)
-        io.writefile("xmake.lua", [[
+        local xmake_lua = [[
             target("imgui")
                 set_kind("static")
                 add_files("*.cpp")
                 add_headerfiles("imgui.h", "imconfig.h")
-        ]])
+        ]]
+        
+        local user_config = package:config("user_config")
+        if user_config ~= nil then
+            if is_host("windows") then
+                user_config = user_config:gsub("\\", "\\\\")
+            end
+            xmake_lua = xmake_lua .. "add_defines(\"IMGUI_USER_CONFIG=\\\"" .. user_config .. "\\\"\")"
+        end
+
+        io.writefile("xmake.lua", xmake_lua)
         import("package.tools.xmake").install(package)
     end)
 
     on_test(function (package)
-        assert(package:check_cxxsnippets({test = [[
+        local user_config = package:config("user_config")
+        assert(user_config ~= nil or package:check_cxxsnippets({test = [[
             void test() {
                 IMGUI_CHECKVERSION();
                 ImGui::CreateContext();


### PR DESCRIPTION
**Problem**
ImGui has a way to override some things with custom config, which is completely inaccessible from xmake. There is no way to override assertions with custom ones for example cause of this.

**Solution**
Provide new config option with which user can set user config. Downside is that this cannot be properly tested against, so tests have to pass when this option is specified. ~~I added some warning print to let user know that there may be some issues when using library in this way inside on_test.~~

Would be great if there was something like this, as we would like to override ImGui assertions in our project and we cannot currently. This solution was tested on it .
As ImGui is compiled as static library, we can just define how assertion function looks and define IM_ASSERT inside config to resolve to it for library compilation.
We then define assertion function in our project and it gets properly linked later, thanks to it being static.

This should enhance experience for those who know what they are doing and allow us to use ImGui in more advanced way.
