### PR TITLE
Add `gtest_main` and configs to `gtest`

### DIFF
--- a/packages/g/gtest/xmake.lua
+++ b/packages/g/gtest/xmake.lua
@@ -10,6 +10,9 @@ package("gtest")
     add_versions("github:1.10.0", "release-1.10.0")
     add_versions("archive:1.10.0", "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91")
 
+    add_configs("main",  {description = "Link to the gtest_main entry point.", default = false, type = "boolean"})
+    add_configs("gmock", {description = "Link to the googlemock library.", default = true, type = "boolean"})
+
     if is_plat("linux") then
         add_syslinks("pthread")
     end
@@ -23,9 +26,18 @@ package("gtest")
                 add_includedirs("googletest/include", "googletest")
                 add_headerfiles("googletest/include/(**.h)")
 
+            target("gtest_main")
+                set_kind("static")
+                set_languages("cxx11")
+                set_default(]] .. tostring(package:config("gtest_main")) .. [[)
+                add_files("googletest/src/gtest_main.cc")
+                add_includedirs("googletest/include", "googletest")
+                add_headerfiles("googletest/include/(**.h)")
+
             target("gmock")
                 set_kind("static")
                 set_languages("cxx11")
+                set_default(]] .. tostring(package:config("gmock")) .. [[)
                 add_files("googlemock/src/gmock-all.cc")
                 add_includedirs("googlemock/include", "googlemock", "googletest/include", "googletest")
                 add_headerfiles("googlemock/include/(**.h)")


### PR DESCRIPTION
Configuration options have been added to decide whether or not `gtest_main` should be linked against.
For consistency, a similar option was added for the `gmock` target.

Example usage with C++ 20:

```lua
-- use master for C++ 20 support (see https://github.com/google/googletest/issues/2914)
add_requires("gtest master", {configs = {main = true, gmock = true}})

target("my_test")
    set_languages("cxx20")
    set_kind("binary")

    add_files("my_test.cpp")
    add_packages("gtest")

    if is_plat("windows") then
        -- fixes "LINK : fatal error LNK1561: entry point must be defined"
        add_ldflags("/subsystem:console")
    end
```

Fixes #475.