### PR TITLE
Add mingw support to vulkan-hpp

### DIFF
--- a/packages/v/vulkan-hpp/xmake.lua
+++ b/packages/v/vulkan-hpp/xmake.lua
@@ -12,16 +12,18 @@ package("vulkan-hpp")
     add_deps("cmake")
 
     on_install("windows", "linux", "macosx", "mingw", function (package)
-        local is_mingw = package:is_plat("mingw")
-        if is_mingw then
-            package:requireinfo().plat = os.host()
+        local plat, arch
+        if package:is_plat("mingw") and package.plat_set then
+            plat = package:plat_set(os.host())
+            arch = package:arch_set(os.arch())
         end
         import("package.tools.cmake").build(package, {buildir = "build"})
-        if is_mingw then
-            package:requireinfo().plat = "mingw"
+        if plat and arch then
+            package:plat_set(plat)
+            package:arch_set(arch)
         end
         os.mkdir("build")
-        if os.is_host("windows") then
+        if is_host("windows") then
             os.cp(path.join("**", "VulkanHppGenerator.exe"), "build")
         else
             os.cp(path.join("**", "VulkanHppGenerator"), "build")

--- a/packages/v/vulkan-hpp/xmake.lua
+++ b/packages/v/vulkan-hpp/xmake.lua
@@ -12,15 +12,16 @@ package("vulkan-hpp")
     add_deps("cmake")
 
     on_install("windows", "linux", "macosx", "mingw", function (package)
-        local plat, arch
+        local arch_prev
         if package:is_plat("mingw") and package.plat_set then
-            plat = package:plat_set(os.host())
-            arch = package:arch_set(os.arch())
+            arch_prev = package:arch()
+            package:plat_set(os.host())
+            package:arch_set(os.arch())
         end
         import("package.tools.cmake").build(package, {buildir = "build"})
-        if plat and arch then
-            package:plat_set(plat)
-            package:arch_set(arch)
+        if arch_prev then
+            package:plat_set("mingw")
+            package:arch_set(arch_prev)
         end
         os.mkdir("build")
         if is_host("windows") then

--- a/packages/v/vulkan-hpp/xmake.lua
+++ b/packages/v/vulkan-hpp/xmake.lua
@@ -11,10 +11,17 @@ package("vulkan-hpp")
 
     add_deps("cmake")
 
-    on_install("windows", "linux", "macosx", function (package)
+    on_install("windows", "linux", "macosx", "mingw", function (package)
+        local is_mingw = package:is_plat("mingw")
+        if is_mingw then
+            package:requireinfo().plat = os.host()
+        end
         import("package.tools.cmake").build(package, {buildir = "build"})
+        if is_mingw then
+            package:requireinfo().plat = "mingw"
+        end
         os.mkdir("build")
-        if package:is_plat("windows") then
+        if os.is_host("windows") then
             os.cp(path.join("**", "VulkanHppGenerator.exe"), "build")
         else
             os.cp(path.join("**", "VulkanHppGenerator"), "build")


### PR DESCRIPTION
To build vulkan-hpp the VulkanHppGenerator needs to build for the host system. With this change xmake will temporarily switch the platform to the host to use cmake and then switch back.