### PR TITLE
Update xcb-proto to 1.14.1 (fixes installation with Python 3.9)

### DIFF
--- a/packages/x/xcb-proto/xmake.lua
+++ b/packages/x/xcb-proto/xmake.lua
@@ -3,9 +3,11 @@ package("xcb-proto")
     set_homepage("https://www.x.org/")
     set_description("X.Org: XML-XCB protocol descriptions for libxcb code generation")
 
-    set_urls("https://xcb.freedesktop.org/dist/xcb-proto-$(version).tar.gz")
+    set_urls("https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-$(version).tar.gz",
+             "https://xcb.freedesktop.org/dist/xcb-proto-$(version).tar.gz")
     add_versions("1.13", "0698e8f596e4c0dbad71d3dc754d95eb0edbb42df5464e0f782621216fa33ba7")
     add_versions("1.14", "1c3fa23d091fb5e4f1e9bf145a902161cec00d260fabf880a7a248b02ab27031")
+    add_versions("1.14.1", "85cd21e9d9fbc341d0dbf11eace98d55d7db89fda724b0e598855fcddf0944fd")
 
     if is_plat("macosx", "linux") then
         add_deps("pkg-config", "python 3.x", {kind = "binary"})


### PR DESCRIPTION
xcb-proto is broken with Python 3.9:
```
Failed to load the xcbgen Python package!
Make sure that xcb/proto installed it on your Python path.
If not, you will need to create a .pth file or define $PYTHONPATH
to extend the path.
Refer to the README file in xcb/proto for more info.
```

this has been fixed by 1.14.1
