### PR TITLE
update libmpdclient package

### DIFF
--- a/packages/l/libmpdclient/xmake.lua
+++ b/packages/l/libmpdclient/xmake.lua
@@ -1,12 +1,15 @@
 package("libmpdclient")
     set_homepage("https://musicpd.org/libs/libmpdclient/")
     set_description("A stable, documented, asynchronous API library for interfacing MPD in the C, C++ & Objective C languages.")
+    set_kind("shared")
     add_urls("https://musicpd.org/download/libmpdclient/2/libmpdclient-$(version).tar.xz")
     add_versions("2.19", "158aad4c2278ab08e76a3f2b0166c99b39fae00ee17231bd225c5a36e977a189")
     add_deps("meson", "ninja")
 
     on_install("linux", function (package)
-        import("package.tools.meson").install(package)
+        local configs = {}
+        table.insert(configs, "-Ddefault_library=shared")
+        import("package.tools.meson").install(package, configs)
         os.cp("include", package:installdir())
         os.cp("build_*/version.h", package:installdir() .. "/include/mpd")
         os.rm(package:installdir() .. "/include/mpd/version.h.in")

--- a/packages/l/libmpdclient/xmake.lua
+++ b/packages/l/libmpdclient/xmake.lua
@@ -8,6 +8,8 @@ package("libmpdclient")
     on_install("linux", function (package)
         import("package.tools.meson").install(package)
         os.cp("include", package:installdir())
+        os.cp("build_*/version.h", package:installdir() .. "/include/mpd")
+        os.rm(package:installdir() .. "/include/mpd/version.h.in")
     end)
 
     on_test(function (package)

--- a/packages/l/libmpdclient/xmake.lua
+++ b/packages/l/libmpdclient/xmake.lua
@@ -1,14 +1,13 @@
 package("libmpdclient")
     set_homepage("https://musicpd.org/libs/libmpdclient/")
     set_description("A stable, documented, asynchronous API library for interfacing MPD in the C, C++ & Objective C languages.")
-    set_kind("shared")
     add_urls("https://musicpd.org/download/libmpdclient/2/libmpdclient-$(version).tar.xz")
     add_versions("2.19", "158aad4c2278ab08e76a3f2b0166c99b39fae00ee17231bd225c5a36e977a189")
     add_deps("meson", "ninja")
 
     on_install("linux", function (package)
         local configs = {}
-        table.insert(configs, "-Ddefault_library=shared")
+        table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
         import("package.tools.meson").install(package, configs)
         os.cp("include", package:installdir())
         os.cp("build_*/version.h", package:installdir() .. "/include/mpd")


### PR DESCRIPTION
This fixes an issue I encountered where the `version.h` header wasn't 
being installed due to it being generated at build time, and then
removes the `version.h.in` file that isn't needed.