### PR TITLE
improve cuda logging

### DIFF
--- a/packages/c/cuda/xmake.lua
+++ b/packages/c/cuda/xmake.lua
@@ -26,6 +26,7 @@ package("cuda")
         
                 for _, util in ipairs(utils) do
                     if not find_library(util, cuda.linkdirs) then
+                        wprint(format("The library %s for %s is not found!", util, package:arch()))
                         return
                     end
                     table.insert(result.links, util)


### PR DESCRIPTION
在带on_fetch的package里面应该多加一些log，这样在fetch失败的时候更容易解决问题。反面例子见 https://github.com/xmake-io/xmake/issues/2257