### PR TITLE
Add includedirs for libsdl_xx

### DIFF
--- a/packages/l/libsdl_gfx/xmake.lua
+++ b/packages/l/libsdl_gfx/xmake.lua
@@ -29,6 +29,8 @@ package("libsdl_gfx")
 
     add_links("SDL2_gfx")
 
+    add_includedirs("include", "include/SDL2")
+
     on_install("windows", function(package)
         local vs = import("core.tool.toolchain").load("msvc"):config("vs")
         if tonumber(vs) < 2019 then

--- a/packages/l/libsdl_image/xmake.lua
+++ b/packages/l/libsdl_image/xmake.lua
@@ -23,6 +23,8 @@ package("libsdl_image")
 
     add_links("SDL2_image")
 
+    add_includedirs("include", "include/SDL2")
+
     on_install("windows", "mingw", function (package)
         local arch = package:arch()
         if package:is_plat("mingw") then

--- a/packages/l/libsdl_mixer/xmake.lua
+++ b/packages/l/libsdl_mixer/xmake.lua
@@ -23,6 +23,8 @@ package("libsdl_mixer")
 
     add_links("SDL2_mixer")
 
+    add_includedirs("include", "include/SDL2")
+
     on_install("windows", "mingw", function (package)
         local arch = package:arch()
         if package:is_plat("mingw") then

--- a/packages/l/libsdl_net/xmake.lua
+++ b/packages/l/libsdl_net/xmake.lua
@@ -23,6 +23,8 @@ package("libsdl_net")
 
     add_links("SDL2_net")
 
+    add_includedirs("include", "include/SDL2")
+
     on_install("windows", "mingw", function (package)
         local arch = package:arch()
         if package:is_plat("mingw") then

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -26,6 +26,8 @@ package("libsdl_ttf")
 
     add_links("SDL2_ttf")
 
+    add_includedirs("include", "include/SDL2")
+
     on_install("windows", "mingw", function (package)
         local arch = package:arch()
         if package:is_plat("mingw") then


### PR DESCRIPTION
All libsdl_xx packages (and libsdl itself) can be included by omitting the SDL2 folder, like this:
```cpp
#include <SDL2_gfxPrimitives.h>
#include <SDL_image.h>
#include <SDL_mixer.h>
#include <SDL_net.h>
#include <SDL_ttf.h>
```

This is not possible with xmake packages, I fixed that by adding include dirs