### PR TITLE
Update freetype and use cmake on Linux/macosx

### DIFF
--- a/packages/f/freetype/xmake.lua
+++ b/packages/f/freetype/xmake.lua
@@ -48,7 +48,7 @@ package("freetype")
         add_dep("woff2", "brotli")
     end)
 
-    on_install("windows", "mingw", "linux", "macosx", function (package)
+    on_install(function (package)
         local configs = {"-DCMAKE_INSTALL_LIBDIR=lib"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))


### PR DESCRIPTION
The makefile can't find brotli when installed by xmake: <https://github.com/NazaraEngine/xmake-repo/runs/7544869084?check_suite_focus=true#step:5:1026>

I think it's same to use cmake to build it (as this is what vcpkg does)