### PR TITLE
Add extsources to brotli

### DIFF
--- a/packages/b/brotli/xmake.lua
+++ b/packages/b/brotli/xmake.lua
@@ -19,6 +19,14 @@ package("brotli")
 
     add_links("brotlienc", "brotlidec", "brotlicommon")
 
+    if is_plat("mingw") and is_subhost("msys") then
+        add_extsources("pacman::brotli")
+    elseif is_plat("linux") then
+        add_extsources("pacman::brotli", "apt::libbrotli-dev)
+    elseif is_plat("macosx") then
+        add_extsources("brew::brotli")
+    end
+
     on_load(function (package)
         package:addenv("PATH", "bin")
     end)

--- a/packages/b/brotli/xmake.lua
+++ b/packages/b/brotli/xmake.lua
@@ -22,7 +22,7 @@ package("brotli")
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::brotli")
     elseif is_plat("linux") then
-        add_extsources("pacman::brotli", "apt::libbrotli-dev)
+        add_extsources("pacman::brotli", "apt::libbrotli-dev")
     elseif is_plat("macosx") then
         add_extsources("brew::brotli")
     end


### PR DESCRIPTION
@waruqi on ubuntu, the executable `brotli` is in its own package separated from the rest (`libbrotli-dev`). I do not know how the xmake repository handles this.