### PR TITLE
add itk, vtk and range-v3

### DIFF
--- a/packages/b/bzip2/xmake.lua
+++ b/packages/b/bzip2/xmake.lua
@@ -1,18 +1,17 @@
 package("bzip2")
 
-    set_homepage("https://en.wikipedia.org/wiki/Bzip2")
-    set_description("Freely available high-quality data compressor.")
+    set_homepage("https://sourceware.org/bzip2/")
+    set_description("Freely available, patent free, high-quality data compressor.")
 
-    set_urls("https://ftp.osuosl.org/pub/clfs/conglomeration/bzip2/bzip2-$(version).tar.gz",
-             "https://fossies.org/linux/misc/bzip2-$(version).tar.gz")
-    add_versions("1.0.6", "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd")
+    add_urls("https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz")
+    add_versions("1.0.8", "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269")
 
     on_load("windows", function (package)
-        package:addenv("PATH", "bin")
         package:add("links", "libbz2")
     end)
 
     on_install("windows", function (package)
+        package:addenv("PATH", "bin")
         io.gsub("makefile.msc", "%-MD", "-" .. package:config("vs_runtime"))
         import("package.tools.nmake").build(package, {"-f", "makefile.msc", "bzip2"})
         os.cp("libbz2.lib", package:installdir("lib"))
@@ -21,6 +20,7 @@ package("bzip2")
     end)
 
     on_install("macosx", "linux", function (package)
+        package:addenv("PATH", "bin")
         local configs = {}
         if package:config("pic") ~= false then
             table.insert(configs, "CFLAGS=-fPIC")

--- a/packages/b/bzip2/xmake.lua
+++ b/packages/b/bzip2/xmake.lua
@@ -3,7 +3,7 @@ package("bzip2")
     set_homepage("https://sourceware.org/bzip2/")
     set_description("Freely available, patent free, high-quality data compressor.")
 
-    add_urls("https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz")
+    add_urls("https://sourceware.org/pub/bzip2/bzip2-$(version).tar.gz")
     add_versions("1.0.8", "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269")
 
     on_load("windows", function (package)

--- a/packages/c/cairo/port/cairo-features.h.in
+++ b/packages/c/cairo/port/cairo-features.h.in
@@ -21,7 +21,7 @@
 
 #define CAIRO_HAS_GOBJECT_FUNCTIONS 0
 
-#define CAIRO_HAS_FT_FONT ${FT_ON}
-#define CAIRO_HAS_FC_FONT ${FT_ON}
+#define CAIRO_HAS_FT_FONT 1
+#define CAIRO_HAS_FC_FONT ${FC_ON}
 
 #endif

--- a/packages/c/cairo/port/xmake.lua
+++ b/packages/c/cairo/port/xmake.lua
@@ -10,19 +10,28 @@ if has_config("with_x11") then
 end
 
 option("with_freetype")
-    set_default(is_plat("linux") and true or false)
+    set_default(true)
     add_defines(
         "HAVE_FT_GLYPHSLOT_EMBOLDEN=1",
         "HAVE_FT_LIBRARY_SETLCDFILTER=1",
         "HAVE_FT_GLYPHSLOT_OBLIQUE=1",
         "HAVE_FT_LOAD_SFNT_TABLE=1",
-        "HAVE_FT_GET_X11_FONT_FORMAT=1",
-        "CAIRO_HAS_FT_FONT=1",
-        "CAIRO_HAS_FC_FONT=1"
+        "HAVE_FT_GET_X11_FONT_FORMAT=" .. (has_config("with_x11") and "1" or "0"),
+        "CAIRO_HAS_FT_FONT=1"
     )
 option_end()
 if has_config("with_freetype") then
-    add_requires("freetype", "fontconfig")
+    add_requires("freetype")
+end
+
+option("with_fontconfig")
+    set_default(is_plat("linux") and true or false)
+    add_defines(
+        "CAIRO_HAS_FC_FONT=1"
+    )
+option_end()
+if has_config("with_fontconfig") then
+    add_requires("fontconfig")
 end
 
 target("cairo")

--- a/packages/c/cairo/xmake.lua
+++ b/packages/c/cairo/xmake.lua
@@ -6,9 +6,9 @@ package("cairo")
     set_urls("https://cairographics.org/releases/cairo-$(version).tar.xz")
     add_versions("1.16.0", "5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331")
 
-    add_deps("libpng", "pixman", "zlib")
+    add_deps("libpng", "pixman", "zlib", "freetype")
     if is_plat("linux") then
-        add_deps("freetype", "fontconfig")
+        add_deps("fontconfig")
     end
 
     if is_plat("windows") then
@@ -28,7 +28,7 @@ package("cairo")
     on_install("windows", "macosx", "linux", function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         os.cp(path.join(package:scriptdir(), "port", "cairo-features.h.in"), "cairo-features.h")
-        io.replace("cairo-features.h", "${FT_ON}", (package:is_plat("linux") and "1" or "0"), {plain = true})
+        io.replace("cairo-features.h", "${FC_ON}", (package:is_plat("linux") and "1" or "0"), {plain = true})
         import("package.tools.xmake").install(package, {kind = package:config("shared") and "shared" or "static"})
     end)
 

--- a/packages/e/entt/xmake.lua
+++ b/packages/e/entt/xmake.lua
@@ -5,12 +5,14 @@ package("entt")
 
     set_urls("https://github.com/skypjack/entt/archive/$(version).tar.gz",
              "https://github.com/skypjack/entt.git")
-
+    add_versions("v3.7.0", "39ad5c42acf3434f8c37e0baa18a8cb562c0845383a6b4da17fdbacc9f0a7695")
     add_versions("v3.6.0", "94b7dc874acd0961cfc28cf6b0342eeb0b7c58250ddde8bdc6c101e84b74c190")
+
     add_deps("cmake")
 
     on_install(function (package)
-        local configs = {}
+        local configs = {"-DENTT_BUILD_TESTING=OFF"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/e/expat/xmake.lua
+++ b/packages/e/expat/xmake.lua
@@ -5,16 +5,24 @@ package("expat")
     set_license("MIT")
 
     set_urls("https://github.com/libexpat/libexpat/releases/download/R_$(version).tar.bz2", {version = function (version) return version:gsub("%.", "_") .. "/expat-" .. version end})
-
+    add_versions("2.3.0", "f122a20eada303f904d5e0513326c5b821248f2d4d2afbf5c6f1339e511c0586")
     add_versions("2.2.10", "b2c160f1b60e92da69de8e12333096aeb0c3bf692d41c60794de278af72135a5")
     add_versions("2.2.6", "17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2")
 
-    if is_plat("windows") then
+    if is_plat("windows") or is_plat("mingw") then
         add_deps("cmake")
     end
 
-    on_install("windows", function (package)
+    on_load("windows", function (package)
+        if not package:config("shared") then
+            package:add("defines", "XML_STATIC")
+        end
+    end)
+
+    on_install("windows", "mingw", function (package)
         local configs = {"-DEXPAT_BUILD_EXAMPLES=OFF", "-DEXPAT_BUILD_TESTS=OFF", "-DEXPAT_BUILD_DOCS=OFF"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DEXPAT_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/h/houdini/xmake.lua
+++ b/packages/h/houdini/xmake.lua
@@ -1,0 +1,69 @@
+package("houdini")
+
+    set_homepage("https://www.sidefx.com/")
+    set_description("Houdini is built from the ground up to be a procedural system that empowers artists to work freely, create multiple iterations and rapidly share workflows with colleagues.")
+
+    on_fetch(function (package, opt)
+        if opt.system then
+            import("lib.detect.find_path")
+            import("lib.detect.find_program")
+            import("lib.detect.find_library")
+
+            -- init search paths
+            local paths = {"$(env Houdini_ROOT)"}
+            if package:is_plat("windows") then
+                local keys = winos.registry_keys("HKEY_LOCAL_MACHINE\\SOFTWARE\\Side Effects Software\\Houdini *.*.*")
+                for _, key in ipairs(keys) do
+                    table.insert(paths, winos.registry_query(key .. ";InstallPath"))
+                end
+            elseif package:is_plat("macosx") then
+                for _, path in ipairs(os.dirs("/Applications/Houdini/Houdini*.*.*")) do
+                    table.insert(paths, path)
+                end
+            else
+                for _, path in ipairs(os.dirs("/opt/hfs*.*.*")) do
+                    table.insert(paths, path)
+                end
+            end
+
+            -- find sdkdir
+            local result = {sdkdir = nil, links = {}, linkdirs = {}, includedirs = {}, libfiles = {}}
+            result.sdkdir = find_path("houdini_setup", paths)
+            if result.sdkdir then
+                package:addenv("PATH", path.join(result.sdkdir, "bin"))
+            else
+                local prog = find_program("houdini", {paths = os.getenv("PATH")})
+                if prog then
+                    result.sdkdir = path.directory(path.directory(prog))
+                else
+                    return
+                end
+            end
+            
+            -- find library
+            local prefix = (package:is_plat("windows") and "lib" or "")
+            local libs = {"HAPI"}
+            for _, lib in ipairs(libs) do
+                local libname = prefix .. lib
+                local linkinfo = find_library(libname, {result.sdkdir}, {suffixes = "custom/houdini/dsolib"})
+                if linkinfo then
+                    table.insert(result.linkdirs, linkinfo.linkdir)
+                    table.insert(result.links, libname)
+                    if package:is_plat("windows") then
+                        table.insert(result.libfiles, path.join(linkinfo.linkdir, libname .. ".lib"))
+                        table.insert(result.libfiles, path.join(result.sdkdir, "bin", libname .. ".dll"))
+                    end
+                end
+            end
+
+            -- find headers
+            local path = find_path(path.join("HAPI", "HAPI.h"), {result.sdkdir}, {suffixes = path.join("toolkit", "include")})
+            if path then
+                table.insert(result.includedirs, path)
+            end
+
+            if #result.includedirs > 0 and #result.linkdirs > 0 then
+                return result
+            end
+        end
+    end)

--- a/packages/i/itk/xmake.lua
+++ b/packages/i/itk/xmake.lua
@@ -1,0 +1,50 @@
+package("itk")
+
+    set_homepage("https://itk.org/")
+    set_description("ITK is an open-source, cross-platform library that provides developers with an extensive suite of software tools for image analysis.")
+    set_license("Apache-2.0")
+
+    add_urls("https://github.com/InsightSoftwareConsortium/ITK/archive/refs/tags/$(version).tar.gz")
+    add_versions("v5.2.0", "e53961cd78df8bcfaf8bd8b813ae2cafdde984c7650a2ddf7dcf808df463ea74")
+
+    add_deps("cmake", "eigen")
+    if is_plat("windows") then
+        add_syslinks("shell32", "advapi32")
+    elseif is_plat("linux") then
+        add_syslinks("dl", "pthread")
+    end
+    on_load("windows", "linux", "macosx", function (package)
+        local ver = package:version():major() .. "." .. package:version():minor()
+        package:add("includedirs", "include/ITK-" .. ver)
+        local libs = {"ITKWatersheds", "ITKVideoIO", "ITKVideoCore", "ITKVTK", "ITKTestKernel", "ITKRegistrationMethodsv4", "ITKRegionGrowing", "ITKQuadEdgeMeshFiltering", "ITKOptimizersv4", "ITKMarkovRandomFieldsClassifiers", "itklbfgs", "ITKKLMRegionGrowing", "ITKIOVTK", "ITKIOTransformMatlab", "ITKIOTransformInsightLegacy", "ITKIOTransformHDF5", "ITKIOTransformBase", "ITKTransformFactory", "ITKIOStimulate", "ITKIOSpatialObjects", "ITKIOXML", "ITKIOSiemens", "ITKIOPNG", "itkpng", "ITKIONRRD", "ITKNrrdIO", "ITKIONIFTI", "ITKIOMeta", "ITKIOMeshVTK", "ITKIOMeshOFF", "ITKIOMeshOBJ", "ITKIOMeshGifti", "ITKIOMeshFreeSurfer", "ITKIOMeshBYU", "ITKIOMeshBase", "ITKIOMRC", "ITKIOMINC", "itkminc2", "ITKIOLSM", "ITKIOTIFF", "itktiff", "ITKIOJPEG2000", "itkopenjpeg", "ITKIOJPEG", "itkjpeg", "ITKIOHDF5", "ITKIOGIPL", "ITKIOGE", "ITKIOIPL", "ITKIOGDCM", "ITKIOCSV", "ITKIOBruker", "ITKIOBioRad", "ITKIOBMP", "hdf5-static", "hdf5_cpp-static", "ITKPDEDeformableRegistration", "ITKgiftiio", "ITKniftiio", "ITKznz", "gdcmMSFF", "gdcmDICT", "ITKEXPAT", "ITKDiffusionTensorImage", "ITKDenoising", "ITKDeformableMesh", "ITKDICOMParser", "ITKConvolution", "ITKFFT", "ITKColormap", "ITKBiasCorrection", "ITKPolynomials", "ITKOptimizers", "ITKImageFeature", "ITKSmoothing", "ITKIOImageBase", "ITKFastMarching", "ITKQuadEdgeMesh", "ITKMathematicalMorphology", "ITKLabelMap", "ITKPath", "ITKSpatialObjects", "ITKMetaIO", "itkzlib", "ITKMesh", "ITKTransform", "ITKStatistics", "itkNetlibSlatec", "ITKCommon", "itkvcl", "itkvnl_algo", "itkvnl", "itkv3p_netlib", "itksys", "itkdouble-conversion"}
+        for _, lib in ipairs(libs) do
+            package:add("links", lib .. "-" .. ver)
+        end
+    end)
+
+    on_install("windows", "linux", "macosx", function (package)
+        local configs = {"-DITK_SKIP_PATH_LENGTH_CHECKS=ON",
+                         "-DBUILD_TESTING=OFF",
+                         "-DBUILD_EXAMPLES=OFF",
+                         "-DITK_WRAPPING=OFF",
+                         "-DITK_USE_SYSTEM_EIGEN=ON"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        if package:config("pic") ~= false then
+            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
+        end
+        if package:is_plat("windows") then
+            import("package.tools.cmake").install(package, configs, {buildir = os.tmpdir()})
+        else
+            import("package.tools.cmake").install(package, configs)
+        end
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            void test() {
+                using ImageType = itk::Image<unsigned short, 3>;
+                ImageType::Pointer image = ImageType::New();
+            }
+        ]]}, {configs = {languages = "c++11"}, includes = "itkImage.h"}))
+    end)

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -5,6 +5,7 @@ package("opencv")
 
     add_urls("https://github.com/opencv/opencv/archive/$(version).tar.gz",
              "https://github.com/opencv/opencv.git")
+    add_versions("4.5.2", "ae258ed50aa039279c3d36afdea5c6ecf762515836b27871a8957c610d0424f8")
     add_versions("4.5.1", "e27fe5b168918ab60d58d7ace2bd82dd14a4d0bd1d3ae182952c2113f5637513")
     add_versions("4.2.0", "9ccb2192d7e8c03c58fee07051364d94ed7599363f3b0dce1c5e6cc11c1bb0ec")
     add_versions("3.4.9", "b7ea364de7273cfb3b771a0d9c111b8b8dfb42ff2bcd2d84681902fb8f49892a")
@@ -20,6 +21,7 @@ package("opencv")
         add_syslinks("gdi32", "user32", "advapi32", "comdlg32")
     end
 
+    add_resources("4.5.2", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/4.5.2.tar.gz", "9f52fd3114ac464cb4c9a2a6a485c729a223afb57b9c24848484e55cef0b5c2a")
     add_resources("4.5.1", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/4.5.1.tar.gz", "12c3b1ddd0b8c1a7da5b743590a288df0934e5cef243e036ca290c2e45e425f5")
     add_resources("4.2.0", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/4.2.0.tar.gz", "8a6b5661611d89baa59a26eb7ccf4abb3e55d73f99bb52d8f7c32265c8a43020")
     add_resources("3.4.9", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/3.4.9.tar.gz", "dc7d95be6aaccd72490243efcec31e2c7d3f21125f88286186862cf9edb14a57")
@@ -31,6 +33,7 @@ package("opencv")
     end)
 
     on_install("linux", "macosx", "windows", function (package)
+        io.replace("cmake/OpenCVUtils.cmake", "if(PKG_CONFIG_FOUND OR PkgConfig_FOUND)", "if(NOT WIN32 AND (PKG_CONFIG_FOUND OR PkgConfig_FOUND))", {plain = true})
         local configs = {"-DCMAKE_OSX_DEPLOYMENT_TARGET=",
                          "-DBUILD_JASPER=OFF",
                          "-DBUILD_JPEG=ON",

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -100,7 +100,7 @@ package("opencv")
             -- keep compatibility for old versions
             local instdir = package:installdir(arch, vc_ver)
             if os.isdir(path.join(os.curdir(), "build", "install")) then
-                os.cp(path.join(os.curdir(), "build", "install", arch, vc_ver), package:installdir(arch))
+                os.trycp(path.join(os.curdir(), "build", "install", arch, vc_ver), package:installdir(arch))
             end
 
             -- scanning for links

--- a/packages/o/openjpeg/xmake.lua
+++ b/packages/o/openjpeg/xmake.lua
@@ -12,12 +12,20 @@ package("openjpeg")
     add_deps("cmake")
     add_deps("lcms", "libtiff", "libpng")
 
+    on_load("windows", "linux", "macosx", function (package)
+        local ver = package:version():major() .. "." .. package:version():minor()
+        package:add("includedirs", "include/openjpeg-" .. ver)
+    end)
+
     on_install("windows", "linux", "macosx", function (package)
         local configs = {"-DBUILD_TESTING=OFF", "-DBUILD_DOC=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         import("package.tools.cmake").install(package, configs)
-        os.mv(package:installdir("include", "openjpeg*", "*.h"), package:installdir("include"))
         package:add("PATH", "bin")
+        
+        -- fix cmake import files
+        local ver = package:version():major() .. "." .. package:version():minor()
+        io.gsub(package:installdir("lib", "openjpeg-" .. ver, "OpenJPEGConfig.cmake"), "set%(INC_DIR .-%)", format("set(INC_DIR ${SELF_DIR}/../../include/openjpeg-%s)", ver))
     end)
 
     on_test(function (package)

--- a/packages/o/openssl/xmake.lua
+++ b/packages/o/openssl/xmake.lua
@@ -28,7 +28,7 @@ package("openssl")
         local args = {"Configure"}
         table.insert(args, (package:is_arch("x86") and "VC-WIN32" or "VC-WIN64A"))
         table.insert(args, "--prefix=" .. package:installdir())
-        table.insert(args, "--openssldir=" .. package:installdir("conf"))
+        table.insert(args, "--openssldir=" .. package:installdir())
         os.vrunv("perl", args)
 
         -- temporary workaround, will be removed in future
@@ -42,7 +42,8 @@ package("openssl")
     end)
 
     on_install("linux", "macosx", function (package)
-        os.vrun("./config %s --prefix=\"%s\"", package:debug() and "--debug" or "", package:installdir())
+        -- https://wiki.openssl.org/index.php/Compilation_and_Installation#PREFIX_and_OPENSSLDIR
+        os.vrun("./config %s --openssldir=\"%s\" --prefix=\"%s\"", package:debug() and "--debug" or "", package:installdir(), package:installdir())
         import("package.tools.make").install(package)
     end)
 

--- a/packages/r/range-v3/xmake.lua
+++ b/packages/r/range-v3/xmake.lua
@@ -1,0 +1,36 @@
+package("range-v3")
+
+    set_homepage("https://github.com/ericniebler/range-v3/")
+    set_description("Range library for C++14/17/20, basis for C++20's std::ranges")
+    set_license("BSL-1.0")
+
+    add_urls("https://github.com/ericniebler/range-v3/archive/refs/tags/0.11.0.tar.gz",
+             "https://github.com/ericniebler/range-v3.git")
+    add_versions("0.11.0", "376376615dbba43d3bef75aa590931431ecb49eb36d07bb726a19f680c75e20c")
+
+    add_deps("cmake")
+    if is_plat("windows") then
+        add_cxxflags("/permissive-")
+    end
+
+    on_install(function (package)
+        local configs = {"-DRANGE_V3_DOCS=OFF", "-DRANGE_V3_TESTS=OFF", "-DRANGE_V3_EXAMPLES=OFF", "-DRANGE_V3_PERF=OFF"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            void test() {
+                using namespace ranges;
+                auto triples = views::for_each(views::iota(1), [](int z) {
+                    return views::for_each(views::iota(1, z + 1), [=](int x) {
+                        return views::for_each(views::iota(x, z + 1), [=](int y) {
+                            return yield_if(x * x + y * y == z * z,
+                                            std::make_tuple(x, y, z));
+                        });
+                    });
+                });
+            }
+        ]]}, {configs = {languages = "c++17"}, includes = "range/v3/all.hpp"}))
+    end)

--- a/packages/r/range-v3/xmake.lua
+++ b/packages/r/range-v3/xmake.lua
@@ -4,7 +4,7 @@ package("range-v3")
     set_description("Range library for C++14/17/20, basis for C++20's std::ranges")
     set_license("BSL-1.0")
 
-    add_urls("https://github.com/ericniebler/range-v3/archive/refs/tags/0.11.0.tar.gz",
+    add_urls("https://github.com/ericniebler/range-v3/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ericniebler/range-v3.git")
     add_versions("0.11.0", "376376615dbba43d3bef75aa590931431ecb49eb36d07bb726a19f680c75e20c")
 

--- a/packages/t/tmxparser/xmake.lua
+++ b/packages/t/tmxparser/xmake.lua
@@ -8,7 +8,7 @@ package("tmxparser")
 
     add_deps("zlib", "tinyxml2")
 
-    on_install(function (package)
+    on_install("windows", "macosx", "linux", function (package)
         io.gsub("include/Tmx.h.in", "@VERSION_PATCH@", "@VERSION_ALTER@")
         io.writefile("xmake.lua", ([[
             set_version("%s")
@@ -24,7 +24,14 @@ package("tmxparser")
                 add_configfiles("include/Tmx.h.in", {pattern = "@(.-)@"})
                 add_files("src/**.cpp")
         ]]):format(package:version_str()))
-        import("package.tools.xmake").install(package, {kind = package:config("shared") and "shared" or "static"})
+        local configs = {}
+        if not package:is_plat("windows") then
+            configs.kind = (package:config("shared") and "shared" or "static")
+        end
+        if package:is_plat("linux") and package:config("pic") ~= false then
+            configs.cxflags = "-fPIC"
+        end
+        import("package.tools.xmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/v/vtk/xmake.lua
+++ b/packages/v/vtk/xmake.lua
@@ -1,0 +1,43 @@
+package("vtk")
+
+    set_homepage("https://vtk.org/")
+    set_description("The Visualization Toolkit (VTK) is open source software for manipulating and displaying scientific data.")
+    set_license("BSD-3-Clause")
+
+    add_urls("https://www.vtk.org/files/release/$(version).tar.gz", {version = function (version)
+        return table.concat(table.slice((version):split('%.'), 1, 2), '.') .. "/VTK-" .. version
+    end})
+    add_versions("9.0.1", "1b39a5e191c282861e7af4101eaa8585969a2de05f5646c9199a161213a622c7")
+
+    add_deps("cmake")
+    if is_plat("windows") then
+        add_syslinks("gdi32", "user32", "opengl32", "vfw32", "comctl32", "wsock32")
+    elseif is_plat("linux") then
+        add_syslinks("dl", "pthread")
+    end
+    on_load("windows", "linux", function (package)
+        local ver = package:version():major() .. "." .. package:version():minor()
+        package:add("includedirs", "include/vtk-" .. ver)
+        local libs = {"vtkViewsInfovis", "vtkCommonColor", "vtkViewsContext2D", "vtkTestingRendering", "vtkTestingCore", "vtkRenderingVolumeOpenGL2", "vtkRenderingOpenGL2", "vtkglew", "vtkopengl", "vtkRenderingLabel", "vtkoctree", "vtkRenderingLOD", "vtkRenderingImage", "vtkIOVeraOut", "vtkhdf5", "vtkIOTecplotTable", "vtkIOSegY", "vtkIOParallelXML", "vtkIOParallel", "vtkjsoncpp", "vtkIOPLY", "vtkIOOggTheora", "vtktheora", "vtkogg", "vtkIONetCDF", "vtknetcdf", "vtkIOMotionFX", "vtkpegtl", "vtkIOMINC", "vtkIOLSDyna", "vtkIOInfovis", "vtklibxml2", "vtkzlib", "vtkIOImport", "vtkIOGeometry", "vtkIOVideo", "vtkIOMovie", "vtkIOExportPDF", "vtklibharu", "vtkIOExportGL2PS", "vtkRenderingGL2PSOpenGL2", "vtkgl2ps", "vtkpng", "vtkIOExport", "vtkRenderingVtkJS", "vtkRenderingSceneGraph", "vtkIOExodus", "vtkexodusII", "vtkIOEnSight", "vtkIOCityGML", "vtkpugixml", "vtkIOAsynchronous", "vtkIOAMR", "vtkInteractionImage", "vtkImagingStencil", "vtkImagingStatistics", "vtkImagingMorphological", "vtkImagingMath", "vtkIOSQL", "vtksqlite", "vtkGeovisCore", "vtklibproj", "vtkInfovisLayout", "vtkViewsCore", "vtkInteractionWidgets", "vtkRenderingVolume", "vtkRenderingAnnotation", "vtkImagingHybrid", "vtkImagingColor", "vtkInteractionStyle", "vtkFiltersTopology", "vtkFiltersSelection", "vtkFiltersSMP", "vtkFiltersProgrammable", "vtkFiltersPoints", "vtkFiltersVerdict", "vtkverdict", "vtkFiltersParallelImaging", "vtkFiltersImaging", "vtkImagingGeneral", "vtkFiltersHyperTree", "vtkFiltersGeneric", "vtkFiltersFlowPaths", "vtkFiltersAMR", "vtkFiltersParallel", "vtkFiltersTexture", "vtkFiltersModeling", "vtkFiltersHybrid", "vtkRenderingUI", "vtkDomainsChemistry", "vtkChartsCore", "vtkInfovisCore", "vtkFiltersExtraction", "vtkParallelDIY", "vtkdiy2", "vtkIOXML", "vtkIOXMLParser", "vtkexpat", "vtkParallelCore", "vtkIOLegacy", "vtkIOCore", "vtkdoubleconversion", "vtklz4", "vtklzma", "vtkutf8", "vtkFiltersStatistics", "vtkeigen", "vtkImagingFourier", "vtkImagingSources", "vtkIOImage", "vtkDICOMParser", "vtkjpeg", "vtkmetaio", "vtktiff", "vtkRenderingContext2D", "vtkRenderingFreeType", "vtkfreetype", "vtkkwiml", "vtkRenderingCore", "vtkFiltersSources", "vtkImagingCore", "vtkFiltersGeometry", "vtkFiltersGeneral", "vtkCommonComputationalGeometry", "vtkFiltersCore", "vtkCommonExecutionModel", "vtkCommonDataModel", "vtkCommonSystem", "vtkCommonMisc", "vtkCommonTransforms", "vtkCommonMath", "vtkCommonCore", "vtkloguru", "vtksys"}
+        for _, lib in ipairs(libs) do
+            package:add("links", lib .. "-" .. ver)
+        end
+    end)
+
+    on_install("windows", "linux", function (package)
+        local configs = {"-DVTK_BUILD_TESTING=OFF", "-DVTK_BUILD_EXAMPLES=OFF", "-DVTK_ENABLE_WRAPPING=OFF"}
+        table.insert(configs, "-DCMAKE_INSTALL_LIBDIR=lib")
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            void test() {
+                vtkCompositeDataPipeline* exec = vtkCompositeDataPipeline::New();
+                vtkAlgorithm::SetDefaultExecutivePrototype(exec);
+                exec->Delete();
+            }
+        ]]}, {configs = {languages = "c++11"}, includes = {"vtkAlgorithm.h", "vtkCompositeDataPipeline.h"}}))
+    end)

--- a/packages/v/vtk/xmake.lua
+++ b/packages/v/vtk/xmake.lua
@@ -11,7 +11,7 @@ package("vtk")
 
     add_deps("cmake")
     if is_plat("windows") then
-        add_syslinks("gdi32", "user32", "opengl32", "vfw32", "comctl32", "wsock32")
+        add_syslinks("gdi32", "user32", "shell32", "opengl32", "vfw32", "comctl32", "wsock32", "advapi32")
     elseif is_plat("linux") then
         add_syslinks("dl", "pthread")
     end


### PR DESCRIPTION
openjpeg出了个问题：当前xmake处理cmake包用的是先安装到`$(buildir)/install`下面然后复制各文件到安装目录下面。但有些包的cmake importfile也就是xxxTarget.cmake里面用的是绝对路径，这就会导致这些库一旦移动位置cmake文件的指示就不准了，其他依赖这个库的cmake库就会报错，openjpeg就是此例。

xmake是否考虑换一种形式处理：直接安装到指定位置，然后删除多余的文件夹（不需要copy的文件夹）？这样对cmake的库更加友好