### PR TITLE
fix poppler on linux

### DIFF
--- a/packages/p/poppler/xmake.lua
+++ b/packages/p/poppler/xmake.lua
@@ -14,9 +14,10 @@ package("poppler")
 
     add_deps("cmake")
     add_deps("libtiff", "openjpeg", "lcms", "libjpeg", "libpng", "bzip2", "zlib")
-    add_deps("freetype", {configs = {woff2 = false, png = false, bzip2 = false}})
     if is_plat("linux") then
         add_deps("fontconfig", "expat")
+    else
+        add_deps("freetype", {configs = {woff2 = false, png = false, bzip2 = false}})
     end
 
     add_includedirs("include")


### PR DESCRIPTION
@xq114 这个包，我记得当初 ci 上冲突遇到了，后来好像解了来着，感觉还是冲突了，我先暂时改了下，如有问题，回头可以再想办法改进

> error: package(freetype/>=2.9:{}): conflict dependences with package(freetype/latest:{"bzip2=false","png=false","woff2=false"})!
