### PR TITLE
hiredis: install cmake module to lib/cmake/hiredis.

### DIFF
--- a/packages/h/hiredis/patches/v1.0.2/cmake.patch
+++ b/packages/h/hiredis/patches/v1.0.2/cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f86c9b7..b545e21 100644
+index f86c9b7..55ae30b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,10 +1,9 @@
@@ -116,6 +116,15 @@ index f86c9b7..b545e21 100644
  INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/hiredis.pc
      DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
  
+@@ -72,7 +127,7 @@ export(EXPORT hiredis-targets
+     FILE "${CMAKE_CURRENT_BINARY_DIR}/hiredis-targets.cmake"
+     NAMESPACE hiredis::)
+ 
+-SET(CMAKE_CONF_INSTALL_DIR share/hiredis)
++SET(CMAKE_CONF_INSTALL_DIR lib/cmake/hiredis)
+ SET(INCLUDE_INSTALL_DIR include)
+ include(CMakePackageConfigHelpers)
+ configure_package_config_file(hiredis-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/hiredis-config.cmake
 @@ -95,10 +150,12 @@ IF(ENABLE_SSL)
          ENDIF()
      ENDIF()

--- a/packages/h/hiredis/xmake.lua
+++ b/packages/h/hiredis/xmake.lua
@@ -9,7 +9,7 @@ package("hiredis")
     add_versions('v1.0.2', 'e0ab696e2f07deb4252dda45b703d09854e53b9703c7d52182ce5a22616c3819')
     -- This patch is created with hiredis commit f8de9a4. Removed NuGet related install code.
     -- We need latest CMakeLists.txt to get static library support. It also contains other fixes.
-    add_patches("v1.0.2", path.join(os.scriptdir(), "patches", "v1.0.2", "cmake.patch"), "d75d3034cc5d487440d7bc24a3a2229a433351639848562e2416461ede4f428f")
+    add_patches("v1.0.2", path.join(os.scriptdir(), "patches", "v1.0.2", "cmake.patch"), "a2115f727821e4a121e4e2145ef3e5caa0669559f24f2213125119520ee4d881")
 
     add_configs("openssl", {description = "with openssl library", default = false, type = "boolean"})
 


### PR DESCRIPTION
By installing cmake module to common `lib/cmake/hiredis` dir, xrepo-cmake can use this package easier.

My debug branch workflow [fails[(https://github.com/cyfdecyf/xmake-repo/runs/5194239126?check_suite_focus=true) for Arch linux build. Guess this is not caused by my change.