### PR TITLE
add dav1d

### DIFF
--- a/packages/d/dav1d/xmake.lua
+++ b/packages/d/dav1d/xmake.lua
@@ -1,0 +1,25 @@
+package("dav1d")
+
+    set_homepage("https://www.videolan.org/projects/dav1d.html")
+    set_description("dav1d is a new AV1 cross-platform decoder, open-source, and focused on speed, size and correctness.")
+    set_license("BSD-2-Clause")
+
+    add_urls("https://downloads.videolan.org/pub/videolan/dav1d/$(version)/dav1d-$(version).tar.xz")
+    add_versions("0.9.0", "cfae88e8067c9b2e5b96d95a7a00155c353376fe9b992a96b4336e0eab19f9f6")
+
+    add_deps("nasm", "meson")
+    if is_plat("linux") then
+        add_syslinks("pthread", "dl")
+    end
+
+    on_install("windows", "macosx", "linux|x86_64", function (package)
+        local configs = {"--libdir=lib", "-Denable_tests=false"}
+        table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
+        import("package.tools.meson").install(package, configs)
+        package:addenv("PATH", "bin")
+    end)
+
+    on_test(function (package)
+        os.vrun("dav1d -v")
+        assert(package:has_cfuncs("dav1d_default_settings", {includes = "dav1d/dav1d.h"}))
+    end)

--- a/packages/m/meson/xmake.lua
+++ b/packages/m/meson/xmake.lua
@@ -6,6 +6,7 @@ package("meson")
 
     add_urls("https://github.com/mesonbuild/meson/releases/download/$(version)/meson-$(version).tar.gz",
              "https://github.com/mesonbuild/meson.git")
+    add_versions("0.58.0", "f4820df0bc969c99019fd4af8ca5f136ee94c63d8a5ad67e7eb73bdbc9182fdd")
     add_versions("0.56.0", "291dd38ff1cd55fcfca8fc985181dd39be0d3e5826e5f0013bf867be40117213")
     add_versions("0.50.1", "f68f56d60c80a77df8fc08fa1016bc5831605d4717b622c96212573271e14ecc")
 


### PR DESCRIPTION
给meson传一个--libdir=lib也是必要的，这大大减少安装位置的复杂性（ci默认设置ubuntu上是lib/x86_64-linux-gnu，fedora上是lib64，arch上是lib）不过之前的meson包没有加这个设置，所以暂时还不能放到package.tools.meson里面去