### PR TITLE
civetweb: add syslink when enabling openssl and zlib.

### DIFF
--- a/packages/c/civetweb/xmake.lua
+++ b/packages/c/civetweb/xmake.lua
@@ -21,14 +21,13 @@ package("civetweb")
     end
 
     on_load(function (package)
-        local configdeps = {
-            openssl = "openssl",
-            zlib    = "zlib",
-        }
-        for name, dep in pairs(configdeps) do
-            if package:config(name) then
-                package:add("deps", dep)
-            end
+        if package:config("openssl") then
+            package:add("deps", "openssl")
+            package:add("syslinks", "ssl", "crypto")
+        end
+        if package:config("zlib") then
+            package:add("deps", "zlib")
+            package:add("syslinks", "z")
         end
     end)
 


### PR DESCRIPTION
CI 环境中发现开启 openssh, zlib 必须添加相关库的 syslink 才能让 `on_test` 成功通过。