### PR TITLE
pcre2: support all platforms.

### DIFF
--- a/packages/p/pcre2/xmake.lua
+++ b/packages/p/pcre2/xmake.lua
@@ -7,14 +7,15 @@ package("pcre2")
 
     add_versions("10.39", "0781bd2536ef5279b1943471fdcdbd9961a2845e1d2c9ad849b9bd98ba1a9bd4")
 
-    if is_host("windows") then
-        add_deps("cmake")
-    end
+    add_deps("cmake")
 
-    add_configs("jit", {description = "Enable jit.", default = true, type = "boolean"})
     add_configs("bitwidth", {description = "Set the code unit width.", default = "8", values = {"8", "16", "32"}})
 
     on_load(function (package)
+        if not package:is_plat("iphoneos") then
+            package:add("configs", "jit", {description = "Enable jit.", default = true, type = "boolean"})
+        end
+
         local bitwidth = package:config("bitwidth") or "8"
         if package:version():ge("10.39") and package:is_plat("windows") and not package:config("shared") then
             package:add("links", "pcre2-" .. bitwidth .. "-static")
@@ -27,7 +28,7 @@ package("pcre2")
         end
     end)
 
-    on_install("windows", function (package)
+    on_install(function (package)
         if package:version():lt("10.21") then
             io.replace("CMakeLists.txt", [[SET(CMAKE_C_FLAGS -I${PROJECT_SOURCE_DIR}/src)]], [[SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${PROJECT_SOURCE_DIR}/src")]], {plain = true})
         end
@@ -46,27 +47,6 @@ package("pcre2")
             table.insert(configs, "-DPCRE2_STATIC_RUNTIME=" .. (package:config("vs_runtime"):startswith("MT") and "ON" or "OFF"))
         end
         import("package.tools.cmake").install(package, configs)
-    end)
-
-    on_install("macosx", "linux", "mingw", function (package)
-        local configs = {}
-        table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
-        table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
-        if package:debug() then
-            table.insert(configs, "--enable-debug")
-        end
-        if package:config("pic") ~= false then
-            table.insert(configs, "--with-pic")
-        end
-        if package:config("jit") then
-            table.insert(configs, "--enable-jit")
-        end
-        local bitwidth = package:config("bitwidth") or "8"
-        if bitwidth ~= "8" then
-            table.insert(configs, "--disable-pcre2-8")
-            table.insert(configs, "--enable-pcre2-" .. bitwidth)
-        end
-        import("package.tools.autoconf").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/p/pcre2/xmake.lua
+++ b/packages/p/pcre2/xmake.lua
@@ -9,11 +9,12 @@ package("pcre2")
 
     add_deps("cmake")
 
+    add_configs("jit", {description = "Enable jit.", default = true, type = "boolean"})
     add_configs("bitwidth", {description = "Set the code unit width.", default = "8", values = {"8", "16", "32"}})
 
     on_load(function (package)
-        if not package:is_plat("iphoneos") then
-            package:add("configs", "jit", {description = "Enable jit.", default = true, type = "boolean"})
+        if package:is_plat("iphoneos") then
+            package:config_set("jit", false)
         end
 
         local bitwidth = package:config("bitwidth") or "8"


### PR DESCRIPTION
我自己的 fork 中发现 iphoneos action 打开 jit 编译失败。搜到了苹果自己使用的 [pcre2 changelog](https://opensource.apple.com/source/pcre/pcre-12/pcre/ChangeLog.auto.html)，里面提到 `JIT is now supported on jailbroken iOS devices`，之后再没有关于 iOS JIT compilation 的消息，所以先 disable 掉。

另外移除了 autoconf 编译的代码，统一用 cmake。