### PR TITLE
fix some os.tmpdir misusing

### DIFF
--- a/.github/workflows/archlinux.yml
+++ b/.github/workflows/archlinux.yml
@@ -18,10 +18,6 @@ jobs:
     steps:
       - name: Installation
         run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           pacman -Sy --noconfirm --needed git base-devel perl make unzip
           pacman -Sy --noconfirm --needed mesa gcc-fortran glu
       - uses: actions/checkout@v1

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -19,10 +19,6 @@ jobs:
       - name: Installation
         run: |
           uname -a
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           dnf -y install gfortran
           dnf -y install mesa-libGL-devel mesa-libGLU-devel
           dnf -y install @development-tools @rpm-development-tools

--- a/packages/a/abseil/xmake.lua
+++ b/packages/a/abseil/xmake.lua
@@ -15,7 +15,7 @@ package("abseil")
         local configs = {"-DCMAKE_CXX_STANDARD=17"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        import("package.tools.cmake").install(package, configs, {buildir = os.tmpdir()})
+        import("package.tools.cmake").install(package, configs, {buildir = os.tmpfile() .. ".dir"})
     end)
 
     on_test(function (package)

--- a/packages/i/itk/xmake.lua
+++ b/packages/i/itk/xmake.lua
@@ -4,8 +4,9 @@ package("itk")
     set_description("ITK is an open-source, cross-platform library that provides developers with an extensive suite of software tools for image analysis.")
     set_license("Apache-2.0")
 
-    add_urls("https://github.com/InsightSoftwareConsortium/ITK/archive/refs/tags/$(version).tar.gz")
-    add_versions("v5.2.0", "e53961cd78df8bcfaf8bd8b813ae2cafdde984c7650a2ddf7dcf808df463ea74")
+    add_urls("https://github.com/InsightSoftwareConsortium/ITK/releases/download/v$(version)/InsightToolkit-$(version).tar.gz")
+    add_versions("5.2.0", "12c9cf543cbdd929330322f0a704ba6925a13d36d01fc721a74d131c0b82796e")
+    add_versions("5.2.1", "192d41bcdd258273d88069094f98c61c38693553fd751b54f8cda308439555db")
 
     add_deps("cmake", "eigen")
     if is_plat("windows") then
@@ -27,14 +28,15 @@ package("itk")
                          "-DBUILD_TESTING=OFF",
                          "-DBUILD_EXAMPLES=OFF",
                          "-DITK_WRAPPING=OFF",
-                         "-DITK_USE_SYSTEM_EIGEN=ON"}
+                         "-DITK_USE_SYSTEM_EIGEN=ON",
+                         "-DCMAKE_CXX_STANDARD=14"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         if package:config("pic") ~= false then
             table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
         end
         if package:is_plat("windows") then
-            import("package.tools.cmake").install(package, configs, {buildir = os.tmpdir()})
+            import("package.tools.cmake").install(package, configs, {buildir = path.join(os.tmpdir(), "itk_build")})
         else
             import("package.tools.cmake").install(package, configs)
         end
@@ -46,5 +48,5 @@ package("itk")
                 using ImageType = itk::Image<unsigned short, 3>;
                 ImageType::Pointer image = ImageType::New();
             }
-        ]]}, {configs = {languages = "c++11"}, includes = "itkImage.h"}))
+        ]]}, {configs = {languages = "c++14"}, includes = "itkImage.h"}))
     end)

--- a/packages/m/magnum/xmake.lua
+++ b/packages/m/magnum/xmake.lua
@@ -84,7 +84,7 @@ package("magnum")
         for _, utility in ipairs(utilities) do
             table.insert(configs, "-DWITH_" .. utility:upper() .. "=" .. (package:config(utility) and "ON" or "OFF"))
         end
-        import("package.tools.cmake").install(package, configs, {buildir = os.tmpdir()})
+        import("package.tools.cmake").install(package, configs, {buildir = os.tmpfile() .. ".dir"})
     end)
 
     on_test(function (package)

--- a/packages/v/vtk/patches/9.0.3/limits.patch
+++ b/packages/v/vtk/patches/9.0.3/limits.patch
@@ -1,0 +1,44 @@
+diff --git a/Common/Core/vtkGenericDataArrayLookupHelper.h b/Common/Core/vtkGenericDataArrayLookupHelper.h
+--- a/Common/Core/vtkGenericDataArrayLookupHelper.h
++++ b/Common/Core/vtkGenericDataArrayLookupHelper.h
+@@ -25,6 +25,7 @@
+ #include "vtkIdList.h"
+ #include <algorithm>
+ #include <cmath>
++#include <limits>
+ #include <unordered_map>
+ #include <vector>
+ 
+diff --git a/Common/DataModel/vtkPiecewiseFunction.cxx b/Common/DataModel/vtkPiecewiseFunction.cxx
+--- a/Common/DataModel/vtkPiecewiseFunction.cxx
++++ b/Common/DataModel/vtkPiecewiseFunction.cxx
+@@ -22,6 +22,7 @@
+ #include <cassert>
+ #include <cmath>
+ #include <iterator>
++#include <limits>
+ #include <set>
+ #include <vector>
+ 
+diff --git a/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx b/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
+--- a/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
++++ b/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
+@@ -27,6 +27,7 @@
+ #include "vtkHyperTreeGridNonOrientedCursor.h"
+ 
+ #include <cmath>
++#include <limits>
+ 
+ vtkStandardNewMacro(vtkHyperTreeGridThreshold);
+ 
+diff --git a/Rendering/Core/vtkColorTransferFunction.cxx b/Rendering/Core/vtkColorTransferFunction.cxx
+--- a/Rendering/Core/vtkColorTransferFunction.cxx
++++ b/Rendering/Core/vtkColorTransferFunction.cxx
+@@ -21,6 +21,7 @@
+ #include <algorithm>
+ #include <cmath>
+ #include <iterator>
++#include <limits>
+ #include <set>
+ #include <vector>
+ 

--- a/packages/v/vtk/xmake.lua
+++ b/packages/v/vtk/xmake.lua
@@ -8,6 +8,9 @@ package("vtk")
         return table.concat(table.slice((version):split('%.'), 1, 2), '.') .. "/VTK-" .. version
     end})
     add_versions("9.0.1", "1b39a5e191c282861e7af4101eaa8585969a2de05f5646c9199a161213a622c7")
+    add_versions("9.0.3", "bc3eb9625b2b8dbfecb6052a2ab091fc91405de4333b0ec68f3323815154ed8a")
+
+    add_patches("9.0.3", path.join(os.scriptdir(), "patches", "9.0.3", "limits.patch"), "3bebcd1cac52462b0cf84c8232c3426202c75c944784252b215b4416cbe111db")
 
     add_deps("cmake")
     if is_plat("windows") then
@@ -25,7 +28,7 @@ package("vtk")
     end)
 
     on_install("windows", "linux", function (package)
-        local configs = {"-DVTK_BUILD_TESTING=OFF", "-DVTK_BUILD_EXAMPLES=OFF", "-DVTK_ENABLE_WRAPPING=OFF"}
+        local configs = {"-DVTK_BUILD_TESTING=OFF", "-DVTK_BUILD_EXAMPLES=OFF", "-DVTK_ENABLE_WRAPPING=OFF", "-DCMAKE_CXX_STANDARD=14"}
         table.insert(configs, "-DCMAKE_INSTALL_LIBDIR=lib")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
@@ -39,5 +42,5 @@ package("vtk")
                 vtkAlgorithm::SetDefaultExecutivePrototype(exec);
                 exec->Delete();
             }
-        ]]}, {configs = {languages = "c++11"}, includes = {"vtkAlgorithm.h", "vtkCompositeDataPipeline.h"}}))
+        ]]}, {configs = {languages = "c++14"}, includes = {"vtkAlgorithm.h", "vtkCompositeDataPipeline.h"}}))
     end)


### PR DESCRIPTION
os.tmpdir()返回的是“临时文件存放的目录”而不是“临时目录”，因此用在buildir里不合适（多个包安装会引发冲突），这里修改了一些误用