### PR TITLE
Fix libsdl_* .dll installation and run

### DIFF
--- a/packages/l/libsdl/xmake.lua
+++ b/packages/l/libsdl/xmake.lua
@@ -36,7 +36,7 @@ package("libsdl")
             package:add("defines", "SDL_MAIN_HANDLED")
         end
         if package:is_plat("linux") and package:config("with_x") then
-            package:add("deps", "libxext")
+            package:add("deps", "libxext", {private = true})
         end
         if package:is_plat("macosx") and package:version():ge("2.0.14") then
             package:add("frameworks", "CoreHaptics", "GameController")

--- a/packages/l/libsdl_gfx/xmake.lua
+++ b/packages/l/libsdl_gfx/xmake.lua
@@ -59,7 +59,10 @@ package("libsdl_gfx")
         if package:is_plat("linux") and package:config("pic") ~= false then
             table.insert(configs, "--with-pic")
         end
-        table.insert(configs, "--with-sdl-prefix=" .. package:dep("libsdl"):installdir())
+        local libsdl = package:dep("libsdl")
+        if libsdl and not libsdl:is_system() then
+            table.insert(configs, "--with-sdl-prefix=" .. libsdl:installdir())
+        end
         import("package.tools.autoconf").install(package, configs)
     end)
 

--- a/packages/l/libsdl_gfx/xmake.lua
+++ b/packages/l/libsdl_gfx/xmake.lua
@@ -53,6 +53,9 @@ package("libsdl_gfx")
         else
             table.insert(configs, "--enable-shared=no")
         end
+        if package:is_plat("linux") and package:config("pic") ~= false then
+            table.insert(configs, "--with-pic")
+        end
         table.insert(configs, "--with-sdl-prefix=" .. package:dep("libsdl"):installdir())
         import("package.tools.autoconf").install(package, configs)
     end)

--- a/packages/l/libsdl_gfx/xmake.lua
+++ b/packages/l/libsdl_gfx/xmake.lua
@@ -42,7 +42,7 @@ package("libsdl_gfx")
 
         local build_dir = path.join(arch, mode)
         os.cp(path.join(build_dir, "*.lib"), package:installdir("lib"))
-        os.cp(path.join(build_dir, "*.dll"), package:installdir("lib"))
+        os.cp(path.join(build_dir, "*.dll"), package:installdir("bin"))
         os.cp("*.h", package:installdir("include", "SDL2"))
     end)
 

--- a/packages/l/libsdl_gfx/xmake.lua
+++ b/packages/l/libsdl_gfx/xmake.lua
@@ -30,6 +30,9 @@ package("libsdl_gfx")
         content = content:gsub("%%%(AdditionalLibraryDirectories%)", package:dep("libsdl"):installdir("lib") .. ";%%%(AdditionalLibraryDirectories%)")
         io.writefile(file_name, content)
 
+        -- MSVC trick no longer required since C++11
+        io.replace("SDL2_gfxPrimitives.c", "#if defined(_MSC_VER)", "#if 0", {plain = true})
+
         local configs = {}
         local arch = package:is_arch("x86") and "Win32" or "x64"
         local mode = package:debug() and "Debug" or "Release"

--- a/packages/l/libsdl_image/xmake.lua
+++ b/packages/l/libsdl_image/xmake.lua
@@ -35,7 +35,10 @@ package("libsdl_image")
         if package:is_plat("linux") and package:config("pic") ~= false then
             table.insert(configs, "--with-pic")
         end
-        table.insert(configs, "--with-sdl-prefix=" .. package:dep("libsdl"):installdir())
+        local libsdl = package:dep("libsdl")
+        if libsdl and not libsdl:is_system() then
+            table.insert(configs, "--with-sdl-prefix=" .. libsdl:installdir())
+        end
         import("package.tools.autoconf").install(package, configs)
     end)
 

--- a/packages/l/libsdl_image/xmake.lua
+++ b/packages/l/libsdl_image/xmake.lua
@@ -22,7 +22,7 @@ package("libsdl_image")
         end
         os.cp("include/*", package:installdir("include/SDL2"))
         os.cp(path.join("lib", arch, "*.lib"), package:installdir("lib"))
-        os.cp(path.join("lib", arch, "*.dll"), package:installdir("lib"))
+        os.cp(path.join("lib", arch, "*.dll"), package:installdir("bin"))
     end)
 
     on_install("macosx", "linux", function (package)

--- a/packages/l/libsdl_image/xmake.lua
+++ b/packages/l/libsdl_image/xmake.lua
@@ -32,6 +32,9 @@ package("libsdl_image")
         else
             table.insert(configs, "--enable-shared=no")
         end
+        if package:is_plat("linux") and package:config("pic") ~= false then
+            table.insert(configs, "--with-pic")
+        end
         table.insert(configs, "--with-sdl-prefix=" .. package:dep("libsdl"):installdir())
         import("package.tools.autoconf").install(package, configs)
     end)

--- a/packages/l/libsdl_mixer/xmake.lua
+++ b/packages/l/libsdl_mixer/xmake.lua
@@ -35,7 +35,10 @@ package("libsdl_mixer")
         if package:is_plat("linux") and package:config("pic") ~= false then
             table.insert(configs, "--with-pic")
         end
-        table.insert(configs, "--with-sdl-prefix=" .. package:dep("libsdl"):installdir())
+        local libsdl = package:dep("libsdl")
+        if libsdl and not libsdl:is_system() then
+            table.insert(configs, "--with-sdl-prefix=" .. libsdl:installdir())
+        end
         import("package.tools.autoconf").install(package, configs)
     end)
 

--- a/packages/l/libsdl_mixer/xmake.lua
+++ b/packages/l/libsdl_mixer/xmake.lua
@@ -22,7 +22,7 @@ package("libsdl_mixer")
         end
         os.cp("include/*", package:installdir("include/SDL2"))
         os.cp(path.join("lib", arch, "*.lib"), package:installdir("lib"))
-        os.cp(path.join("lib", arch, "*.dll"), package:installdir("lib"))
+        os.cp(path.join("lib", arch, "*.dll"), package:installdir("bin"))
     end)
 
     on_install("macosx", "linux", function (package)

--- a/packages/l/libsdl_mixer/xmake.lua
+++ b/packages/l/libsdl_mixer/xmake.lua
@@ -32,6 +32,9 @@ package("libsdl_mixer")
         else
             table.insert(configs, "--enable-shared=no")
         end
+        if package:is_plat("linux") and package:config("pic") ~= false then
+            table.insert(configs, "--with-pic")
+        end
         table.insert(configs, "--with-sdl-prefix=" .. package:dep("libsdl"):installdir())
         import("package.tools.autoconf").install(package, configs)
     end)

--- a/packages/l/libsdl_net/xmake.lua
+++ b/packages/l/libsdl_net/xmake.lua
@@ -35,7 +35,10 @@ package("libsdl_net")
         if package:is_plat("linux") and package:config("pic") ~= false then
             table.insert(configs, "--with-pic")
         end
-        table.insert(configs, "--with-sdl-prefix=" .. package:dep("libsdl"):installdir())
+        local libsdl = package:dep("libsdl")
+        if libsdl and not libsdl:is_system() then
+            table.insert(configs, "--with-sdl-prefix=" .. libsdl:installdir())
+        end
         import("package.tools.autoconf").install(package, configs)
     end)
 

--- a/packages/l/libsdl_net/xmake.lua
+++ b/packages/l/libsdl_net/xmake.lua
@@ -32,6 +32,9 @@ package("libsdl_net")
         else
             table.insert(configs, "--enable-shared=no")
         end
+        if package:is_plat("linux") and package:config("pic") ~= false then
+            table.insert(configs, "--with-pic")
+        end
         table.insert(configs, "--with-sdl-prefix=" .. package:dep("libsdl"):installdir())
         import("package.tools.autoconf").install(package, configs)
     end)

--- a/packages/l/libsdl_net/xmake.lua
+++ b/packages/l/libsdl_net/xmake.lua
@@ -22,7 +22,7 @@ package("libsdl_net")
         end
         os.cp("include/*", package:installdir("include/SDL2"))
         os.cp(path.join("lib", arch, "*.lib"), package:installdir("lib"))
-        os.cp(path.join("lib", arch, "*.dll"), package:installdir("lib"))
+        os.cp(path.join("lib", arch, "*.dll"), package:installdir("bin"))
     end)
 
     on_install("macosx", "linux", function (package)

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -38,7 +38,10 @@ package("libsdl_ttf")
         if package:is_plat("linux") and package:config("pic") ~= false then
             table.insert(configs, "--with-pic")
         end
-        table.insert(configs, "--with-sdl-prefix=" .. package:dep("libsdl"):installdir())
+        local libsdl = package:dep("libsdl")
+        if libsdl and not libsdl:is_system() then
+            table.insert(configs, "--with-sdl-prefix=" .. libsdl:installdir())
+        end
         import("package.tools.autoconf").install(package, configs)
     end)
 

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -35,6 +35,9 @@ package("libsdl_ttf")
         else
             table.insert(configs, "--enable-shared=no")
         end
+        if package:is_plat("linux") and package:config("pic") ~= false then
+            table.insert(configs, "--with-pic")
+        end
         table.insert(configs, "--with-sdl-prefix=" .. package:dep("libsdl"):installdir())
         import("package.tools.autoconf").install(package, configs)
     end)

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -25,7 +25,7 @@ package("libsdl_ttf")
         end
         os.cp("include/*", package:installdir("include/SDL2"))
         os.cp(path.join("lib", arch, "*.lib"), package:installdir("lib"))
-        os.cp(path.join("lib", arch, "*.dll"), package:installdir("lib"))
+        os.cp(path.join("lib", arch, "*.dll"), package:installdir("bin"))
     end)
 
     on_install("macosx", "linux", function (package)


### PR DESCRIPTION
libsdl_gfx, libsdl_image, libsdl_mixer, libsdl_net and libsdl_ttf had the same issue libsdl had, .dll were copied to the wrong folder which causes issue when using `xmake run` on Windows