### PR TITLE
add hiredis

### DIFF
--- a/packages/h/hiredis/patches/v1.0.2/cmake.patch
+++ b/packages/h/hiredis/patches/v1.0.2/cmake.patch
@@ -1,0 +1,192 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f86c9b7..b545e21 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,10 +1,9 @@
+ CMAKE_MINIMUM_REQUIRED(VERSION 3.4.0)
+-INCLUDE(GNUInstallDirs)
+-PROJECT(hiredis)
+ 
+ OPTION(ENABLE_SSL "Build hiredis_ssl for SSL support" OFF)
+ OPTION(DISABLE_TESTS "If tests should be compiled or not" OFF)
+-OPTION(ENABLE_SSL_TESTS, "Should we test SSL connections" OFF)
++OPTION(ENABLE_SSL_TESTS "Should we test SSL connections" OFF)
++OPTION(ENABLE_ASYNC_TESTS "Should we run all asynchronous API tests" OFF)
+ 
+ MACRO(getVersionBit name)
+   SET(VERSION_REGEX "^#define ${name} (.+)$")
+@@ -20,7 +19,13 @@ getVersionBit(HIREDIS_SONAME)
+ SET(VERSION "${HIREDIS_MAJOR}.${HIREDIS_MINOR}.${HIREDIS_PATCH}")
+ MESSAGE("Detected version: ${VERSION}")
+ 
+-PROJECT(hiredis VERSION "${VERSION}")
++PROJECT(hiredis LANGUAGES "C" VERSION "${VERSION}")
++INCLUDE(GNUInstallDirs)
++
++# Hiredis requires C99
++SET(CMAKE_C_STANDARD 99)
++SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
++SET(CMAKE_DEBUG_POSTFIX d)
+ 
+ SET(ENABLE_EXAMPLES OFF CACHE BOOL "Enable building hiredis examples")
+ 
+@@ -41,30 +46,80 @@ IF(WIN32)
+ ENDIF()
+ 
+ ADD_LIBRARY(hiredis SHARED ${hiredis_sources})
++ADD_LIBRARY(hiredis_static STATIC ${hiredis_sources})
++ADD_LIBRARY(hiredis::hiredis ALIAS hiredis)
++ADD_LIBRARY(hiredis::hiredis_static ALIAS hiredis_static)
+ 
+ SET_TARGET_PROPERTIES(hiredis
+     PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE
+     VERSION "${HIREDIS_SONAME}")
++SET_TARGET_PROPERTIES(hiredis_static
++    PROPERTIES COMPILE_PDB_NAME hiredis_static)
++SET_TARGET_PROPERTIES(hiredis_static
++    PROPERTIES COMPILE_PDB_NAME_DEBUG hiredis_static${CMAKE_DEBUG_POSTFIX})
+ IF(WIN32 OR MINGW)
+-    TARGET_LINK_LIBRARIES(hiredis PRIVATE ws2_32)
++    TARGET_LINK_LIBRARIES(hiredis PUBLIC ws2_32 crypt32)
++    TARGET_LINK_LIBRARIES(hiredis_static PUBLIC ws2_32 crypt32)
++ELSEIF(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
++    TARGET_LINK_LIBRARIES(hiredis PUBLIC m)
++    TARGET_LINK_LIBRARIES(hiredis_static PUBLIC m)
++ELSEIF(CMAKE_SYSTEM_NAME MATCHES "SunOS")
++    TARGET_LINK_LIBRARIES(hiredis PUBLIC socket)
++    TARGET_LINK_LIBRARIES(hiredis_static PUBLIC socket)
+ ENDIF()
+ 
+-TARGET_INCLUDE_DIRECTORIES(hiredis PUBLIC $<INSTALL_INTERFACE:.> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
++TARGET_INCLUDE_DIRECTORIES(hiredis PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
++TARGET_INCLUDE_DIRECTORIES(hiredis_static PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+ 
+ CONFIGURE_FILE(hiredis.pc.in hiredis.pc @ONLY)
+ 
+-INSTALL(TARGETS hiredis
++set(CPACK_PACKAGE_VENDOR "Redis")
++set(CPACK_PACKAGE_DESCRIPTION "\
++Hiredis is a minimalistic C client library for the Redis database.
++
++It is minimalistic because it just adds minimal support for the protocol, \
++but at the same time it uses a high level printf-alike API in order to make \
++it much higher level than otherwise suggested by its minimal code base and the \
++lack of explicit bindings for every Redis command.
++
++Apart from supporting sending commands and receiving replies, it comes with a \
++reply parser that is decoupled from the I/O layer. It is a stream parser designed \
++for easy reusability, which can for instance be used in higher level language bindings \
++for efficient reply parsing.
++
++Hiredis only supports the binary-safe Redis protocol, so you can use it with any Redis \
++version >= 1.2.0.
++
++The library comes with multiple APIs. There is the synchronous API, the asynchronous API \
++and the reply parsing API.")
++set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/redis/hiredis")
++set(CPACK_PACKAGE_CONTACT "michael dot grunder at gmail dot com")
++set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
++set(CPACK_RPM_PACKAGE_AUTOREQPROV ON)
++
++include(CPack)
++
++INSTALL(TARGETS hiredis hiredis_static
+     EXPORT hiredis-targets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
++if (MSVC)
++    INSTALL(FILES $<TARGET_PDB_FILE:hiredis>
++        DESTINATION ${CMAKE_INSTALL_BINDIR}
++        CONFIGURATIONS Debug RelWithDebInfo)
++    INSTALL(FILES $<TARGET_FILE_DIR:hiredis_static>/$<TARGET_FILE_BASE_NAME:hiredis_static>.pdb
++        DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        CONFIGURATIONS Debug RelWithDebInfo)
++endif()
++
+ INSTALL(FILES hiredis.h read.h sds.h async.h alloc.h
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hiredis)
+-    
++
+ INSTALL(DIRECTORY adapters
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hiredis)
+-    
++
+ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/hiredis.pc
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ 
+@@ -95,10 +150,12 @@ IF(ENABLE_SSL)
+         ENDIF()
+     ENDIF()
+     FIND_PACKAGE(OpenSSL REQUIRED)
+-    SET(hiredis_ssl_sources 
++    SET(hiredis_ssl_sources
+         ssl.c)
+     ADD_LIBRARY(hiredis_ssl SHARED
+             ${hiredis_ssl_sources})
++    ADD_LIBRARY(hiredis_ssl_static STATIC
++            ${hiredis_ssl_sources})
+ 
+     IF (APPLE)
+         SET_PROPERTY(TARGET hiredis_ssl PROPERTY LINK_FLAGS "-Wl,-undefined -Wl,dynamic_lookup")
+@@ -108,23 +165,39 @@ IF(ENABLE_SSL)
+         PROPERTIES
+         WINDOWS_EXPORT_ALL_SYMBOLS TRUE
+         VERSION "${HIREDIS_SONAME}")
++    SET_TARGET_PROPERTIES(hiredis_ssl_static
++        PROPERTIES COMPILE_PDB_NAME hiredis_ssl_static)
++    SET_TARGET_PROPERTIES(hiredis_ssl_static
++        PROPERTIES COMPILE_PDB_NAME_DEBUG hiredis_ssl_static${CMAKE_DEBUG_POSTFIX})
+ 
+     TARGET_INCLUDE_DIRECTORIES(hiredis_ssl PRIVATE "${OPENSSL_INCLUDE_DIR}")
++    TARGET_INCLUDE_DIRECTORIES(hiredis_ssl_static PRIVATE "${OPENSSL_INCLUDE_DIR}")
++
+     TARGET_LINK_LIBRARIES(hiredis_ssl PRIVATE ${OPENSSL_LIBRARIES})
+     IF (WIN32 OR MINGW)
+         TARGET_LINK_LIBRARIES(hiredis_ssl PRIVATE hiredis)
++        TARGET_LINK_LIBRARIES(hiredis_ssl_static PUBLIC hiredis_static)
+     ENDIF()
+     CONFIGURE_FILE(hiredis_ssl.pc.in hiredis_ssl.pc @ONLY)
+ 
+-    INSTALL(TARGETS hiredis_ssl
++    INSTALL(TARGETS hiredis_ssl hiredis_ssl_static
+         EXPORT hiredis_ssl-targets
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
++    if (MSVC)
++        INSTALL(FILES $<TARGET_PDB_FILE:hiredis_ssl>
++            DESTINATION ${CMAKE_INSTALL_BINDIR}
++            CONFIGURATIONS Debug RelWithDebInfo)
++        INSTALL(FILES $<TARGET_FILE_DIR:hiredis_ssl_static>/$<TARGET_FILE_BASE_NAME:hiredis_ssl_static>.pdb
++            DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            CONFIGURATIONS Debug RelWithDebInfo)
++    endif()
++
+     INSTALL(FILES hiredis_ssl.h
+         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hiredis)
+-    
++
+     INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/hiredis_ssl.pc
+         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ 
+@@ -149,11 +222,14 @@ ENDIF()
+ IF(NOT DISABLE_TESTS)
+     ENABLE_TESTING()
+     ADD_EXECUTABLE(hiredis-test test.c)
++    TARGET_LINK_LIBRARIES(hiredis-test hiredis)
+     IF(ENABLE_SSL_TESTS)
+         ADD_DEFINITIONS(-DHIREDIS_TEST_SSL=1)
+-        TARGET_LINK_LIBRARIES(hiredis-test hiredis hiredis_ssl)
+-    ELSE()
+-        TARGET_LINK_LIBRARIES(hiredis-test hiredis)
++        TARGET_LINK_LIBRARIES(hiredis-test hiredis_ssl)
++    ENDIF()
++    IF(ENABLE_ASYNC_TESTS)
++        ADD_DEFINITIONS(-DHIREDIS_TEST_ASYNC=1)
++        TARGET_LINK_LIBRARIES(hiredis-test event)
+     ENDIF()
+     ADD_TEST(NAME hiredis-test
+         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test.sh)

--- a/packages/h/hiredis/xmake.lua
+++ b/packages/h/hiredis/xmake.lua
@@ -1,0 +1,35 @@
+package("hiredis")
+
+    set_homepage("https://github.com/redis/hiredis")
+    set_description("Minimalistic C client for Redis >= 1.2")
+    set_license("BSD-3-Clause")
+
+    add_urls("https://github.com/redis/hiredis/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/redis/hiredis.git")
+    add_versions('v1.0.2', 'e0ab696e2f07deb4252dda45b703d09854e53b9703c7d52182ce5a22616c3819')
+
+    add_configs("openssl", {description = "with openssl library", default = false, type = "boolean"})
+
+    add_deps("cmake")
+
+    on_load(function (package)
+        if package:config("openssl") then
+            package:add("deps", "openssl")
+        end
+    end)
+
+    on_install(function (package)
+        local configs = {
+            "-DDISABLE_TESTS=ON",
+            "-DENABLE_SSL_TESTS=OFF",
+            "-DENABLE_ASYNC_TESTS=OFF",
+        }
+
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DENABLE_SSL=" .. (package:config("openssl") and "ON" or "OFF"))
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("redisCommand", {includes = "hiredis/hiredis.h"}))
+    end)

--- a/packages/h/hiredis/xmake.lua
+++ b/packages/h/hiredis/xmake.lua
@@ -7,6 +7,9 @@ package("hiredis")
     add_urls("https://github.com/redis/hiredis/archive/refs/tags/$(version).tar.gz",
              "https://github.com/redis/hiredis.git")
     add_versions('v1.0.2', 'e0ab696e2f07deb4252dda45b703d09854e53b9703c7d52182ce5a22616c3819')
+    -- This patch is created with hiredis commit f8de9a4. Removed NuGet related install code.
+    -- We need latest CMakeLists.txt to get static library support. It also contains other fixes.
+    add_patches("v1.0.2", path.join(os.scriptdir(), "patches", "v1.0.2", "cmake.patch"), "d75d3034cc5d487440d7bc24a3a2229a433351639848562e2416461ede4f428f")
 
     add_configs("openssl", {description = "with openssl library", default = false, type = "boolean"})
 
@@ -28,6 +31,16 @@ package("hiredis")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DENABLE_SSL=" .. (package:config("openssl") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)
+
+        -- hiredis cmake builds static and shared library at the same time.
+        -- Remove unneeded one after install.
+        if package:config("shared") then 
+            os.tryrm(path.join(package:installdir("lib"), "*.a")) 
+        else 
+            os.tryrm(path.join(package:installdir("lib"), "*.so")) 
+            os.tryrm(path.join(package:installdir("lib"), "*.so.*")) 
+            os.tryrm(path.join(package:installdir("lib"), "*.dylib")) 
+        end 
     end)
 
     on_test(function (package)


### PR DESCRIPTION
The hiredis `CMakeLists.txt` does not provide option to build static or shared library. They are always built together.

The `Makefile` provides `dynamic`, `static` target, but seems to work only on Unix-like systems.

So I choose to use cmake in this PR.