### PR TITLE
brotli: add version for pkgconfig file.

### DIFF
--- a/packages/b/brotli/port/xmake.lua
+++ b/packages/b/brotli/port/xmake.lua
@@ -1,5 +1,14 @@
 add_rules("mode.debug", "mode.release")
 
+option("vers")
+    set_default("")
+    set_showmenu(true)
+option_end()
+
+if has_config("vers") then
+    set_version(get_config("vers"))
+end
+
 target("brotlienc")
     set_kind("$(kind)")
     add_deps("brotlicommon")

--- a/packages/b/brotli/xmake.lua
+++ b/packages/b/brotli/xmake.lua
@@ -50,7 +50,7 @@ package("brotli")
 
     on_install(function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
-        local configs = {buildir = "xbuild"}
+        local configs = {buildir = "xbuild", vers = package:version_str()}
         if package:config("shared") then
             configs.kind = "shared"
         end


### PR DESCRIPTION
pkgconfig 文件缺少 version 信息导致不可使用，libcurl 依然无法安装 #1074 #1079 