### PR TITLE
nlohmann_json: use c++11 for on_test.

### DIFF
--- a/packages/n/nlohmann_json/xmake.lua
+++ b/packages/n/nlohmann_json/xmake.lua
@@ -38,5 +38,5 @@ package("nlohmann_json")
                 json data;
                 data["name"] = "world";
             }
-        ]]}, {configs = {languages = "c++14"}, includes = {"nlohmann/json.hpp"}}))
+        ]]}, {configs = {languages = "c++11"}, includes = {"nlohmann/json.hpp"}}))
     end)


### PR DESCRIPTION
nlohmann_json is written in vanilla C++11. It compile with gcc-4.8 which don't support `-std=c++14` option.