### PR TITLE
Chipmunk fixes

### DIFF
--- a/packages/c/chipmunk2d/patches/7.0.3/android.patch
+++ b/packages/c/chipmunk2d/patches/7.0.3/android.patch
@@ -16,10 +16,10 @@ index 9544da8..82d027e 100644
  
  /// @defgroup basicTypes Basic Types
 diff --git a/src/cpHastySpace.c b/src/cpHastySpace.c
-index 8dca425..8422c3e 100644
+index 8dca425..fa3074d 100644
 --- a/src/cpHastySpace.c
 +++ b/src/cpHastySpace.c
-@@ -7,8 +7,14 @@
+@@ -7,8 +7,16 @@
  //TODO: Move all the thread stuff to another file
  
  //#include <sys/param.h >
@@ -27,6 +27,8 @@ index 8dca425..8422c3e 100644
 +
 +#ifdef __APPLE__
  #include <sys/sysctl.h>
++#elif defined(ANDROID)
++#include <linux/sysctl.h>
 +#endif
 +
 +#ifndef _WIN32

--- a/packages/c/chipmunk2d/patches/7.0.3/android.patch
+++ b/packages/c/chipmunk2d/patches/7.0.3/android.patch
@@ -1,14 +1,12 @@
 diff --git a/include/chipmunk/chipmunk_types.h b/include/chipmunk/chipmunk_types.h
-index 9544da8..444f5c6 100644
+index 9544da8..82d027e 100644
 --- a/include/chipmunk/chipmunk_types.h
 +++ b/include/chipmunk/chipmunk_types.h
-@@ -53,8 +53,12 @@
- #endif
+@@ -54,7 +54,11 @@
  
  #ifndef CP_USE_DOUBLES
--	// Use doubles by default for higher precision.
+ 	// Use doubles by default for higher precision.
 -	#define CP_USE_DOUBLES 1
-+	// Use doubles by default for higher precision when possible.
 +	#if (!defined(__ARM_NEON__) || !__ARM_NEON__ || __arm64)
 +		#define CP_USE_DOUBLES 1
 +	#else
@@ -18,18 +16,22 @@ index 9544da8..444f5c6 100644
  
  /// @defgroup basicTypes Basic Types
 diff --git a/src/cpHastySpace.c b/src/cpHastySpace.c
-index 8dca425..3e3792c 100644
+index 8dca425..8422c3e 100644
 --- a/src/cpHastySpace.c
 +++ b/src/cpHastySpace.c
-@@ -8,7 +8,11 @@
+@@ -7,8 +7,14 @@
+ //TODO: Move all the thread stuff to another file
  
  //#include <sys/param.h >
- #ifndef _WIN32
-+#if defined(ANDROID)
-+#include <linux/sysctl.h>
-+#else
+-#ifndef _WIN32
++
++#ifdef __APPLE__
  #include <sys/sysctl.h>
 +#endif
++
++#ifndef _WIN32
++#include <pthread.h>
++#elif defined(__MINGW32__)
  #include <pthread.h>
  #else
  #ifndef WIN32_LEAN_AND_MEAN

--- a/packages/c/chipmunk2d/xmake.lua
+++ b/packages/c/chipmunk2d/xmake.lua
@@ -4,11 +4,11 @@ package("chipmunk2d")
     set_description("A fast and lightweight 2D game physics library.")
     set_license("MIT")
 
-    set_urls("https://github.com/slembcke/Chipmunk2D/archive/Chipmunk-$(version).tar.gz",
+    set_urls("https://github.com/slembcke/Chipmunk2D/archive/$(version).tar.gz",
              "https://github.com/slembcke/Chipmunk2D.git")
 
-    add_versions("7.0.3", "1e6f093812d6130e45bdf4cb80280cb3c93d1e1833d8cf989d554d7963b7899a")
-    add_patches("7.0.3", path.join(os.scriptdir(), "patches", "7.0.3", "android.patch"), "8efbd57350d0ae5febbbc03223417114d99018a31330c88d5f57e3ccbf9334fa")
+    add_versions("Chipmunk-7.0.3", "1e6f093812d6130e45bdf4cb80280cb3c93d1e1833d8cf989d554d7963b7899a")
+    add_patches("Chipmunk-7.0.3", path.join(os.scriptdir(), "patches", "7.0.3", "android.patch"), "b8169e0a283a1b38f9bfe9aedc28d31b152a3b864138d2b5ca13bce4bfc2599f")
 
     add_deps("cmake")
 

--- a/packages/c/chipmunk2d/xmake.lua
+++ b/packages/c/chipmunk2d/xmake.lua
@@ -11,6 +11,10 @@ package("chipmunk2d")
     add_versions("github:7.0.3", "87340c216bf97554dc552371bbdecf283f7c540e")
     add_patches("7.0.3", path.join(os.scriptdir(), "patches", "7.0.3", "android.patch"), "08e80020880e9bf3c61b48d41537d953e7bf6a63797eb8bcd6b78ba038b79d8f")
 
+    if is_host("linux") then
+        add_extsources("apt::libchipmunk-dev")
+    end
+
     add_deps("cmake")
 
     if is_plat("linux") then

--- a/packages/c/chipmunk2d/xmake.lua
+++ b/packages/c/chipmunk2d/xmake.lua
@@ -4,11 +4,12 @@ package("chipmunk2d")
     set_description("A fast and lightweight 2D game physics library.")
     set_license("MIT")
 
-    set_urls("https://github.com/slembcke/Chipmunk2D/archive/$(version).tar.gz",
-             "https://github.com/slembcke/Chipmunk2D.git")
+    add_urls("https://github.com/slembcke/Chipmunk2D/archive/Chipmunk-$(version).tar.gz", {alias = "archive"})
+    add_urls("https://github.com/slembcke/Chipmunk2D.git", {alias = "github"})
 
-    add_versions("Chipmunk-7.0.3", "1e6f093812d6130e45bdf4cb80280cb3c93d1e1833d8cf989d554d7963b7899a")
-    add_patches("Chipmunk-7.0.3", path.join(os.scriptdir(), "patches", "7.0.3", "android.patch"), "08e80020880e9bf3c61b48d41537d953e7bf6a63797eb8bcd6b78ba038b79d8f")
+    add_versions("archive:7.0.3", "1e6f093812d6130e45bdf4cb80280cb3c93d1e1833d8cf989d554d7963b7899a")
+    add_versions("github:7.0.3", "87340c216bf97554dc552371bbdecf283f7c540e")
+    add_patches("7.0.3", path.join(os.scriptdir(), "patches", "7.0.3", "android.patch"), "08e80020880e9bf3c61b48d41537d953e7bf6a63797eb8bcd6b78ba038b79d8f")
 
     add_deps("cmake")
 

--- a/packages/c/chipmunk2d/xmake.lua
+++ b/packages/c/chipmunk2d/xmake.lua
@@ -8,7 +8,7 @@ package("chipmunk2d")
              "https://github.com/slembcke/Chipmunk2D.git")
 
     add_versions("Chipmunk-7.0.3", "1e6f093812d6130e45bdf4cb80280cb3c93d1e1833d8cf989d554d7963b7899a")
-    add_patches("Chipmunk-7.0.3", path.join(os.scriptdir(), "patches", "7.0.3", "android.patch"), "b8169e0a283a1b38f9bfe9aedc28d31b152a3b864138d2b5ca13bce4bfc2599f")
+    add_patches("Chipmunk-7.0.3", path.join(os.scriptdir(), "patches", "7.0.3", "android.patch"), "08e80020880e9bf3c61b48d41537d953e7bf6a63797eb8bcd6b78ba038b79d8f")
 
     add_deps("cmake")
 


### PR DESCRIPTION
See https://github.com/DigitalPulseSoftware/NazaraEngine/issues/347

Compilation is failing on recent Linux distributions because `sys/sysctl.h` has been removed, this fixes it.

Also I noticed that the GitHub uses `Chipmunk-7.0.3` and not 7.0.3 as a tag, so git clone + checkout basically failed.