### PR TITLE
librdkafka: remove unnecessary syslinks.

### DIFF
--- a/packages/l/librdkafka/xmake.lua
+++ b/packages/l/librdkafka/xmake.lua
@@ -36,11 +36,6 @@ package("librdkafka")
         for name, dep in pairs(configdeps) do
             if package:config(name) then
                 package:add("deps", dep)
-                if name == "sasl" then
-                    package:add("syslinks", "sasl2")
-                else
-                    package:add("syslinks", dep)
-                end
             end
         end
     end)


### PR DESCRIPTION
最初写的时候对每个依赖包添加了 syslinks。按 #1071 的建议，这个是不应该添加的，而且添加后会导致启用 ssl 时 `on_test` 失败。

第二个 commit 是因为用 `rg 'add_configs.*ssl'` 看了下，整个 xmake-repo 中 openssl config 名字用 `ssl` 的只有 libwebsockets, cpp-httplib, mariadb-connector-c 这三个。librdkafka 当时写的时候应该是从哪个拷贝过来的。

如果不希望做此修改，我 force push 去掉这个修改。