### PR TITLE
add cacert and openh264

### DIFF
--- a/packages/c/ca-certificates/xmake.lua
+++ b/packages/c/ca-certificates/xmake.lua
@@ -1,0 +1,18 @@
+package("ca-certificates")
+
+    set_kind("library", {headeronly = true})
+    set_homepage("https://mkcert.org/")
+    set_description("Mozilla’s carefully curated collection of Root Certificates for validating the trustworthiness of SSL certificates while verifying the identity of TLS hosts.")
+
+    add_urls("https://github.com/xmake-mirror/xmake-cacert/archive/refs/tags/$(version).zip")
+    add_versions("20211118", "5d8b1f11d5c746d5af425063ba1f4acee4b18c681e7df2050f1b81cef079c227")
+
+    on_install(function (package)
+        os.cp("cacert.pem", package:installdir())
+        package:addenv("SSL_CERT_DIR", package:installdir())
+        package:addenv("SSL_CERT_FILE", path.join(package:installdir(), "cacert.pem"))
+    end)
+
+    on_test(function (package)
+        assert(os.isfile(path.join(package:installdir(), "cacert.pem")))
+    end)

--- a/packages/g/gn/xmake.lua
+++ b/packages/g/gn/xmake.lua
@@ -1,24 +1,26 @@
 package("gn")
 
+    set_kind("binary")
     set_homepage("https://gn.googlesource.com/gn")
     set_description("GN is a meta-build system that generates build files for Ninja.")
-    set_kind("binary")
 
     if is_host("windows") then
         if os.arch() == "x64" then
-            add_urls("https://github.com/xmake-mirror/gn-releases/raw/v$(version)/gn-windows-amd64.zip")
-            add_versions("20201128", "1cf7fbda62a585925391cc551053e0c6313a9c5aabc02c3c20c138c0ea6bc2bf")
+            add_urls("https://github.com/xmake-mirror/gn-releases/releases/download/v$(version)/gn-windows-amd64.zip")
+            add_versions("20211117", "517cdbfc1cbcc349d92781cd88ea34fb294b2a7f7b24c10678582eee587ee5b6")
         end
     elseif is_host("linux") then
-        add_urls("https://github.com/xmake-mirror/gn-releases/raw/v$(version)/gn-linux-amd64.zip")
-        add_versions("20201128", "756d6a88adcb157bd80eb4cea10df9e77fa1e7a328c67858b4c0cd0ab15c9f6e")
+        if os.arch() == "x86_64" then
+            add_urls("https://github.com/xmake-mirror/gn-releases/releases/download/v$(version)/gn-linux-amd64.zip")
+            add_versions("20211117", "6cc2da268a8402c0ac4f933fb06e8ac656a2450e5a4b645586b0b6a8b3e2944f")
+        end
     elseif is_host("macosx") then
         if os.arch() == "arm64" then
-            add_urls("https://github.com/xmake-mirror/gn-releases/raw/v$(version)/gn-mac-arm64.zip")
-            add_versions("20201128", "be0be7cc48ced8124f1da53fe3c571cefa6390ccd7f531144e3dffd4b51e1138")
+            add_urls("https://github.com/xmake-mirror/gn-releases/releases/download/v$(version)/gn-mac-arm64.zip")
+            add_versions("20211117", "5954adcaaf6ed69ab4c5270897ea389ce94d0584c709040257428f8604400211")
         else
-            add_urls("https://github.com/xmake-mirror/gn-releases/raw/v$(version)/gn-mac-amd64.zip")
-            add_versions("20201128", "34dc4171ec89cf7839c8ada4fec80860109b4af936688a3bfe9373c464667573")
+            add_urls("https://github.com/xmake-mirror/gn-releases/releases/download/v$(version)/gn-mac-amd64.zip")
+            add_versions("20211117", "025d9d60da03e080603a78c94a885d5c864c859248a877b2684d808aa5987c86")
         end
     end
 

--- a/packages/o/openh264/xmake.lua
+++ b/packages/o/openh264/xmake.lua
@@ -1,0 +1,31 @@
+package("openh264")
+
+    set_homepage("http://www.openh264.org/")
+    set_description("OpenH264 is a codec library which supports H.264 encoding and decoding.")
+    set_license("BSD-2-Clause")
+
+    add_urls("https://github.com/cisco/openh264/archive/refs/tags/$(version).tar.gz")
+    add_versions("v2.1.1", "af173e90fce65f80722fa894e1af0d6b07572292e76de7b65273df4c0a8be678")
+
+    add_deps("meson", "ninja", "nasm")
+    if is_plat("linux") then
+        add_syslinks("pthread", "rt")
+    end
+    on_install("windows", "linux", function (package)
+        import("package.tools.meson").build(package, {"-Dtests=disabled"}, {buildir = "out"})
+        import("package.tools.ninja").install(package, {}, {buildir = "out"})
+        if package:config("shared") then
+            os.tryrm(path.join(package:installdir("lib"), "libopenh264.a"))
+        else
+            os.tryrm(path.join(package:installdir("lib"), "libopenh264.so*"))
+            os.tryrm(path.join(package:installdir("lib"), "openh264.lib"))
+            os.tryrm(path.join(package:installdir("bin"), "openh264-*.dll"))
+        end
+        if package:is_plat("windows") then
+            os.trymv(path.join(package:installdir("lib"), "libopenh264.a"), path.join(package:installdir("lib"), "openh264.lib"))
+        end
+    end)
+
+    on_test(function (package)
+        assert(package:has_cxxfuncs("WelsGetCodecVersion", {includes = "wels/codec_api.h"}))
+    end)

--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -34,7 +34,7 @@ package("python")
     end
 
     if is_host("macosx", "linux") then
-        add_deps("openssl", {host = true})
+        add_deps("openssl", "ca-certificates", {host = true})
     end
 
     if is_host("linux") then

--- a/packages/p/python2/xmake.lua
+++ b/packages/p/python2/xmake.lua
@@ -29,7 +29,7 @@ package("python2")
     end
 
     if is_host("macosx", "linux") then
-        add_deps("openssl", {host = true})
+        add_deps("openssl", "ca-certificates", {host = true})
     end
 
     if is_host("linux") then


### PR DESCRIPTION
之前python经常遇到的ssl错误都是xmake安装的openssl缺少cert文件导致的，只要加上cert文件就可以了