### PR TITLE
add nanoflann, tinyfiledialogs and filament

### DIFF
--- a/packages/f/filament/xmake.lua
+++ b/packages/f/filament/xmake.lua
@@ -23,11 +23,11 @@ package("filament")
         if package:is_plat("windows") then
             table.insert(configs, "-DUSE_STATIC_CRT=" .. (package:config("vs_runtime"):startswith("MT") and "ON" or "OFF"))
         end
-        local extracfg = {buildir = os.tmpdir()}
+        local opt = {buildir = os.tmpdir()}
         if package:config("ninja") then
-            extracfg.cmake_generator = "Ninja"
+            opt.cmake_generator = "Ninja"
         end
-        import("package.tools.cmake").install(package, configs, extracfg)
+        import("package.tools.cmake").install(package, configs, opt)
         package:addenv("PATH", "bin")
     end)
 

--- a/packages/f/filament/xmake.lua
+++ b/packages/f/filament/xmake.lua
@@ -1,0 +1,36 @@
+package("filament")
+
+    set_homepage("https://google.github.io/filament/")
+    set_description("Filament is a real-time physically-based renderer written in C++.")
+    set_license("Apache-2.0")
+
+    add_urls("https://github.com/google/filament/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/google/filament.git")
+    add_versions("v1.9.23", "f353167208df8c2c6cf56175e863bd4d9e36d1655df7bcae36a85c107e009107")
+
+    add_configs("ninja", {description = "Use ninja to build the library.", default = false, type = "boolean"})
+
+    add_deps("cmake")
+    on_load("windows|x64", function (package)
+        if package:config("ninja") then
+            package:add("deps", "ninja")
+        end
+    end)
+
+    on_install("windows|x64", function (package)
+        local configs = {"-DFILAMENT_ENABLE_JAVA=OFF", "-DFILAMENT_SKIP_SAMPLES=ON"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        if package:is_plat("windows") then
+            table.insert(configs, "-DUSE_STATIC_CRT=" .. (package:config("vs_runtime"):startswith("MT") and "ON" or "OFF"))
+        end
+        local extracfg = {buildir = os.tmpdir()}
+        if package:config("ninja") then
+            extracfg.cmake_generator = "Ninja"
+        end
+        import("package.tools.cmake").install(package, configs, extracfg)
+        package:addenv("PATH", "bin")
+    end)
+
+    on_test(function (package)
+        assert(package:has_cxxtypes("filament::Engine", {configs = {languages = "c++11"}, includes = "filament/Engine.h"}))
+    end)

--- a/packages/n/nanoflann/xmake.lua
+++ b/packages/n/nanoflann/xmake.lua
@@ -1,0 +1,25 @@
+package("nanoflann")
+
+    set_homepage("https://github.com/jlblancoc/nanoflann/")
+    set_description("nanoflann: a C++11 header-only library for Nearest Neighbor (NN) search with KD-trees")
+    set_license("BSD-2-Clause")
+
+    add_urls("https://github.com/jlblancoc/nanoflann/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/jlblancoc/nanoflann.git")
+    add_versions("v1.3.2", "e100b5fc8d72e9426a80312d852a62c05ddefd23f17cbb22ccd8b458b11d0bea")
+
+    on_install(function (package)
+        os.cp("include/nanoflann.hpp", package:installdir("include"))
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            void test() {
+                const size_t num_results = 1;
+                size_t ret_index;
+                float out_dist_sqr;
+                nanoflann::KNNResultSet<float> resultSet(num_results);
+                resultSet.init(&ret_index, &out_dist_sqr);
+            }
+        ]]}, {configs = {languages = "c++11"}, includes = "nanoflann.hpp"}))
+    end)

--- a/packages/t/tinyfiledialogs/xmake.lua
+++ b/packages/t/tinyfiledialogs/xmake.lua
@@ -1,0 +1,34 @@
+package("tinyfiledialogs")
+
+    set_homepage("https://sourceforge.net/projects/tinyfiledialogs/")
+    set_description("Native dialog library for WINDOWS MAC OSX GTK+ QT CONSOLE")
+    set_license("zlib")
+
+    add_urls("https://git.code.sf.net/p/tinyfiledialogs/code.git")
+    add_versions("3.8.8", "d89567798fb1b989c6fc46a61698e4734760e0bf")
+
+    if is_plat("windows") then
+        add_syslinks("comdlg32", "ole32", "user32", "shell32")
+    end
+    on_install("windows", "linux", "macosx", function (package)
+        io.writefile("xmake.lua", [[
+            add_rules("mode.debug", "mode.release")
+            target("tinyfiledialogs")
+                set_kind("static")
+                add_files("tinyfiledialogs.c")
+                add_headerfiles("tinyfiledialogs.h")
+        ]])
+        import("package.tools.xmake").install(package)
+    end)
+
+    on_test(function (package)
+        assert(package:check_csnippets({test = [[
+            #include <stdio.h>
+            #include <string.h>
+            #include "tinyfiledialogs.h"
+            void test() {
+                char const * lWillBeGraphicMode;
+                lWillBeGraphicMode = tinyfd_inputBox("tinyfd_query", NULL, NULL);
+            }
+        ]]}))
+    end)


### PR DESCRIPTION
filament在macos/linux上要求用新版的clang编译，不支持gcc; 是否可以在package描述里面指定toolchain，或者判断当前toolchain是否符合要求？

filament暂不支持shared library，见https://github.com/google/filament/issues/1075