### PR TITLE
fix freeglut

### DIFF
--- a/packages/f/freeglut/xmake.lua
+++ b/packages/f/freeglut/xmake.lua
@@ -4,11 +4,10 @@ package("freeglut")
     set_description("A free-software/open-source alternative to the OpenGL Utility Toolkit (GLUT) library.")
     set_license("MIT")
 
-    set_urls("https://github.com/dcnieho/FreeGLUT/archive/FG_$(version).zip",
-            {version = function (version) return (version:gsub("%.", "_")) end})
-    add_versions("3.0.0", "050e09f17630249a7d2787c21691e4b7d7b86957a06b3f3f34fa887b561d8e04")
-    add_versions("3.2.1", "501324c27a3ee809ac4a6374f63c5049c1c0d342d93fdb5db12b8c1c84760fa4")
-    add_versions("3.2.2", "2c913b7f698e2183d753c94440f5a0fe3785a1c564e6b73e073c2f6a1b077bf8")
+    set_urls("https://github.com/FreeGLUTProject/freeglut/releases/download/v$(version)/freeglut-$(version).tar.gz")
+    add_versions("3.0.0", "2a43be8515b01ea82bcfa17d29ae0d40bd128342f0930cd1f375f1ff999f76a2")
+    add_versions("3.2.1", "d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68")
+    add_versions("3.2.2", "c5944a082df0bba96b5756dddb1f75d0cd72ce27b5395c6c1dde85c2ff297a50")
 
     add_patches("3.2.1", path.join(os.scriptdir(), "patches", "3.2.1", "gcc10.patch"), "26cf5026249c9e288080a75a1e9b40b3fa74a4048321cc93907f1476c5a6508b")
 


### PR DESCRIPTION
freeglut上游更改了所有release的tag，原来的url已经404了， 此处修复