### PR TITLE
Add docking branch version to imgui package

### DIFF
--- a/packages/i/imgui/xmake.lua
+++ b/packages/i/imgui/xmake.lua
@@ -6,6 +6,7 @@ package("imgui")
     add_urls("https://github.com/ocornut/imgui/archive/$(version).tar.gz",
              "https://github.com/ocornut/imgui.git")
 
+    add_versions("v1.83-docking", "80b5fb51edba2fd3dea76ec3e88153e2492243d1")
     add_versions("v1.83", "ccf3e54b8d1fa30dd35682fc4f50f5d2fe340b8e29e08de71287d0452d8cc3ff")
     add_versions("v1.82", "fefa2804bd55f3d25b134af08c0e1f86d4d059ac94cef3ee7bd21e2f194e5ce5")
     add_versions("v1.81", "f7c619e03a06c0f25e8f47262dbc32d61fd033d2c91796812bf0f8c94fca78fb")
@@ -27,6 +28,9 @@ package("imgui")
             package:add("deps", "glad")
             package:add("deps", "glfw")
             package:add("defines", "IMGUI_IMPL_OPENGL_LOADER_GLAD")
+        end
+        if string.find(package:version_str(), "-docking") ~= nil then
+            package:set("urls", {"https://github.com/ocornut/imgui.git"})
         end
     end)
 


### PR DESCRIPTION
This PR adds the latest stable docking branch version of imgui
to its xmake.lua package. It is up-to-date with the main one.
See: ocornut/imgui#4424

The extra code in the on_load function matches all the versions
containing '-docker' in their name and removes the precompiled
archive url, thus avoiding an obvious curl failure.
This allows to reduce CI build time by avoiding requesting
an HTTP 404 resource.