### PR TITLE
update pcre, expat and sqlite3

### DIFF
--- a/packages/e/expat/xmake.lua
+++ b/packages/e/expat/xmake.lua
@@ -5,6 +5,7 @@ package("expat")
     set_license("MIT")
 
     set_urls("https://github.com/libexpat/libexpat/releases/download/R_$(version).tar.bz2", {version = function (version) return version:gsub("%.", "_") .. "/expat-" .. version end})
+    add_versions("2.4.1", "2f9b6a580b94577b150a7d5617ad4643a4301a6616ff459307df3e225bcfbf40")
     add_versions("2.3.0", "f122a20eada303f904d5e0513326c5b821248f2d4d2afbf5c6f1339e511c0586")
     add_versions("2.2.10", "b2c160f1b60e92da69de8e12333096aeb0c3bf692d41c60794de278af72135a5")
     add_versions("2.2.6", "17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2")

--- a/packages/p/pcre/xmake.lua
+++ b/packages/p/pcre/xmake.lua
@@ -5,6 +5,7 @@ package("pcre")
 
     set_urls("https://ftp.pcre.org/pub/pcre/pcre-$(version).zip",
              "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-$(version).zip")
+    add_versions("8.45", "5b709aa45ea3b8bb73052947200ad187f651a2049158fb5bbfed329e4322a977")
     add_versions("8.44", "3464cc5effda458e1c80882e53fc710195bf0d6d923c0866cafea43c7f321d25")
     add_versions("8.40", "99e19194fa57d37c38e897d07ecb3366b18e8c395b36c6d555706a7f1df0a5d4")
     add_versions("8.41", "0e914a3a5eb3387cad6ffac591c44b24bc384c4e828643643ebac991b57dfcc5")

--- a/packages/s/sqlite3/xmake.lua
+++ b/packages/s/sqlite3/xmake.lua
@@ -20,6 +20,7 @@ package("sqlite3")
     add_versions("3.34.0+100", "2a3bca581117b3b88e5361d0ef3803ba6d8da604b1c1a47d902ef785c1b53e89")
     add_versions("3.35.0+300", "ecbccdd440bdf32c0e1bb3611d635239e3b5af268248d130d0445a32daf0274b")
     add_versions("3.35.0+400", "7771525dff0185bfe9638ccce23faa0e1451757ddbda5a6c853bb80b923a512d")
+    add_versions("3.36.0+000", "bd90c3eb96bee996206b83be7065c9ce19aef38c3f4fb53073ada0d0b69bbce3")
 
     if is_plat("macosx", "linux", "bsd") then
         add_syslinks("pthread", "dl")


### PR DESCRIPTION
sqlite3测试的时候装的仍然是3.35.0+400而不是最新的3.36.0+000，有点奇怪