### PR TITLE
qt5: fix datarace

### DIFF
--- a/packages/q/qt5lib/xmake.lua
+++ b/packages/q/qt5lib/xmake.lua
@@ -17,7 +17,7 @@ package("qt5lib")
     end)
 
     on_fetch(function (package)
-        local qt = package:dep("qt5base"):data("qt")
+        local qt = package:dep("qt5base"):fetch()
         if not qt then
             return
         end


### PR DESCRIPTION
When using already installed Qt package, I noticed that calling find_qt would pause the coroutine and allows another one to perform the fetch, causing issue:

- qt5base: fetch
- qt5base: <pause because of find_qt>
- qt5core: fetch (before qt5base finished)
- qt5core: tries to retrieve Qt info before qt5base finished - error

The problem doesn't happen when in verbose mode (because no concurrency happens)

To fix this I made it so qt5core fetches qt5base, but it was causing multiple simultaneous find_qt calls.

To fix this, I added some kind of "mutex" around the find_qt call in qt5base, so only one is made then the result is cached.

I think this is an issue inside of xmake itself, as it shouldn't try to fetch packages before their dependencies are fetched, but this is a working temporary fix.