### PR TITLE
libsdl: Add with_x option

### DIFF
--- a/packages/l/libsdl/xmake.lua
+++ b/packages/l/libsdl/xmake.lua
@@ -25,7 +25,8 @@ package("libsdl")
     end
     add_includedirs("include", "include/SDL2")
 
-    add_configs("use_sdlmain", {description = "Use SDL_main entry", default = true, type = "boolean"})
+    add_configs("with_x", {description = "Enables X support (requires it on the system)", default = true, type = "boolean"})
+    add_configs("use_sdlmain", {description = "Use SDL_main entry point", default = true, type = "boolean"})
 
     on_load(function (package)
         if package:config("use_sdlmain") then
@@ -108,12 +109,14 @@ package("libsdl")
         else
             table.insert(configs, "--enable-shared=no")
         end
-        if package:is_plat("linux") and package:config("pic") ~= false then
-            table.insert(configs, "--with-pic")
-        end
         if package:is_plat("linux") then
-            -- fix Missing Xext.h if some X libs are found
-            table.insert(configs, "--without-x")
+            if package:config("pic") ~= false then
+                table.insert(configs, "--with-pic")
+            end
+
+            if not package:config("with_x") then
+                table.insert(configs, "--without-x")
+            end
         end
         import("package.tools.autoconf").install(package, configs)
     end)


### PR DESCRIPTION
Disabling X support with libsdl will be a huge problem to most Linux users as Wayland, the only other serious windowing system, is not as widespread and X is currently the de-facto display server for the Linux world.

I propose to add a with_x option which will allow users to disable X support if they don't want it (which I doubt will happen except if you build only for your system and don't want to distribute your app, also it will only happen if libsdl2 isn't already installed on the system which is unlikely on a graphical distribution).  
As a consequence, Fedora build will fail. I think we should add the `libxext-dev` package to the CI to fix this.

SDL only requires X headers (among other) to build, and doesn't link it, so I tried to use xmake dependency system to handle libxext automatically but I couldn't manage to make it work (I'm never used autoconf before).

Here are my changes, in case it helps someone to do it in the future.

In on_load add:
```lua
        if package:is_plat("linux") and package:config("with_x") then
            package:add("deps", "libx11", "libxext", {system = false, links = {}})
        end
```

Replace on_install by this:
```lua
    on_install("macosx", "linux", function (package)
        local configs = {}
        if package:config("shared") then
            table.insert(configs, "--enable-shared=yes")
        else
            table.insert(configs, "--enable-shared=no")
        end
        if package:is_plat("linux") then
            if package:config("pic") ~= false then
                table.insert(configs, "--with-pic")
            end

            if package:config("with_x") then
                local headers
                for _, name in pairs({"libx11", "libxext"}) do
                    local pkg = package:dep(name):fetch()
                    if pkg and pkg.sysincludedirs then
                        headers = headers or {}
                        for _, headerpath in pairs(pkg.sysincludedirs) do
                            table.insert(headers, headerpath)
                        end
                    end
                end
                -- fix Missing Xext.h if some X libs are found
                if headers then
                    table.insert(configs, "--x-includes=" .. table.concat(headers, ";"))
                end
            else
                table.insert(configs, "--without-x")
            end
        end
        import("package.tools.autoconf").install(package, configs)
    end)
```