### PR TITLE
Rework documentation links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ xmake-repo is an official xmake package repository.
 
 <img src="https://xmake.io/assets/img/index/package_manage.png" width="80%" />
 
-If you want to know more, please refer to:
+If you want to know more, please refer to the xmake documentation:
 
+* [Remote Packages in xmake](https://xmake.io/#/package/remote_package)
 * [Github](https://github.com/xmake-io/xmake)
 * [HomePage](https://xmake.io)
 
@@ -75,7 +76,11 @@ xrepo is a cross-platform C/C++ package manager based on [Xmake](https://github.
 
 It is based on the runtime provided by xmake, but it is a complete and independent package management program. Compared with package managers such as vcpkg/homebrew, xrepo can provide C/C++ packages for more platforms and architectures at the same time.
 
-If you want to know more, please refer to: [Documents](https://xrepo.xmake.io/#/getting_started), [Github](https://github.com/xmake-io/xrepo) and [Gitee](https://gitee.com/tboox/xrepo)
+If you want to know more, please refer to the xrepo documentation: 
+
+* [Documents](https://xrepo.xmake.io/#/getting_started) 
+* [Github](https://github.com/xmake-io/xrepo) 
+* [Gitee](https://gitee.com/tboox/xrepo)
 
 ![](https://xrepo.xmake.io/assets/img/xrepo.gif)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ xmake-repo is an official xmake package repository.
 
 If you want to know more, please refer to:
 
-* [Documents](https://xmake.io/#/home)
 * [Github](https://github.com/xmake-io/xmake)
 * [HomePage](https://xmake.io)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -66,7 +66,6 @@ xmake-repo是一个官方的xmake包管理仓库，收录了常用的c/c++开发
 
 如果你想要了解更多，请参考：
 
-* [在线文档](https://xmake.io/#/zh/)
 * [在线源码](https://github.com/xmake-io/xmake)
 * [项目主页](https://xmake.io/cn)
 


### PR DESCRIPTION

This removes the broken links in the README.md
#372 

It also makes it clearer which links link to which documentation (In the english README).
#373 

I replaced one link to the xmake homepage by a more relevant link to the section about remote packages(In the english README). I can't do this for the chinese version as I don't speak chinese.

