### PR TITLE
update libcurl and glfw

### DIFF
--- a/packages/g/glfw/xmake.lua
+++ b/packages/g/glfw/xmake.lua
@@ -10,6 +10,7 @@ package("glfw")
     add_versions("3.3.4", "cc8ac1d024a0de5fd6f68c4133af77e1918261396319c24fd697775a6bc93b63")
     add_versions("3.3.5", "32fdb8705784adfe3082f97e0d41e7c515963e977b5a14c467a887cf0da827b5")
     add_versions("3.3.6", "ed07b90e334dcd39903e6288d90fa1ae0cf2d2119fec516cf743a0a404527c02")
+    add_versions("3.3.7", "fd21a5f65bcc0fc3c76e0f8865776e852de09ef6fbc3620e09ce96d2b2807e04")
 
     add_configs("glfw_include", {description = "Choose submodules enabled in glfw", default = "none", type = "string", values = {"none", "vulkan", "glu", "glext", "es2", "es3"}})
 

--- a/packages/l/libcurl/patches/7.84.0/sched.patch
+++ b/packages/l/libcurl/patches/7.84.0/sched.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/easy_lock.h b/lib/easy_lock.h
+--- a/lib/easy_lock.h
++++ b/lib/easy_lock.h
+@@ -36,6 +36,9 @@
+ 
+ #elif defined (HAVE_ATOMIC)
+ #include <stdatomic.h>
++#if defined(HAVE_SCHED_YIELD)
++#include <sched.h>
++#endif
+ 
+ #define curl_simple_lock atomic_bool
+ #define CURL_SIMPLE_LOCK_INIT false

--- a/packages/l/libcurl/versions.lua
+++ b/packages/l/libcurl/versions.lua
@@ -1,4 +1,5 @@
 function add_versions_list()
+    add_versions("7.84.0", "702fb26e73190a3bd77071aa146f507b9817cc4dfce218d2ab87f00cd3bc059d")
     add_versions("7.82.0", "46d9a0400a33408fd992770b04a44a7434b3036f2e8089ac28b57573d59d371f")
     add_versions("7.81.0", "1e7a38d7018ec060f1f16df839854f0889e94e122c4cfa5d3a37c2dc56f1e258")
     add_versions("7.80.0", "dd0d150e49cd950aff35e16b628edf04927f0289df42883750cf952bb858189c")

--- a/packages/l/libcurl/versions.lua
+++ b/packages/l/libcurl/versions.lua
@@ -53,4 +53,6 @@ function add_versions_list()
     add_versions("7.33.0", "0afde4cd949e2658eddc3cda675b19b165eea1af48ac5f3e1ec160792255d1b3")
     add_versions("7.32.0", "8e3db42548e01407cb2f1407660c0f528b89ec7afda6264442fc2b229b95223b")
     add_versions("7.31.0", "a73b118eececff5de25111f35d1d0aafe1e71afdbb83082a8e44d847267e3e08")
+
+    add_patches("7.84.0", path.join(os.scriptdir(), "patches", "7.84.0", "sched.patch"), "e79f56f840cbc6996a153f19d9266bd46fe4154e6b494c8ee0478cb5b87662d3")
 end

--- a/packages/l/libcurl/xmake.lua
+++ b/packages/l/libcurl/xmake.lua
@@ -80,7 +80,7 @@ package("libcurl")
                             zlib     = "CURL_ZLIB",
                             zstd     = "CURL_ZSTD",
                             brotli   = "CURL_BROTLI",
-                            libssh2  = (version:ge("7.81") and "CURL_USE_LIBSSL2" or "CMAKE_USE_LIBSSL2")}
+                            libssh2  = (version:ge("7.81") and "CURL_USE_LIBSSH2" or "CMAKE_USE_LIBSSH2")}
         for name, opt in pairs(configopts) do
             table.insert(configs, "-D" .. opt .. "=" .. (package:config(name) and "ON" or "OFF"))
         end


### PR DESCRIPTION
python从系统里找的时候，不需要安装openssl/zlib/libffi等，直接调用就可以，因此修改了依赖逻辑