### PR TITLE
librdkafka: add more platforms.

### DIFF
--- a/packages/l/librdkafka/xmake.lua
+++ b/packages/l/librdkafka/xmake.lua
@@ -10,7 +10,7 @@ package("librdkafka")
 
     add_links("rdkafka++", "rdkafka")
 
-    on_install("linux", "macosx", "windows", function (package)
+    on_install("linux", "macosx", "windows", "mingw", "android", function (package)
         local configs = {"-DRDKAFKA_BUILD_EXAMPLES=OFF", "-DRDKAFKA_BUILD_TESTS=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))


### PR DESCRIPTION
librdkaka 在 cross 编译时遇到了奇怪的[编译错误](https://github.com/cyfdecyf/xmake-repo/runs/5354139942?check_suite_focus=true)，所以没有打开 cross。

因为 android 编译能成功，看了下 librdkafka 打包相关代码中有 arch arm64，应该支持 arm，不确定我遇到的错误是否跟 toolchain 设置有关。