### PR TITLE
Catch2: Add cxx17 option and build using C++17 by default

### DIFF
--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -13,7 +13,9 @@ package("catch2")
     add_versions("2.13.6", "39d50f5d1819cdf2908066664d57c2cde4a4000c364ad3376ea099735c896ff4")
     add_versions("2.13.5", "728679b056dc1248cc79b3a1999ff7453f76422c68417563fc47a0ac2aaeeaef")
     add_versions("2.9.2", "dc486300de22b0d36ddba1705abb07b9e5780639d824ba172ddf7062b2a1bf8f")
-    
+
+    add_configs("cxx17", {description = "Compiles Catch as a C++17 library (requires a C++17 compiler).", default = true, type = "boolean"})
+
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::catch")
     elseif is_plat("linux") then
@@ -35,6 +37,9 @@ package("catch2")
             local configs = {"-DCATCH_INSTALL_DOCS=OFF", "-DCATCH_BUILD_TESTING=OFF", "-DCATCH_BUILD_EXAMPLES=OFF"}
             table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
             table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+            if package:config("cxx17") then
+                table.insert(configs, "-DCMAKE_CXX_STANDARD=17")
+            end
             import("package.tools.cmake").install(package, configs)
         else
             os.cp("single_include/catch2", package:installdir("include"))


### PR DESCRIPTION
Fixes this issue: https://stackoverflow.com/questions/66227246/catch2-undefined-reference-to-catchstringmaker