### PR TITLE
Assimp: add advapi32 syslink

### DIFF
--- a/packages/a/assimp/xmake.lua
+++ b/packages/a/assimp/xmake.lua
@@ -30,6 +30,10 @@ package("assimp")
 
     add_deps("cmake", "irrxml", "zlib")
 
+    if is_plat("windows") then
+        add_syslinks("advapi32")
+    end
+
     on_load(function (package)
         if is_plat("linux") and package:config("shared") then
             package:add("ldflags", "-Wl,--as-needed," .. package:installdir("lib", "libassimp.so"))


### PR DESCRIPTION
It looks like Assimp requires advapi32: https://github.com/DigitalPulseSoftware/NazaraEngine/runs/4652831084?check_suite_focus=true#step:9:707 on Windows
https://github.com/assimp/assimp/blob/6693e7e08c7f12c9d569ab6baef44ec176734fae/code/CMakeLists.txt#L1256

Not sure why CI didn't fail