### PR TITLE
flex: add more platforms.

### DIFF
--- a/packages/f/flex/xmake.lua
+++ b/packages/f/flex/xmake.lua
@@ -16,7 +16,7 @@ package("flex")
         add_deps("m4")
     end
 
-    on_load("macosx", "linux", function (package)
+    on_load("macosx", "linux", "bsd", "android", "iphoneos", "cross", function (package)
         package:addenv("PATH", "bin")
     end)
 
@@ -24,7 +24,7 @@ package("flex")
         -- handled by winflexbison
     end)
 
-    on_install("macosx", "linux", function (package)
+    on_install("macosx", "linux", "bsd", "android", "iphoneos", "cross", function (package)
         import("package.tools.autoconf").install(package)
     end)
 


### PR DESCRIPTION
只有 MinGW 不支持。编译时 configure 脚本会寻找 `sys/wait.h`，但 mingw 没有这个头文件。