### PR TITLE
h5cpp 

### DIFF
--- a/packages/b/boost/xmake.lua
+++ b/packages/b/boost/xmake.lua
@@ -143,7 +143,7 @@ package("boost")
             "debug-symbols=" .. (package:debug() and "on" or "off"),
             "link=" .. (package:config("shared") and "shared" or "static")
         }
-        if package:is_arch(".+64") then
+        if package:is_arch(".+64.*") then
             table.insert(argv, "address-model=64")
         else
             table.insert(argv, "address-model=32")

--- a/packages/h/h5cpp/patches/fix-find-hdf5.patch
+++ b/packages/h/h5cpp/patches/fix-find-hdf5.patch
@@ -1,0 +1,58 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c50784b3..dd97d117 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -171,11 +171,6 @@ install(FILES
+     DESTINATION ${CMAKE_INSTALL_PACKAGEDIR}
+     COMPONENT development)
+ 
+-install(FILES
+-        cmake/FindHDF5.cmake
+-        DESTINATION ${CMAKE_INSTALL_PACKAGEDIR}/hdf5
+-        COMPONENT development)
+-
+ #
+ # uninstall target
+ #
+diff --git a/cmake/HDF5LibraryConfig.cmake b/cmake/HDF5LibraryConfig.cmake
+index c05fe75f..307adf2c 100644
+--- a/cmake/HDF5LibraryConfig.cmake
++++ b/cmake/HDF5LibraryConfig.cmake
+@@ -2,7 +2,7 @@ if(H5CPP_WITH_MPI)
+   set(HDF5_PREFER_PARALLEL TRUE)
+ endif()
+ 
+-find_package(HDF5 REQUIRED COMPONENTS C HL)
++find_package(HDF5 CONFIG REQUIRED COMPONENTS C HL)
+ message(STATUS "==============================================================")
+ message(STATUS "========================Found HDF5============================")
+ message(STATUS "==============================================================")
+diff --git a/src/h5cpp/CMakeLists.txt b/src/h5cpp/CMakeLists.txt
+index 03a98885..606e1308 100644
+--- a/src/h5cpp/CMakeLists.txt
++++ b/src/h5cpp/CMakeLists.txt
+@@ -39,8 +39,12 @@ add_doxygen_source_deps(${h5cpp_headers})
+ 
+ if (H5CPP_BUILD_SHARED)
+ 	target_compile_definitions(h5cpp PRIVATE H5CPP_EXPORTS PUBLIC H5CPP_BUILD_SHARED)
++  set(_suffix "shared")
++else()
++  set(_suffix "static")
+ endif()
+ 
++
+ set(H5CPP_LINKS ${MPI_CXX_LIBRARIES})
+ if(H5CPP_WITH_BOOST)
+   list(APPEND H5CPP_LINKS Boost::filesystem Boost::system)
+@@ -86,9 +90,9 @@ endif()
+ target_link_libraries(h5cpp
+   PUBLIC 
+     ${H5CPP_LINKS}
+-    hdf5::hdf5
++    "hdf5::hdf5-${_suffix}"
+   PRIVATE ${COVERAGE_LIBRARIES}
+-    hdf5::hdf5_hl
++    "hdf5::hdf5_hl-${_suffix}"
+     Threads::Threads
+     ${H5CPP_FILTER_TARGETS}
+     ${CMAKE_DL_LIBS}

--- a/packages/h/h5cpp/patches/fix-find-hdf5.patch
+++ b/packages/h/h5cpp/patches/fix-find-hdf5.patch
@@ -15,23 +15,47 @@ index c50784b3..dd97d117 100644
  # uninstall target
  #
 diff --git a/cmake/HDF5LibraryConfig.cmake b/cmake/HDF5LibraryConfig.cmake
-index c05fe75f..307adf2c 100644
+index c05fe75f..7461f5ea 100644
 --- a/cmake/HDF5LibraryConfig.cmake
 +++ b/cmake/HDF5LibraryConfig.cmake
-@@ -2,7 +2,7 @@ if(H5CPP_WITH_MPI)
+@@ -2,22 +2,24 @@ if(H5CPP_WITH_MPI)
    set(HDF5_PREFER_PARALLEL TRUE)
  endif()
  
 -find_package(HDF5 REQUIRED COMPONENTS C HL)
 +find_package(HDF5 CONFIG REQUIRED COMPONENTS C HL)
++if(H5CPP_BUILD_SHARED)
++  set(libtype SHARED)
++else()
++  set(libtype STATIC)
++endif()
  message(STATUS "==============================================================")
  message(STATUS "========================Found HDF5============================")
  message(STATUS "==============================================================")
+-message(STATUS "Found HDF5 libraries in: ${HDF5_LIBRARY_DIRS}")
+-message(STATUS "Found HDF5 libraries: ${HDF5_LIBRARIES}")
+-message(STATUS "Found HDF5 HL libraries: ${HDF5_HL_LIBRARIES}")
+-message(STATUS "Found HDF5 headers: ${HDF5_INCLUDE_DIRS}")
+-message(STATUS "Found HDF5 definitions: ${HDF5_DEFINITIONS}")
++message(STATUS "Found HDF5 libraries: ${HDF5_EXPORT_LIBRARIES}")
++message(STATUS "Found HDF5 headers: ${HDF5_INCLUDE_DIR}")
+ message(STATUS "Found HDF5 HDF5_VERSION = ${HDF5_VERSION}")
+-message(STATUS "Found HDF5 HDF5_IS_PARALLEL = ${HDF5_IS_PARALLEL}")
++message(STATUS "Found HDF5 HDF5_ENABLE_PARALLEL = ${HDF5_ENABLE_PARALLEL}")
+ message(STATUS "==============================================================")
+ 
+ 
+ if(H5CPP_WITH_MPI)
+-  if(NOT HDF5_IS_PARALLEL)
++  if(NOT HDF5_ENABLE_PARALLEL)
+     message(FATAL_ERROR "The HDF5 version found does not support MPI")
+   endif()
+ endif()
 diff --git a/src/h5cpp/CMakeLists.txt b/src/h5cpp/CMakeLists.txt
-index 03a98885..606e1308 100644
+index 03a98885..0c8cd9de 100644
 --- a/src/h5cpp/CMakeLists.txt
 +++ b/src/h5cpp/CMakeLists.txt
-@@ -39,8 +39,12 @@ add_doxygen_source_deps(${h5cpp_headers})
+@@ -39,6 +39,9 @@ add_doxygen_source_deps(${h5cpp_headers})
  
  if (H5CPP_BUILD_SHARED)
  	target_compile_definitions(h5cpp PRIVATE H5CPP_EXPORTS PUBLIC H5CPP_BUILD_SHARED)
@@ -40,11 +64,8 @@ index 03a98885..606e1308 100644
 +  set(_suffix "static")
  endif()
  
-+
  set(H5CPP_LINKS ${MPI_CXX_LIBRARIES})
- if(H5CPP_WITH_BOOST)
-   list(APPEND H5CPP_LINKS Boost::filesystem Boost::system)
-@@ -86,9 +90,9 @@ endif()
+@@ -86,9 +89,9 @@ endif()
  target_link_libraries(h5cpp
    PUBLIC 
      ${H5CPP_LINKS}

--- a/packages/h/h5cpp/xmake.lua
+++ b/packages/h/h5cpp/xmake.lua
@@ -7,16 +7,33 @@ package("h5cpp")
              "https://github.com/ess-dmsc/h5cpp.git")
     add_versions("v0.5.1", "8fcab57ffbc2d799fe315875cd8fcf67e8b059cccc441ea45a001c03f6a9fd25")
 
+    add_patches("v0.5.1", path.join(os.scriptdir(), "patches", "fix-find-hdf5.patch"), "30e9db5786cc3fba4202c64880ef0009dc77affa15154355803b96cf12948c95")
+
     add_deps("cmake")
-    add_deps("hdf5")
+    add_deps("zlib")
+
+    on_load(function (package)
+        package:add("deps", "hdf5", { configs = {shared = package:config("shared")} })
+    end)
 
     on_install(function (package)
-        local configs = {"-DH5CPP_WITH_BOOST=OFF", "-DH5CPP_CONAN=DISABLE"}
+        os.rm("cmake/FindHDF5.cmake")
+        local configs = {
+            "-DH5CPP_WITH_BOOST=OFF",
+            "-DH5CPP_CONAN=DISABLE",
+            "-DH5CPP_DISABLE_TESTS=ON",
+            "-DH5CPP_BUILD_DOCS=OFF"
+        }
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        import("package.tools.cmake").install(package, configs)
+        table.insert(configs, "-DH5CPP_BUILD_SHARED=" .. (package:config("shared") and "ON" or "OFF"))
+        import("package.tools.cmake").install(package, configs, {packagedeps = "hdf5"})
+        package:addenv("PATH", package:installdir("bin"))
     end)
 
-    on_test(function (package)
-        assert(package:has_cfuncs("foo", {includes = "foo.h"}))
-    end)
+    -- on_test(function (package)
+    --     assert(package:check_cxxsnippets({test = [[
+    --         void test() {
+    --             auto type = hdf5::datatype::TypeTrait<int>::create();
+    --         }
+    --     ]]}, {configs = {languages = "c++17"}, includes = {"h5cpp/hdf5.hpp"}}))
+    -- end)

--- a/packages/h/h5cpp/xmake.lua
+++ b/packages/h/h5cpp/xmake.lua
@@ -1,0 +1,22 @@
+package("h5cpp")
+    set_homepage("https://ess-dmsc.github.io/h5cpp/")
+    set_description("C++ wrapper for the HDF5 C-library")
+    set_license("LGPL-2.1")
+
+    add_urls("https://github.com/ess-dmsc/h5cpp/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/ess-dmsc/h5cpp.git")
+    add_versions("v0.5.1", "8fcab57ffbc2d799fe315875cd8fcf67e8b059cccc441ea45a001c03f6a9fd25")
+
+    add_deps("cmake")
+    add_deps("hdf5")
+
+    on_install(function (package)
+        local configs = {"-DH5CPP_WITH_BOOST=OFF", "-DH5CPP_CONAN=DISABLE"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("foo", {includes = "foo.h"}))
+    end)

--- a/packages/h/h5cpp/xmake.lua
+++ b/packages/h/h5cpp/xmake.lua
@@ -7,7 +7,7 @@ package("h5cpp")
              "https://github.com/ess-dmsc/h5cpp.git")
     add_versions("v0.5.1", "8fcab57ffbc2d799fe315875cd8fcf67e8b059cccc441ea45a001c03f6a9fd25")
 
-    add_patches("v0.5.1", path.join(os.scriptdir(), "patches", "fix-find-hdf5.patch"), "30e9db5786cc3fba4202c64880ef0009dc77affa15154355803b96cf12948c95")
+    add_patches("v0.5.1", path.join(os.scriptdir(), "patches", "fix-find-hdf5.patch"), "25f26ec6994d387571d7c068ba0405a34db45480a9c17fe3ea6402042e7de87c")
 
     add_deps("cmake")
     add_deps("zlib")
@@ -26,14 +26,17 @@ package("h5cpp")
         }
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DH5CPP_BUILD_SHARED=" .. (package:config("shared") and "ON" or "OFF"))
-        import("package.tools.cmake").install(package, configs, {packagedeps = "hdf5"})
+        if is_plat("windows") and package:config("shared") then
+            package:add("defines", "H5_BUILT_AS_DYNAMIC_LIB")
+        end
+        import("package.tools.cmake").install(package, configs, {packagedeps = {"hdf5"}})
         package:addenv("PATH", package:installdir("bin"))
     end)
 
-    -- on_test(function (package)
-    --     assert(package:check_cxxsnippets({test = [[
-    --         void test() {
-    --             auto type = hdf5::datatype::TypeTrait<int>::create();
-    --         }
-    --     ]]}, {configs = {languages = "c++17"}, includes = {"h5cpp/hdf5.hpp"}}))
-    -- end)
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            void test() {
+                auto type = hdf5::datatype::TypeTrait<int>::create();
+            }
+        ]]}, {configs = {languages = "c++17"}, includes = {"h5cpp/hdf5.hpp"}}))
+    end)

--- a/packages/h/h5cpp/xmake.lua
+++ b/packages/h/h5cpp/xmake.lua
@@ -16,7 +16,7 @@ package("h5cpp")
         package:add("deps", "hdf5", { configs = {shared = package:config("shared")} })
     end)
 
-    on_install(function (package)
+    on_install("windows", "macosx", "linux", function (package)
         os.rm("cmake/FindHDF5.cmake")
         local configs = {
             "-DH5CPP_WITH_BOOST=OFF",

--- a/packages/h/hdf5/xmake.lua
+++ b/packages/h/hdf5/xmake.lua
@@ -17,23 +17,21 @@ package("hdf5")
         add_syslinks("dl")
     end
     on_install("windows", "macosx", "linux", function (package)
-        local configs = {"-DHDF5_GENERATE_HEADERS=OFF", "-DBUILD_TESTING=OFF", "-DHDF5_BUILD_EXAMPLES=OFF"}
+        local configs = {
+            "-DHDF5_GENERATE_HEADERS=OFF",
+            "-DBUILD_TESTING=OFF",
+            "-DHDF5_BUILD_EXAMPLES=OFF",
+            "-DHDF_PACKAGE_NAMESPACE:STRING=hdf5::",
+            "-DHDF5_MSVC_NAMING_CONVENTION=OFF"
+        }
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DONLY_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DBUILD_STATIC_LIBS=" .. (package:config("shared") and "OFF" or "ON"))
         table.insert(configs, "-DHDF5_BUILD_CPP_LIB=" .. (package:config("cpplib") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)
-        if package:is_plat("windows") then
-            -- fix libname to let cmake can find it.
-            for _, libfile in ipairs(os.files(path.join(package:installdir("lib"), "*.lib"))) do
-                local basename = path.basename(libfile)
-                if basename:startswith("lib") then
-                    os.mv(libfile, path.join(path.directory(libfile), basename:sub(4) .. ".lib"))
-                end
-            end
-        end
-        package:addenv("PATH", "bin")
+        package:addenv("HDF5_ROOT", path.join(package:installdir("share"), "cmake"))
+        package:addenv("PATH", package:installdir("bin"))
     end)
 
     on_test(function (package)

--- a/packages/h/hdf5/xmake.lua
+++ b/packages/h/hdf5/xmake.lua
@@ -10,7 +10,7 @@ package("hdf5")
     add_versions("1.12.0", "a62dcb276658cb78e6795dd29bf926ed7a9bc4edf6e77025cd2c689a8f97c17a")
     add_versions("1.12.1", "79c66ff67e666665369396e9c90b32e238e501f345afd2234186bfb8331081ca")
 
-    add_configs("cpp", {description = "Build HDF5 C++ Library", default = false, type = "boolean"})
+    add_configs("cpplib", {description = "Build HDF5 C++ Library", default = false, type = "boolean"})
 
     add_deps("cmake")
     if is_plat("linux") then
@@ -22,7 +22,7 @@ package("hdf5")
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DONLY_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DBUILD_STATIC_LIBS=" .. (package:config("shared") and "OFF" or "ON"))
-        table.insert(configs, "-DHDF5_BUILD_CPP_LIB=" .. (package:config("cpp") and "ON" or "OFF"))
+        table.insert(configs, "-DHDF5_BUILD_CPP_LIB=" .. (package:config("cpplib") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)
         if package:is_plat("windows") then
             -- fix libname to let cmake can find it.
@@ -44,7 +44,7 @@ package("hdf5")
         end
         assert(package:has_cfuncs("H5open", {includes = "H5public.h"}))
 
-        if package:config("cpp") then
+        if package:config("cpplib") then
              assert(package:check_cxxsnippets({test = [[
                 void test() {
                     H5::H5Library::open();

--- a/packages/h/hdf5/xmake.lua
+++ b/packages/h/hdf5/xmake.lua
@@ -10,6 +10,8 @@ package("hdf5")
     add_versions("1.12.0", "a62dcb276658cb78e6795dd29bf926ed7a9bc4edf6e77025cd2c689a8f97c17a")
     add_versions("1.12.1", "79c66ff67e666665369396e9c90b32e238e501f345afd2234186bfb8331081ca")
 
+    add_configs("cpp", {description = "Build HDF5 C++ Library", default = false, type = "boolean"})
+
     add_deps("cmake")
     if is_plat("linux") then
         add_syslinks("dl")
@@ -20,6 +22,7 @@ package("hdf5")
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DONLY_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DBUILD_STATIC_LIBS=" .. (package:config("shared") and "OFF" or "ON"))
+        table.insert(configs, "-DHDF5_BUILD_CPP_LIB=" .. (package:config("cpp") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)
         if package:is_plat("windows") then
             -- fix libname to let cmake can find it.
@@ -40,4 +43,12 @@ package("hdf5")
             os.vrun("h5diff --version")
         end
         assert(package:has_cfuncs("H5open", {includes = "H5public.h"}))
+
+        if package:config("cpp") then
+             assert(package:check_cxxsnippets({test = [[
+                void test() {
+                    H5::H5Library::open();
+                }
+            ]]}, {configs = {languages = "c++17"}, includes = {"H5Cpp.h"}}))
+        end
     end)

--- a/packages/h/highfive/patches/fix-find-hdf5.patch
+++ b/packages/h/highfive/patches/fix-find-hdf5.patch
@@ -1,0 +1,16 @@
+diff --git a/CMake/HighFiveTargetDeps.cmake b/CMake/HighFiveTargetDeps.cmake
+index 50c3e9d..83ea21b 100644
+--- a/CMake/HighFiveTargetDeps.cmake
++++ b/CMake/HighFiveTargetDeps.cmake
+@@ -8,9 +8,9 @@ if(NOT TARGET libdeps)
+ 
+   # HDF5
+   if(NOT DEFINED HDF5_C_LIBRARIES)
+-    set(HDF5_NO_FIND_PACKAGE_CONFIG_FILE TRUE)  # Consistency
++    set(HDF5_NO_FIND_PACKAGE_CONFIG_FILE FALSE)  # use config
+     set(HDF5_PREFER_PARALLEL ${HIGHFIVE_PARALLEL_HDF5})
+-    find_package(HDF5 REQUIRED)
++    find_package(HDF5 REQUIRED HINTS ${HDF5_ROOT})
+   endif()
+ 
+   if(HIGHFIVE_PARALLEL_HDF5 AND NOT HDF5_IS_PARALLEL)

--- a/packages/h/highfive/xmake.lua
+++ b/packages/h/highfive/xmake.lua
@@ -8,6 +8,8 @@ package("highfive")
 
     add_versions("v2.3.1", "41728a1204bdfcdcef8cbc3ddffe5d744c5331434ce3dcef35614b831234fcd7")
 
+    add_patches("v2.3.1", path.join(os.scriptdir(), "patches", "fix-find-hdf5.patch"), "6a37e12f1796394d7691b36561829bf220336ec42a736c103509ac93537a36c9")
+
     add_deps("cmake")
     add_deps("hdf5")
 


### PR DESCRIPTION
## 新的packge
[h5cpp: A modern C++ interface for HDF5](https://github.com/ess-dmsc/h5cpp)

## 存在一些问题
`h5cpp` 依赖 `hdf5` 这个包，它在使用 cmake 进行 configuration 的时候，会出现找不到 `libhdf5.lib` 这个文件。

输出错误信息如下，问题出在使用依赖 `hdf5` 的 `hdf5-targets.cmake` 来寻找这个库文件。相关的PR #759 和 #771.

>可以了，我改了下 merge 了。。https://github.com/xmake-io/xmake-repo/pull/771
调整了下 hdf5 里面的库名，不然 cmake 找不到。。2016 ci failed 不用管，不支持 c++17
_Originally posted by @waruqi in https://github.com/xmake-io/xmake-repo/issues/759#issuecomment-997402189_


顺带一提，`h5cpp`需要使用 C++17中的`std::filesystem`。

```bash
CMake Error at C:/Users/54405/AppData/Local/.xmake/packages/h/hdf5/1.12.1/14fc73d3901d4c1ea970f78c3a218028/share/cmake/hdf5/hdf5-targets.cmake:152 (message):
  The imported target "hdf5-static" references the file

     "C:/Users/54405/AppData/Local/.xmake/packages/h/hdf5/1.12.1/14fc73d3901d4c1ea970f78c3a218028/lib/libhdf5.lib"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "C:/Users/54405/AppData/Local/.xmake/packages/h/hdf5/1.12.1/14fc73d3901d4c1ea970f78c3a218028/share/cmake/hdf5/hdf5-targets.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  C:/Users/54405/AppData/Local/.xmake/packages/h/hdf5/1.12.1/14fc73d3901d4c1ea970f78c3a218028/share/cmake/hdf5/hdf5-config.cmake:144 (include)
  cmake/FindHDF5.cmake:502 (find_package)
  cmake/HDF5LibraryConfig.cmake:5 (find_package)
  CMakeLists.txt:96 (include)
```