### PR TITLE
improve openmp

### DIFF
--- a/packages/o/openmp/xmake.lua
+++ b/packages/o/openmp/xmake.lua
@@ -25,8 +25,6 @@ package("openmp")
                 elseif package:has_tool(toolkind, "icl") then
                     package:add(flagname, "-Qopenmp")
                 end
-            end
-            if package:is_plat("macosx", "linux") then
                 if package:config("runtime") == "default" then
                     if package:has_tool(toolkind, "cl") then
                         package:add("ldflags", "/openmp")
@@ -44,8 +42,6 @@ package("openmp")
                         package:add("ldflags", "-Qopenmp")
                     end
                 end
-            end
-            if package:is_plat("windows") then
                 if package:config("runtime") == "custom" then
                     if package:has_tool(toolkind, "cl") then
                         package:add("ldflags", "/openmp")


### PR DESCRIPTION
这里仍有一些问题：

1. 有的老编译器不支持openmp，这时应该报错找不到openmp，on_fetch不应该直接返回true
2. 只有apple clang才需要额外链接libomp，llvm clang即使在macos上也不需要链接libomp。应该区分这两种编译器，cmake中可以用`if(AppleClang) ...`来区分，xmake中也应该有类似的机制