### PR TITLE
Add extsources to ffmpeg

### DIFF
--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -60,7 +60,7 @@ package("ffmpeg")
                             result = result .. pkginfo
                         end
                     else
-                        return {}
+                        return nil
                     end
                 end
                 local ffmpeg = find_tool("ffmpeg", {check = "-help", version = true, command = "-version", parse = "%d+%.?%d+%.?%d+", force = true})

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -60,7 +60,7 @@ package("ffmpeg")
                             result = result .. pkginfo
                         end
                     else
-                        return nil
+                        return
                     end
                 end
                 local ffmpeg = find_tool("ffmpeg", {check = "-help", version = true, command = "-version", parse = "%d+%.?%d+%.?%d+", force = true})

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -75,15 +75,13 @@ package("ffmpeg")
                 end
                 result.includedirs = table.unique(result.includedirs)
                 result.linkdirs = table.unique(result.linkdirs)
-                import("lib.detect.find_programver")
                 
+                import("lib.detect.find_programver")
                 local version = find_programver("ffmpeg", {command = "-version"})
                 if(version == nil) then
                     return
                 end
-                    
                 result.version = version:gsub("(.*)%-.*$","%1") --remove -0ubuntu0.22.04.1 on ubuntu
-                
                 return result
             end
         end)

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -52,6 +52,31 @@ package("ffmpeg")
     elseif is_plat("macosx") then
         add_extsources("brew::ffmpeg")
     end
+    
+    if on_fetch then
+        on_fetch("linux", function (package, opt)
+            if opt.system then
+                local result
+                for _, name in ipairs({"libavcodec", "libavdevice", "libavfilter", "libavformat", "libavutil", "libpostproc", "libswresample", "libswscale"}) do
+                    local pkginfo = package.find_package and package:find_package("pkgconfig::" .. name, opt)
+                    if pkginfo then
+                        if not result then
+                            result = table.copy(pkginfo)
+                        else
+                            local includedirs = pkginfo.sysincludedirs or pkginfo.includedirs
+                            result.links = table.wrap(result.links)
+                            result.linkdirs = table.wrap(result.linkdirs)
+                            result.includedirs = table.wrap(result.includedirs)
+                            table.join2(result.includedirs, includedirs)
+                            table.join2(result.linkdirs, pkginfo.linkdirs)
+                            table.join2(result.links, pkginfo.links)
+                        end
+                    end
+                end
+                return result
+            end
+        end)
+    end
 
     on_load("linux", "macos", "android", function (package)
         local configdeps = {zlib    = "zlib",

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -45,6 +45,14 @@ package("ffmpeg")
         add_deps("yasm")
     end
 
+    if is_plat("mingw") and is_subhost("msys") then
+        add_extsources("pacman::ffmpeg")
+    elseif is_plat("linux") then
+        add_extsources("pacman::ffmpeg")
+    elseif is_plat("macosx") then
+        add_extsources("brew::ffmpeg")
+    end
+
     on_load("linux", "macos", "android", function (package)
         local configdeps = {zlib    = "zlib",
                             bzlib   = "bzip2",

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -54,7 +54,7 @@ package("ffmpeg")
     end
     
     if on_fetch then
-        on_fetch("mingw", "linux", function (package, opt)
+        on_fetch("linux", function (package, opt)
             if opt.system then
                 local result
                 for _, name in ipairs({"libavcodec", "libavdevice", "libavfilter", "libavformat", "libavutil", "libpostproc", "libswresample", "libswscale"}) do

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -54,7 +54,7 @@ package("ffmpeg")
     end
     
     if on_fetch then
-        on_fetch("linux", function (package, opt)
+        on_fetch("mingw", "linux", function (package, opt)
             if opt.system then
                 local result
                 for _, name in ipairs({"libavcodec", "libavdevice", "libavfilter", "libavformat", "libavutil", "libpostproc", "libswresample", "libswscale"}) do
@@ -73,6 +73,17 @@ package("ffmpeg")
                         end
                     end
                 end
+                result.includedirs = table.unique(result.includedirs)
+                result.linkdirs = table.unique(result.linkdirs)
+                import("lib.detect.find_programver")
+                
+                local version = find_programver("ffmpeg", {command = "-version"})
+                if(version == nil) then
+                    return
+                end
+                    
+                result.version = version
+                
                 return result
             end
         end)

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -82,7 +82,7 @@ package("ffmpeg")
                     return
                 end
                     
-                result.version = version
+                result.version = version:gsub("(.*)%-.*$","%1") --remove -0ubuntu0.22.04.1 on ubuntu
                 
                 return result
             end


### PR DESCRIPTION
**Question**: ffmpeg dev files on ubuntu are splitted into multiple packages. So instead of installing one pacman package named `ffmpeg` (on msys2, brew, arch linux for example) that will contain the executable and all the dev files, you need to install multiple packages on ubuntu:
```
ffmpeg, libavcodec-dev, libavdevice-dev, libavfilter-dev, libavformat-dev, libavutil-dev, libpostproc-dev, libswresample-dev, libswscale-dev
```
That means it should be possible, using `add_extsources`, to require multiple packages to be installed to consider the dependency ffmpeg installed, something that could look like:

```lua
add_extsources("pacman::ffmpeg", {"apt::ffmpeg", "apt::libavcodec-dev", "apt::libavdevice-dev", "apt::libavfilter-dev", "apt::libavfilter-dev", "apt::libavformat-dev", "apt::libavutil-dev", "apt::lib-postproc-dev", "apt::libswresample-dev", "apt::libswscale-dev"})
```

Which means: either you have the pacman package ffmpeg installed (arch linux and the likes), or the following deb packages (debian, mint, ubuntu, ...). Is it something possible with xmake ?