### PR TITLE
zstd: version 1.5.2

### DIFF
--- a/packages/z/zstd/xmake.lua
+++ b/packages/z/zstd/xmake.lua
@@ -22,13 +22,13 @@ package("zstd")
                 if is_kind("shared") and is_plat("windows") then
                     add_defines("ZSTD_DLL_EXPORT")
                 end
-				on_config(function (target)
-					if target:is_arch("x64", "x86_64") and target:has_tool("cc", "clang", "gcc") then
-						target:add("files", "lib/decompress/*.S")
-					else
-						target:add("defines", "ZSTD_DISABLE_ASM")
-					end
-				end)
+                on_config(function (target)
+                    if target:is_arch("x64", "x86_64") and target:has_tool("cc", "clang", "gcc") then
+                        target:add("files", "lib/decompress/*.S")
+                    else
+                        target:add("defines", "ZSTD_DISABLE_ASM")
+                    end
+                end)
         ]])
 
         import("package.tools.xmake").install(package)


### PR DESCRIPTION
1.5.2 中的汇编代码编译方式参考了 zstd 源码中 [`meson.bulid`](https://github.com/facebook/zstd/blob/v1.5.2/build/meson/lib/meson.build#L48-L55) 的做法。

对 xmake 的用法不熟悉，如果有更好的写法请反馈。