### PR TITLE
update(packages/a/arrow): remove configs for thrift dep

### DIFF
--- a/packages/a/arrow/xmake.lua
+++ b/packages/a/arrow/xmake.lua
@@ -76,7 +76,7 @@ package("arrow")
             package:add("deps", "zstd")
         end
         if package:config("parquet") then
-            package:add("deps", "thrift", configs)
+            package:add("deps", "thrift")
         end
     end)
 


### PR DESCRIPTION
It is not clear to me where the `config` parameter comes from.