### PR TITLE
fix luajit gc64 option

### DIFF
--- a/packages/l/luajit/xmake.lua
+++ b/packages/l/luajit/xmake.lua
@@ -32,6 +32,7 @@ package("luajit")
         end
         configs.fpu     = package:config("fpu")
         configs.nojit   = package:config("nojit")
+        configs.gc64    = package:config("gc64")
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         import("package.tools.xmake").install(package, configs)
     end)


### PR DESCRIPTION
Forgot to forward the new `gc64` option added in #510 to `port/xmake.lua`.