### PR TITLE
update libtorch

### DIFF
--- a/.github/workflows/archlinux.yml
+++ b/.github/workflows/archlinux.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Installation
         run: |
           pacman -Sy --noconfirm --needed git base-devel perl make unzip
-          pacman -Sy --noconfirm --needed mesa
+          pacman -Sy --noconfirm --needed mesa gfortran
       - uses: actions/checkout@v1
       - uses: xmake-io/github-action-setup-xmake@v1
         with:

--- a/.github/workflows/archlinux.yml
+++ b/.github/workflows/archlinux.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Installation
         run: |
           pacman -Sy --noconfirm --needed git base-devel perl make unzip
-          pacman -Sy --noconfirm --needed mesa gfortran
+          pacman -Sy --noconfirm --needed mesa gcc-fortran
       - uses: actions/checkout@v1
       - uses: xmake-io/github-action-setup-xmake@v1
         with:

--- a/packages/l/libtorch/patches/1.9.0/gcc11.patch
+++ b/packages/l/libtorch/patches/1.9.0/gcc11.patch
@@ -1,0 +1,14 @@
+diff --git a/third_party/XNNPACK/src/xnnpack/intrinsics-polyfill.h b/third_party/XNNPACK/src/xnnpack/intrinsics-polyfill.h
+--- a/third_party/XNNPACK/src/xnnpack/intrinsics-polyfill.h
++++ b/third_party/XNNPACK/src/xnnpack/intrinsics-polyfill.h
+@@ -11,8 +11,8 @@
+ #if defined(__SSE2__)
+ #include <emmintrin.h>
+ 
+-// GCC any, Clang pre-8, Android NDK Clang pre-8.0.7, Apple Clang pre-11, and ICC pre-16
+-#if (defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)) || \
++// GCC pre-11, Clang pre-8, Android NDK Clang pre-8.0.7, Apple Clang pre-11, and ICC pre-16
++#if (defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && __GNUC__ < 11) || \
+     (defined(__clang__) && !defined(__apple_build_version__) && (__clang_major__ < 8)) || \
+     (defined(__clang__) && defined(__ANDROID__) && (__clang_major__ == 8) && (__clang_minor__ == 0) && (__clang_patchlevel__ < 7)) || \
+     (defined(__clang__) && defined(__apple_build_version__) && (__apple_build_version__ < 11000000)) || \

--- a/packages/l/libtorch/xmake.lua
+++ b/packages/l/libtorch/xmake.lua
@@ -7,35 +7,40 @@ package("libtorch")
     add_urls("https://github.com/pytorch/pytorch.git")
     add_versions("v1.8.0", "37c1f4a7fef115d719104e871d0cf39434aa9d56")
     add_versions("v1.8.1", "56b43f4fec1f76953f15a627694d4bba34588969")
+    add_versions("v1.9.0", "d69c22dd61a2f006dcfe1e3ea8468a3ecaf931aa")
+
+    add_patches("v1.9.0", path.join(os.scriptdir(), "patches", "1.9.0", "gcc11.patch"), "4191bb3296f18f040c230d7c5364fb160871962d6278e4ae0f8bc481f27d8e4b")
 
     add_configs("python", {description = "Build python interface.", default = false, type = "boolean"})
-    add_configs("ninja", {description = "Use ninja as build tool.", default = false, type = "boolean"})
+    add_configs("ninja", {description = "Use ninja as build tool.", default = true, type = "boolean"})
+    if not is_plat("macosx") then
+        add_configs("blas", {description = "Set BLAS vendor.", default = "openblas", type = "string", values = {"mkl", "openblas"}})
+    end
 
     add_deps("cmake")
     add_deps("python 3.x", {kind = "binary", system = false})
     add_deps("libuv")
     add_deps("cuda", {optional = true, configs = {utils = {"nvrtc", "cudnn", "cufft", "curand", "cublas", "cudart_static"}}})
-    add_deps("nvtx", "mkl", {optional = true, system = true})
+    add_deps("nvtx", {optional = true, system = true})
     add_includedirs("include")
     add_includedirs("include/torch/csrc/api/include")
+
+    if is_plat("linux") then
+        add_syslinks("rt")
+    end
 
     -- enable long paths for git submodule on windows
     if is_host("windows") and set_policy then
         set_policy("platform.longpaths", true)
     end
 
-    -- prevent the link to the libraries found automatically
-    add_links("")
-
     on_load("windows|x64", "macosx", "linux", function (package)
         if package:config("ninja") then
             package:add("deps", "ninja")
         end
 
-        if not package:is_plat("macosx") then
-            if not find_package("mkl") then
-                package:add("deps", "openblas")
-            end
+        if not package:is_plat("macosx") and package:config("blas") then
+            package:add("deps", package:config("blas"))
         end
     end)
 
@@ -68,38 +73,37 @@ package("libtorch")
                 package:add("links", lib)
             end
         end
+        package:add("links", "fbgemm")
+        package:add("links", "asmjit")
+        package:add("links", "cpuinfo")
+        package:add("links", "clog")
 
         -- some patches to the third-party cmake files
-        io.replace("cmake/Modules/FindMKL.cmake", "MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL \"Intel\"", "FALSE", {plain = true})
         io.replace("third_party/fbgemm/CMakeLists.txt", "PRIVATE FBGEMM_STATIC", "PUBLIC FBGEMM_STATIC", {plain = true})
         io.replace("third_party/protobuf/cmake/install.cmake", "install%(DIRECTORY.-%)", "")
-        io.replace("third_party/ideep/mkl-dnn/src/CMakeLists.txt", "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}", "${CMAKE_INSTALL_LIBDIR}", {plain = true})
         if package:is_plat("windows") and package:config("vs_runtime"):startswith("MD") then
             io.replace("third_party/fbgemm/CMakeLists.txt", "MT", "MD", {plain = true})
         end
 
         -- prepare python
         os.vrun("python -m pip install typing_extensions pyyaml")
-        local configs = {"-DUSE_MPI=OFF"}
+        local configs = {"-DUSE_MPI=OFF", "-DCMAKE_INSTALL_LIBDIR=lib"}
         if package:config("python") then
             table.insert(configs, "-DBUILD_PYTHON=ON")
             os.vrun("python -m pip install numpy")
         else
             table.insert(configs, "-DBUILD_PYTHON=OFF")
+            table.insert(configs, "-DUSE_NUMPY=OFF")
         end
 
         -- prepare for installation
-        local opt = {}
-        if package:config("ninja") then
-            opt.cmake_generator = "Ninja"
-        end
-        local envs = cmake.buildenvs(package, opt)
+        local envs = cmake.buildenvs(package, {cmake_generator = "Ninja"})
         if not package:is_plat("macosx") then
-            if package:dep("mkl"):exists() then
+            if package:config("blas") == "mkl" then
                 table.insert(configs, "-DBLAS=MKL")
                 local mkl = package:dep("mkl"):fetch()
                 table.insert(configs, "-DINTEL_MKL_DIR=" .. path.directory(mkl.sysincludedirs[1]))
-            else
+            elseif package:config("blas") == "openblas" then
                 table.insert(configs, "-DBLAS=OpenBLAS")
                 envs.OpenBLAS_HOME = package:dep("openblas"):installdir()
             end
@@ -110,7 +114,11 @@ package("libtorch")
         if package:is_plat("windows") then
             table.insert(configs, "-DCAFFE2_USE_MSVC_STATIC_RUNTIME=" .. (package:config("vs_runtime"):startswith("MT") and "ON" or "OFF"))
         end
-        opt.envs = envs
+
+        local opt = {envs = envs}
+        if package:config("ninja") then
+            opt.cmake_generator = "Ninja"
+        end
         cmake.install(package, configs, opt)
     end)
 


### PR DESCRIPTION
1. Windows上调用cmake时必须加载msvc的环境变量，否则cmake报错找不到openmp。现在只有generator是ninja时才加msvc环境变量，但这是不对的。这里作为workaround指定了buildenv的参数为generator=ninja

2. windows动态库如果不用ninja会ci报错内存不足（Out of memory error），这个可以切到ninja编译来解决