### PR TITLE
Remove pic related config for cmake.

### DIFF
--- a/packages/d/drogon/xmake.lua
+++ b/packages/d/drogon/xmake.lua
@@ -81,9 +81,6 @@ package("drogon")
             end
         end
 
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/f/freeglut/xmake.lua
+++ b/packages/f/freeglut/xmake.lua
@@ -50,9 +50,6 @@ package("freeglut")
                 table.insert(configs, "-DCMAKE_C_FLAGS=-DFREEGLUT_LIB_PRAGMAS=0 -DFREEGLUT_STATIC=1")
             end
         end
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         if package:is_plat("linux") then
             import("package.tools.cmake").install(package, configs, {packagedeps = {"libxi", "libxxf86vm", "libxrandr", "libxrender"}})
         else

--- a/packages/g/geos/xmake.lua
+++ b/packages/g/geos/xmake.lua
@@ -12,9 +12,6 @@ package("geos")
         local configs = {"-DBUILD_BENCHMARKS=OFF", "-DBUILD_TESTING=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/g/gflags/xmake.lua
+++ b/packages/g/gflags/xmake.lua
@@ -38,9 +38,6 @@ package("gflags")
             table.insert(configs, "-DBUILD_gflags_LIB=OFF")
             table.insert(configs, "-DBUILD_gflags_nothreads_LIB=ON")
         end
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/g/glog/xmake.lua
+++ b/packages/g/glog/xmake.lua
@@ -33,9 +33,6 @@ package("glog")
         for config, dep in pairs(configdeps) do
             table.insert(configs, "-DWITH_" .. config:upper() .. "=" .. (package:config(config) and "ON" or "OFF"))
         end
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/i/itk/xmake.lua
+++ b/packages/i/itk/xmake.lua
@@ -32,9 +32,6 @@ package("itk")
                          "-DCMAKE_CXX_STANDARD=14"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         if package:is_plat("windows") then
             import("package.tools.cmake").install(package, configs, {buildir = path.join(os.tmpdir(), "itk_build")})
         else

--- a/packages/j/jasper/xmake.lua
+++ b/packages/j/jasper/xmake.lua
@@ -31,9 +31,6 @@ package("jasper")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DJAS_ENABLE_SHARED=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DJAS_ENABLE_OPENGL=" .. (package:config("opengl") and "ON" or "OFF"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
 
         -- warning: only works on windows sdk 10.0.18362.0 and later
         import("package.tools.cmake").install(package, configs)

--- a/packages/j/jsoncpp/xmake.lua
+++ b/packages/j/jsoncpp/xmake.lua
@@ -20,9 +20,6 @@ package("jsoncpp")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DBUILD_STATIC_LIBS=" .. (package:config("shared") and "OFF" or "ON"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/l/libfive/xmake.lua
+++ b/packages/l/libfive/xmake.lua
@@ -21,9 +21,6 @@ package("libfive")
         local configs = {"-DBUILD_GUILE_BINDINGS=OFF", "-DBUILD_PYTHON_BINDINGS=OFF", "-DBUILD_STUDIO_APP=OFF", "-DBUILD_TESTS=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
         os.trycp("libfive/include", package:installdir("include"))
     end)

--- a/packages/l/libfreenect2/xmake.lua
+++ b/packages/l/libfreenect2/xmake.lua
@@ -48,9 +48,6 @@ package("libfreenect2")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
 
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
 
         local libjpegturbo = package:dep("libjpeg-turbo"):fetch()
         if libjpegturbo then

--- a/packages/l/libjpeg-turbo/xmake.lua
+++ b/packages/l/libjpeg-turbo/xmake.lua
@@ -44,9 +44,6 @@ package("libjpeg-turbo")
         if package:is_plat("windows") and package:config("vs_runtime"):startswith("MD") then
             table.insert(configs, "-DWITH_CRT_DLL=ON")
         end
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/l/libtiff/xmake.lua
+++ b/packages/l/libtiff/xmake.lua
@@ -16,9 +16,6 @@ package("libtiff")
         local configs = {"-Dzstd=OFF", "-Dlzma=OFF", "-Dwebp=OFF", "-Djpeg=OFF", "-Djbig=OFF", "-Dpixarlog=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         io.replace("CMakeLists.txt", "add_subdirectory(contrib)", "", {plain = true})
         io.replace("CMakeLists.txt", "add_subdirectory(man)", "", {plain = true})
         io.replace("CMakeLists.txt", "add_subdirectory(html)", "", {plain = true})

--- a/packages/m/mariadb-connector-c/xmake.lua
+++ b/packages/m/mariadb-connector-c/xmake.lua
@@ -57,9 +57,6 @@ package("mariadb-connector-c")
                 end
             end
         end
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end	
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/o/osqp/xmake.lua
+++ b/packages/o/osqp/xmake.lua
@@ -12,9 +12,6 @@ package("osqp")
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/p/partio/xmake.lua
+++ b/packages/p/partio/xmake.lua
@@ -14,9 +14,6 @@ package("partio")
         io.gsub("CMakeLists.txt", "find%_package%(GLUT REQUIRED%)", "")
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/p/poppler/xmake.lua
+++ b/packages/p/poppler/xmake.lua
@@ -33,9 +33,6 @@ package("poppler")
         for _, libname in ipairs(libnames) do
             table.insert(configs, "-DENABLE_" .. libname:upper() .. "=" .. (package:config(libname) and "ON" or "OFF"))
         end
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/q/qhull/xmake.lua
+++ b/packages/q/qhull/xmake.lua
@@ -13,9 +13,6 @@ package("qhull")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DBUILD_STATIC_LIBS=" .. (package:config("shared") and "OFF" or "ON"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/s/snappy/xmake.lua
+++ b/packages/s/snappy/xmake.lua
@@ -23,9 +23,6 @@ package("snappy")
         table.insert(configs, "-DSNAPPY_REQUIRE_AVX=" .. (package:config("avx") and "ON" or "OFF"))
         table.insert(configs, "-DSNAPPY_REQUIRE_AVX2=" .. (package:config("avx2") and "ON" or "OFF"))
         table.insert(configs, "-DSNAPPY_HAVE_BMI2=" .. (package:config("bmi2") and "ON" or "OFF"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/s/srt/xmake.lua
+++ b/packages/s/srt/xmake.lua
@@ -18,9 +18,6 @@ package("srt")
         local configs = {"-DENABLE_APPS=OFF", "-DENABLE_TESTING=OFF", "-DENABLE_UNITTESTS=OFF"}
         table.insert(configs, "-DENABLE_SHARED=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DENABLE_STATIC=" .. (package:config("shared") and "OFF" or "ON"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         io.replace("CMakeLists.txt", "install(PROGRAMS scripts/srt-ffplay DESTINATION ${CMAKE_INSTALL_BINDIR})", "", {plain = true})
         table.insert(configs, "-DCMAKE_INSTALL_INCLUDEDIR=" .. package:installdir("include"))
         import("package.tools.cmake").install(package, configs)

--- a/packages/t/tesseract/xmake.lua
+++ b/packages/t/tesseract/xmake.lua
@@ -33,9 +33,6 @@ package("tesseract")
             table.insert(configs, "-DWIN32_MT_BUILD=" .. (package:config("vs_runtime"):startswith("MT") and "ON" or "OFF"))
         end
         table.insert(configs, "-DBUILD_TRAINING_TOOLS=" .. (package:config("training") and "ON" or "OFF"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
         package:addenv("PATH", "bin")
     end)

--- a/packages/t/trantor/xmake.lua
+++ b/packages/t/trantor/xmake.lua
@@ -21,9 +21,6 @@ package("trantor")
     on_install("windows", "macosx", "linux", "mingw@windows", function (package)
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/u/uriparser/xmake.lua
+++ b/packages/u/uriparser/xmake.lua
@@ -21,9 +21,6 @@ package("uriparser")
         if package:is_plat("windows") then
             table.insert(configs, "-DURIPARSER_MSVC_RUNTIME=/" .. package:config("vs_runtime"))
         end
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/x/xerces-c/xmake.lua
+++ b/packages/x/xerces-c/xmake.lua
@@ -17,9 +17,6 @@ package("xerces-c")
         local configs = {"-Dnetwork=OFF", "-DCMAKE_DISABLE_FIND_PACKAGE_ICU=ON", "-DCMAKE_DISABLE_FIND_PACKAGE_CURL=ON"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/z/zziplib/xmake.lua
+++ b/packages/z/zziplib/xmake.lua
@@ -17,9 +17,6 @@ package("zziplib")
         if package:is_plat("windows") then
             table.insert(configs, "-DMSVC_STATIC_RUNTIME=" .. (package:config("vs_runtime"):startswith("MT") and "ON" or "OFF"))
         end
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-        end
         import("package.tools.cmake").install(package, configs)
     end)
 


### PR DESCRIPTION
PIC mode settings is handled in xmake's cmake tool.

Is it possible to make setting build type handled by xmake by default, so we can remove lot's of following code:

```lua
table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
```