### PR TITLE
update re2, glog and improve opencv

### DIFF
--- a/packages/g/gflags/xmake.lua
+++ b/packages/g/gflags/xmake.lua
@@ -20,6 +20,7 @@ package("gflags")
         local configs = {"-DBUILD_TESTING=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        table.insert(configs, "-DBUILD_STATIC_LIBS=" .. (package:config("shared") and "OFF" or "ON"))
         if package:config("mt") then
             table.insert(configs, "-DBUILD_gflags_LIB=ON")
             table.insert(configs, "-DBUILD_gflags_nothreads_LIB=OFF")

--- a/packages/l/libtiff/xmake.lua
+++ b/packages/l/libtiff/xmake.lua
@@ -13,6 +13,7 @@ package("libtiff")
 
     on_install("windows", "mingw", "macosx", "linux", "bsd", function (package)
         local configs = {"-Dzstd=OFF", "-Dlzma=OFF", "-Dwebp=OFF", "-Djpeg=OFF", "-Djbig=OFF", "-Dpixarlog=OFF"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         if package:config("pic") ~= false then
             table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -10,25 +10,69 @@ package("opencv")
     add_versions("4.2.0", "9ccb2192d7e8c03c58fee07051364d94ed7599363f3b0dce1c5e6cc11c1bb0ec")
     add_versions("3.4.9", "b7ea364de7273cfb3b771a0d9c111b8b8dfb42ff2bcd2d84681902fb8f49892a")
 
-    add_deps("cmake", "python 3.x", {kind = "binary"})
-    add_deps("zlib")
+    add_resources("4.5.2", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/4.5.2.tar.gz", "9f52fd3114ac464cb4c9a2a6a485c729a223afb57b9c24848484e55cef0b5c2a")
+    add_resources("4.5.1", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/4.5.1.tar.gz", "12c3b1ddd0b8c1a7da5b743590a288df0934e5cef243e036ca290c2e45e425f5")
+    add_resources("4.2.0", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/4.2.0.tar.gz", "8a6b5661611d89baa59a26eb7ccf4abb3e55d73f99bb52d8f7c32265c8a43020")
+    add_resources("3.4.9", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/3.4.9.tar.gz", "dc7d95be6aaccd72490243efcec31e2c7d3f21125f88286186862cf9edb14a57")
+
+    add_configs("bundled", {description = "Build 3rd-party libraries with OpenCV.", default = true, type = "boolean"})
+
+    add_deps("cmake", "python 3.x")
+
+    local features = {"1394",
+                      "vtk",
+                      "eigen",
+                      "ffmpeg",
+                      "gstreamer",
+                      "gtk",
+                      "ipp",
+                      "halide",
+                      "vulkan",
+                      "jasper",
+                      "openjpeg",
+                      "jpeg",
+                      "webp",
+                      "openexr",
+                      "opengl",
+                      "png",
+                      "tbb",
+                      "tiff",
+                      "itt",
+                      "protobuf",
+                      "quirc"}
+    local default_features = {"1394", "eigen", "ffmpeg", "jpeg", "opengl", "png", "protobuf", "quirc", "webp", "tiff"}
+    local function opencv_is_default(feature)
+        for _, df in ipairs(default_features) do
+            if feature == df then
+                return true
+            end
+        end
+        return false
+    end
+
+    for _, feature in ipairs(features) do
+        add_configs(feature, {description = "Include " .. feature .. " support.", default = opencv_is_default(feature), type = "boolean"})
+    end
+    add_configs("blas", {description = "Set BLAS vendor.", default = nil, type = "string", values = {"mkl", "openblas"}})
+    add_configs("cuda", {description = "Enable CUDA support.", default = false, type = "boolean"})
 
     if is_plat("macosx") then
         add_frameworks("Foundation", "CoreFoundation", "CoreGraphics", "AppKit", "OpenCL")
     elseif is_plat("linux") then
         add_syslinks("pthread", "dl")
     elseif is_plat("windows") then
-        add_syslinks("gdi32", "user32", "advapi32", "comdlg32")
+        add_syslinks("gdi32", "user32", "glu32", "opengl32", "advapi32", "comdlg32")
     end
-
-    add_resources("4.5.2", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/4.5.2.tar.gz", "9f52fd3114ac464cb4c9a2a6a485c729a223afb57b9c24848484e55cef0b5c2a")
-    add_resources("4.5.1", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/4.5.1.tar.gz", "12c3b1ddd0b8c1a7da5b743590a288df0934e5cef243e036ca290c2e45e425f5")
-    add_resources("4.2.0", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/4.2.0.tar.gz", "8a6b5661611d89baa59a26eb7ccf4abb3e55d73f99bb52d8f7c32265c8a43020")
-    add_resources("3.4.9", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/3.4.9.tar.gz", "dc7d95be6aaccd72490243efcec31e2c7d3f21125f88286186862cf9edb14a57")
 
     on_load("linux", "macosx", function (package)
         if package:version():ge("4.0") then
             package:add("includedirs", "include/opencv4")
+        end
+        if package:config("blas") then
+            package:add("deps", package:config("blas"))
+        end
+        if package:config("cuda") then
+            package:add("deps", "cuda", {system = true, configs = {utils = {"cudnn", "cufft", "cublas"}}})
         end
     end)
 
@@ -42,44 +86,33 @@ package("opencv")
         elseif vs == "2019" then vc_ver = "vc16"
         end
         package:add("linkdirs", path.join(arch, vc_ver, linkdir))
-        package:addenv("PATH", path.join(arch, vc_ver, "bin"))
     end)
 
     on_install("linux", "macosx", "windows", function (package)
         io.replace("cmake/OpenCVUtils.cmake", "if(PKG_CONFIG_FOUND OR PkgConfig_FOUND)", "if(NOT WIN32 AND (PKG_CONFIG_FOUND OR PkgConfig_FOUND))", {plain = true})
         local configs = {"-DCMAKE_OSX_DEPLOYMENT_TARGET=",
-                         "-DBUILD_JASPER=OFF",
-                         "-DBUILD_JPEG=ON",
-                         "-DBUILD_OPENEXR=OFF",
                          "-DBUILD_PERF_TESTS=OFF",
-                         "-DBUILD_PNG=OFF",
                          "-DBUILD_TESTS=OFF",
-                         "-DBUILD_TIFF=OFF",
-                         "-DBUILD_ZLIB=OFF",
                          "-DBUILD_opencv_hdf=OFF",
                          "-DBUILD_opencv_java=OFF",
                          "-DBUILD_opencv_text=ON",
                          "-DOPENCV_ENABLE_NONFREE=ON",
                          "-DOPENCV_GENERATE_PKGCONFIG=ON",
-                         "-DWITH_1394=OFF",
-                         "-DWITH_CUDA=OFF",
-                         "-DWITH_EIGEN=ON",
-                         "-DWITH_FFMPEG=ON",
-                         "-DWITH_GPHOTO2=OFF",
-                         "-DWITH_GSTREAMER=OFF",
-                         "-DWITH_JASPER=OFF",
-                         "-DWITH_OPENEXR=ON",
-                         "-DWITH_OPENGL=OFF",
-                         "-DWITH_QT=OFF",
-                         "-DWITH_TBB=ON",
-                         "-DWITH_VTK=OFF",
-                         "-DWITH_ITT=OFF",
-                         "-DWITH_IPP=OFF",
-                         "-DWITH_LAPACK=OFF",
                          "-DBUILD_opencv_python2=OFF",
                          "-DBUILD_opencv_python3=ON"}
+        if package:config("bundled") then
+            table.insert(configs, "-DOPENCV_FORCE_3RDPARTY_BUILD=ON")
+        end
+        for _, feature in ipairs(features) do
+            table.insert(configs, "-DWITH_" .. feature:upper() .. "=" .. (package:config(feature) and "ON" or "OFF"))
+        end
+        if package:config("cuda") then
+            table.insert(configs, "-DWITH_CUDA=ON")
+        end
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        table.insert(configs, "-DBUILD_WITH_STATIC_CRT=" .. (package:config("vs_runtime"):startswith("MT") and "ON" or "OFF"))
+        if package:is_plat("windows") then
+            table.insert(configs, "-DBUILD_WITH_STATIC_CRT=" .. (package:config("vs_runtime"):startswith("MT") and "ON" or "OFF"))
+        end
         local resourcedir = package:resourcedir("opencv_contrib")
         if resourcedir then
             import("lib.detect.find_path")
@@ -107,15 +140,13 @@ package("opencv")
             for _, f in ipairs(os.files(path.join(instdir, linkdir, "*.lib"))) do
                 package:add("links", path.basename(f))
             end
+            package:addenv("PATH", path.join(arch, vc_ver, "bin"))
         else
             os.trycp("3rdparty/**/*.a", package:installdir("lib"))
         end
     end)
 
     on_test(function (package)
-        if package:is_plat("windows") then
-            os.vrun("opencv_version")
-        end
         assert(package:check_cxxsnippets({test = [[
             #include <iostream>
             void test(int argc, char** argv) {

--- a/packages/r/re2/xmake.lua
+++ b/packages/r/re2/xmake.lua
@@ -6,17 +6,17 @@ package("re2")
 
     add_urls("https://github.com/google/re2/archive/$(version).tar.gz", {version = function (version) return version:gsub("%.", "-") end})
     add_versions("2020.11.01", "8903cc66c9d34c72e2bc91722288ebc7e3ec37787ecfef44d204b2d6281954d7")
+    add_versions("2021.06.01", "26155e050b10b5969e986dab35654247a3b1b295e0532880b5a9c13c0a700ceb")
 
     if is_plat("windows") then
         add_deps("cmake")
-    end
-
-    if is_plat("linux") then
+    elseif is_plat("linux") then
         add_syslinks("pthread")
     end
 
     on_install("windows", function (package)
         local configs = {"-DRE2_BUILD_TESTING=OFF"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)
     end)

--- a/packages/v/vcglib/xmake.lua
+++ b/packages/v/vcglib/xmake.lua
@@ -4,7 +4,7 @@ package("vcglib")
     set_description("The Visualization and Computer Graphics Library (VCG for short) is a open source portable C++ templated library for manipulation, processing and displaying with OpenGL of triangle and tetrahedral meshes.")
     set_license("GPL-3.0")
 
-    add_urls("https://github.com/cnr-isti-vclab/vcglib/archive/refs/tags/2020.12.tar.gz")
+    add_urls("https://github.com/cnr-isti-vclab/vcglib/archive/refs/tags/$(version).tar.gz")
     add_versions("2020.12", "731c57435e39c4b958a1d766cadd9865d9db35e36410708f2da7818e9fa5f786")
 
     add_deps("eigen")


### PR DESCRIPTION
opencv里面的links目前是在on_install里面加的（相当于自动探测）

```
	-- scanning for links
    for _, f in ipairs(os.files(path.join(instdir, linkdir, "*.lib"))) do
        package:add("links", path.basename(f))
    end
```

但有时候`add_packages("opencv")`会漏掉一些链接（opencv内部的libpng、libtiff等），不知道是为什么