### PR TITLE
Assimp: Fix compilation with GCC 12 and update to v5.2.4

### DIFF
--- a/packages/a/assimp/patches/5.2.4/fix_x86_windows_build.patch
+++ b/packages/a/assimp/patches/5.2.4/fix_x86_windows_build.patch
@@ -1,0 +1,22 @@
+diff --git a/code/Common/DefaultIOStream.cpp b/code/Common/DefaultIOStream.cpp
+index e30f26acd3..17fc44f9a2 100644
+--- a/code/Common/DefaultIOStream.cpp
++++ b/code/Common/DefaultIOStream.cpp
+@@ -63,7 +63,7 @@ inline int select_fseek(FILE *file, int64_t offset, int origin) {
+ 
+ 
+ 
+-#if defined _WIN64 && (!defined __GNUC__ || __MSVCRT_VERSION__ >= 0x0601)
++#if defined _WIN32 && (!defined __GNUC__ || __MSVCRT_VERSION__ >= 0x0601)
+ template <>
+ inline size_t select_ftell<8>(FILE *file) {
+     return (size_t)::_ftelli64(file);
+@@ -149,7 +149,7 @@ size_t DefaultIOStream::FileSize() const {
+         //
+         // See here for details:
+         // https://www.securecoding.cert.org/confluence/display/seccode/FIO19-C.+Do+not+use+fseek()+and+ftell()+to+compute+the+size+of+a+regular+file
+-#if defined _WIN64 && (!defined __GNUC__ || __MSVCRT_VERSION__ >= 0x0601)
++#if defined _WIN32 && (!defined __GNUC__ || __MSVCRT_VERSION__ >= 0x0601)
+         struct __stat64 fileStat;
+         //using fileno + fstat avoids having to handle the filename
+         int err = _fstat64(_fileno(mFile), &fileStat);

--- a/packages/a/assimp/xmake.lua
+++ b/packages/a/assimp/xmake.lua
@@ -61,7 +61,8 @@ package("assimp")
                          "-DASSIMP_INSTALL_PDB=ON",
                          "-DASSIMP_INJECT_DEBUG_POSTFIX=ON",
                          "-DASSIMP_BUILD_ZLIB=ON",
-                         "-DSYSTEM_IRRXML=ON"}
+                         "-DSYSTEM_IRRXML=ON",
+                         "-DASSIMP_WARNINGS_AS_ERRORS=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
 
         local function add_config_arg(config_name, cmake_name)
@@ -82,16 +83,12 @@ package("assimp")
             table.insert(configs, "-DASSIMP_BUILD_ASSIMP_TOOLS=OFF")
         end
 
-        local cxflags
-        if package:is_plat("linux", "macosx", "mingw") and package:version():le("v5.2.4") then
-            cxflags = {"-Wno-array-compare", "-Wno-array-bounds"}
-        end
         if package:is_plat("mingw") and package:version():lt("v5.1.5") then
             -- CMAKE_COMPILER_IS_MINGW has been removed: https://github.com/assimp/assimp/pull/4311
             io.replace("CMakeLists.txt", "CMAKE_COMPILER_IS_MINGW", "MINGW", {plain = true})
         end
 
-        import("package.tools.cmake").install(package, configs, {cxflags=cxflags})
+        import("package.tools.cmake").install(package, configs)
 
         -- copy pdb
         if package:is_plat("windows") then

--- a/packages/a/assimp/xmake.lua
+++ b/packages/a/assimp/xmake.lua
@@ -6,6 +6,7 @@ package("assimp")
 
     set_urls("https://github.com/assimp/assimp/archive/$(version).zip",
              "https://github.com/assimp/assimp.git")
+    add_versions("v5.2.4", "713e9aa035ae019e5f3f0de1605de308d63538897249a2ba3a2d7d40036ad2b1")
     add_versions("v5.2.3", "9667cfc8ddabd5dd5e83f3aebb99dbf232fce99f17b9fe59540dccbb5e347393")
     add_versions("v5.2.2", "7b833182b89917b3c6e8aee6432b74870fb71f432cc34aec5f5411bd6b56c1b5")
     add_versions("v5.2.1", "636fe5c2cfe925b559b5d89e53a42412a2d2ab49a0712b7d655d1b84c51ed504")
@@ -96,7 +97,7 @@ package("assimp")
             io.replace("CMakeLists.txt", "CMAKE_COMPILER_IS_MINGW", "MINGW", {plain = true})
         end
 
-        import("package.tools.cmake").install(package, configs, {cxflags=cxflags})
+        import("package.tools.cmake").install(package, configs)
 
         -- copy pdb
         if package:is_plat("windows") then

--- a/packages/a/assimp/xmake.lua
+++ b/packages/a/assimp/xmake.lua
@@ -19,6 +19,7 @@ package("assimp")
     add_patches("v5.2.2", path.join(os.scriptdir(), "patches", "5.2.1", "fix_zlib_filefunc_def.patch"), "a9f8a9aa1975888ea751b80c8268296dee901288011eeb1addf518eac40b71b1")
     add_patches("v5.2.3", path.join(os.scriptdir(), "patches", "5.2.1", "fix_zlib_filefunc_def.patch"), "a9f8a9aa1975888ea751b80c8268296dee901288011eeb1addf518eac40b71b1")
     add_patches("v5.2.3", path.join(os.scriptdir(), "patches", "5.2.3", "cmake_static_crt.patch"), "3872a69976055bed9e40814e89a24a3420692885b50e9f9438036e8d809aafb4")
+    add_patches("v5.2.4", path.join(os.scriptdir(), "patches", "5.2.4", "fix_x86_windows_build.patch"), "9a37b6ddb6f8e78d9271644393d32ace1faabc29969ef92f0eaa6ada3e147898")
 
     if not is_host("windows") then
         add_extsources("pkgconfig::assimp")

--- a/packages/a/assimp/xmake.lua
+++ b/packages/a/assimp/xmake.lua
@@ -85,7 +85,7 @@ package("assimp")
 
         local cxflags
         if package:is_plat("linux", "macosx", "mingw") and package:version():le("v5.2.4") then
-            cxflags = "-Wno-array-bounds"
+            cxflags = {"-Wno-array-compare", "-Wno-array-bounds"}
         end
         if package:is_plat("mingw") and package:version():lt("v5.1.5") then
             -- CMAKE_COMPILER_IS_MINGW has been removed: https://github.com/assimp/assimp/pull/4311

--- a/packages/a/assimp/xmake.lua
+++ b/packages/a/assimp/xmake.lua
@@ -83,12 +83,16 @@ package("assimp")
             table.insert(configs, "-DASSIMP_BUILD_ASSIMP_TOOLS=OFF")
         end
 
+        local cxflags
+        if package:is_plat("linux", "macosx", "mingw") and package:version():le("v5.2.4") then
+            cxflags = "-Wno-array-bounds"
+        end
         if package:is_plat("mingw") and package:version():lt("v5.1.5") then
             -- CMAKE_COMPILER_IS_MINGW has been removed: https://github.com/assimp/assimp/pull/4311
             io.replace("CMakeLists.txt", "CMAKE_COMPILER_IS_MINGW", "MINGW", {plain = true})
         end
 
-        import("package.tools.cmake").install(package, configs)
+        import("package.tools.cmake").install(package, configs, {cxflags=cxflags})
 
         -- copy pdb
         if package:is_plat("windows") then

--- a/packages/a/assimp/xmake.lua
+++ b/packages/a/assimp/xmake.lua
@@ -83,9 +83,13 @@ package("assimp")
             table.insert(configs, "-DASSIMP_BUILD_ASSIMP_TOOLS=OFF")
         end
 
-        local cxflags
-        if package:is_plat("linux", "macosx", "mingw") and package:version():le("v5.2.4") then
-            cxflags = {"-Wno-array-compare", "-Wno-array-bounds"}
+        if package:version():lt("v5.2.4") then
+            -- ASSIMP_WARNINGS_AS_ERRORS is not supported before v5.2.4
+            if package:is_plat("windows") then
+                io.replace("code/CMakeLists.txt", "TARGET_COMPILE_OPTIONS(assimp PRIVATE /W4 /WX)", "", {plain = true})
+            else
+                io.replace("code/CMakeLists.txt", "TARGET_COMPILE_OPTIONS(assimp PRIVATE -Werror)", "", {plain = true})
+            end
         end
         if package:is_plat("mingw") and package:version():lt("v5.1.5") then
             -- CMAKE_COMPILER_IS_MINGW has been removed: https://github.com/assimp/assimp/pull/4311

--- a/packages/a/assimp/xmake.lua
+++ b/packages/a/assimp/xmake.lua
@@ -82,12 +82,16 @@ package("assimp")
             table.insert(configs, "-DASSIMP_BUILD_ASSIMP_TOOLS=OFF")
         end
 
+        local cxflags
+        if package:is_plat("linux", "macosx", "mingw") and package:version():le("v5.2.4") then
+            cxflags = {"-Wno-array-compare", "-Wno-array-bounds"}
+        end
         if package:is_plat("mingw") and package:version():lt("v5.1.5") then
             -- CMAKE_COMPILER_IS_MINGW has been removed: https://github.com/assimp/assimp/pull/4311
             io.replace("CMakeLists.txt", "CMAKE_COMPILER_IS_MINGW", "MINGW", {plain = true})
         end
 
-        import("package.tools.cmake").install(package, configs)
+        import("package.tools.cmake").install(package, configs, {cxflags=cxflags})
 
         -- copy pdb
         if package:is_plat("windows") then

--- a/packages/a/assimp/xmake.lua
+++ b/packages/a/assimp/xmake.lua
@@ -19,7 +19,7 @@ package("assimp")
     add_patches("v5.2.2", path.join(os.scriptdir(), "patches", "5.2.1", "fix_zlib_filefunc_def.patch"), "a9f8a9aa1975888ea751b80c8268296dee901288011eeb1addf518eac40b71b1")
     add_patches("v5.2.3", path.join(os.scriptdir(), "patches", "5.2.1", "fix_zlib_filefunc_def.patch"), "a9f8a9aa1975888ea751b80c8268296dee901288011eeb1addf518eac40b71b1")
     add_patches("v5.2.3", path.join(os.scriptdir(), "patches", "5.2.3", "cmake_static_crt.patch"), "3872a69976055bed9e40814e89a24a3420692885b50e9f9438036e8d809aafb4")
-    add_patches("v5.2.4", path.join(os.scriptdir(), "patches", "5.2.4", "fix_x86_windows_build.patch"), "9a37b6ddb6f8e78d9271644393d32ace1faabc29969ef92f0eaa6ada3e147898")
+    add_patches("v5.2.4", path.join(os.scriptdir(), "patches", "5.2.4", "fix_x86_windows_build.patch"), "becb4039c220678cf1e888e3479f8e68d1964c49d58f14c5d247c86b4a5c3293")
 
     if not is_host("windows") then
         add_extsources("pkgconfig::assimp")


### PR DESCRIPTION
Since assimp compiles with -Werror, a GCC update breaks the compilation.
See https://github.com/assimp/assimp/issues/4433