### PR TITLE
fix luajit lua 5.2 compat

### DIFF
--- a/packages/l/luajit/port/xmake.lua
+++ b/packages/l/luajit/port/xmake.lua
@@ -125,6 +125,7 @@ target("buildvm")
     add_includedirs("src")
     set_host_toolchains()
     add_files("src/host/buildvm*.c")
+    add_defines("LUAJIT_ENABLE_LUA52COMPAT", {public = true})
     if is_host("windows") then
         add_defines("_CRT_SECURE_NO_DEPRECATE", "_CRT_STDIO_INLINE=__declspec(dllexport)__inline")
     end


### PR DESCRIPTION
The `buildvm` should be compiled with the `LUAJIT_ENABLE_LUA52COMPAT` define to enable all Lua 5.2 extensions in LuaJIT.

Very basic test:
```lua
print('rawlen is ' .. type(rawlen))
print('table.pack is ' .. type(table.pack))
print('table.unpack is ' .. type(table.unpack))
```

Correct output without extensions:
```
rawlen is nil
table.pack is nil
table.unpack is nil
```

Correct output with enabled extensions:
```
rawlen is function
table.pack is function
table.unpack is function
```

Current output is incorrect:
```
rawlen is nil
table.pack is nil
table.unpack is function
```