### PR TITLE
Add function_ref and add headeronly flag on some libs

### DIFF
--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -1,5 +1,6 @@
 package("catch2")
 
+    set_kind("library", {headeronly = true})
     set_homepage("https://github.com/catchorg/Catch2")
     set_description("Catch2 is a multi-paradigm test framework for C++. which also supports Objective-C (and maybe C). ")
 

--- a/packages/e/expected/xmake.lua
+++ b/packages/e/expected/xmake.lua
@@ -1,5 +1,6 @@
 package("expected")
 
+    set_kind("library", {headeronly = true})
     set_homepage("https://github.com/TartanLlama/expected")
     set_description("C++11/14/17 std::expected with functional-style extensions")
     set_license("CC0")

--- a/packages/f/function_ref/xmake.lua
+++ b/packages/f/function_ref/xmake.lua
@@ -1,0 +1,23 @@
+package("function_ref")
+
+    set_homepage("https://github.com/TartanLlama/function_ref")
+    set_description("A lightweight, non-owning reference to a callable.")
+    set_license("CC0")
+
+    set_urls("https://github.com/TartanLlama/function_ref/archive/$(version).zip",
+             "https://github.com/TartanLlama/function_ref.git")
+
+    add_versions("v1.0.0", "b3161fddbf40b41be984d5649ad6b5790ecebd0388f9db51b3160ecd006963f4")
+
+    on_install(function (package)
+        os.cp("include/tl", package:installdir("include"))
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            void test()
+            {
+                tl::function_ref<void(void)> fr1 = []{};
+            }
+        ]]}, {configs = {languages = "c++11"}, includes = { "tl/function_ref.hpp"} }))
+    end) 

--- a/packages/f/function_ref/xmake.lua
+++ b/packages/f/function_ref/xmake.lua
@@ -1,5 +1,6 @@
 package("function_ref")
 
+    set_kind("library", {headeronly = true})
     set_homepage("https://github.com/TartanLlama/function_ref")
     set_description("A lightweight, non-owning reference to a callable.")
     set_license("CC0")

--- a/packages/f/function_ref/xmake.lua
+++ b/packages/f/function_ref/xmake.lua
@@ -19,5 +19,5 @@ package("function_ref")
             {
                 tl::function_ref<void(void)> fr1 = []{};
             }
-        ]]}, {configs = {languages = "c++11"}, includes = { "tl/function_ref.hpp"} }))
+        ]]}, {configs = {languages = "c++14"}, includes = { "tl/function_ref.hpp"} }))
     end) 

--- a/packages/h/hopscotch-map/xmake.lua
+++ b/packages/h/hopscotch-map/xmake.lua
@@ -1,5 +1,6 @@
 package("hopscotch-map")
 
+    set_kind("library", {headeronly = true})
     set_homepage("https://github.com/Tessil/hopscotch-map")
     set_description("A C++ implementation of a fast hash map and hash set using hopscotch hashing")
 

--- a/packages/s/sol2/xmake.lua
+++ b/packages/s/sol2/xmake.lua
@@ -1,5 +1,6 @@
 package("sol2")
 
+    set_kind("library", {headeronly = true})
     set_homepage("https://github.com/ThePhD/sol2")
     set_description("A C++ library binding to Lua.")
 

--- a/packages/s/sol2/xmake.lua
+++ b/packages/s/sol2/xmake.lua
@@ -7,6 +7,7 @@ package("sol2")
     set_urls("https://github.com/ThePhD/sol2/archive/$(version).tar.gz",
              "https://github.com/ThePhD/sol2.git")
 
+    add_versions("v3.2.3", "f74158f92996f476786be9c9e83f8275129bb1da2a8d517d050421ac160a4b9e")
     add_versions("v3.2.2", "141790dae0c1821dd2dbac3595433de49ba72545845efc3ec7d88de8b0a3b2da")
     add_versions("v3.2.1", "b10f88dc1246f74a10348faef7d2c06e2784693307df74dcd87c4641cf6a6828")
 

--- a/packages/t/tl_expected/xmake.lua
+++ b/packages/t/tl_expected/xmake.lua
@@ -1,4 +1,4 @@
-package("expected")
+package("tl_expected")
 
     set_kind("library", {headeronly = true})
     set_homepage("https://github.com/TartanLlama/expected")
@@ -9,10 +9,6 @@ package("expected")
              "https://github.com/TartanLlama/expected.git")
 
     add_versions("v1.0.0", "c1733556cbd3b532a02b68e2fbc2091b5bc2cccc279e4f6c6bd83877aabd4b02")
-
-    on_load(function (package)
-        cprint("${yellow}the expected package has been renamed to tl_expected, please update its name!${clear}")
-    end)
 
     on_install(function (package)
         os.cp("include/tl", package:installdir("include"))

--- a/packages/t/tl_function_ref/xmake.lua
+++ b/packages/t/tl_function_ref/xmake.lua
@@ -1,4 +1,4 @@
-package("function_ref")
+package("tl_function_ref")
 
     set_kind("library", {headeronly = true})
     set_homepage("https://github.com/TartanLlama/function_ref")


### PR DESCRIPTION
Made by the same guy that made the `expected` package, maybe we should name them tl_expected and tl_function_ref as they're common names.
