### PR TITLE
gflags: disable register cmake user package registry.

### DIFF
--- a/packages/g/gflags/xmake.lua
+++ b/packages/g/gflags/xmake.lua
@@ -17,7 +17,11 @@ package("gflags")
         add_syslinks("pthread")
     end
     on_install("windows", "linux", "macosx", function (package)
-        local configs = {"-DBUILD_TESTING=OFF"}
+        local configs = {
+            "-DBUILD_TESTING=OFF",
+            "-DGFLAGS_REGISTER_BUILD_DIR=OFF",
+            "-DGFLAGS_REGISTER_INSTALL_PREFIX=OFF",
+        }
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DBUILD_STATIC_LIBS=" .. (package:config("shared") and "OFF" or "ON"))


### PR DESCRIPTION
`gflags` by default adds registry file under `$HOME/.cmake` during install, which should be avoided when using Xrepo.

I've several questions related to `gflags` and `glog` pacakge, which I'd like to contribute further PRs but need guidance.

1. Is there any specific reason to use `mt=false` as default? I personally prefer to enable multi-thread by default for `gflags`, and this is also the default in vcpkg's `gflags` portfile.
2. Can I make `gflags` and `glog` packages to support "cross" platform? I wish for this because I want to specify different compilers when using xrepo-cmake. I can do this in my private repo, but would like to contribute if there's no problems for this.