### PR TITLE
update libtiff, libdeflate, nlohmann_json, simage

### DIFF
--- a/packages/l/libdeflate/xmake.lua
+++ b/packages/l/libdeflate/xmake.lua
@@ -8,6 +8,7 @@ package("libdeflate")
              "https://github.com/ebiggers/libdeflate.git")
     add_versions("v1.8", "50711ad4e9d3862f8dfb11b97eb53631a86ee3ce49c0e68ec2b6d059a9662f61")
     add_versions("v1.10", "5c1f75c285cd87202226f4de49985dcb75732f527eefba2b3ddd70a8865f2533")
+    add_versions("v1.13", "0d81f197dc31dc4ef7b6198fde570f4e8653c77f4698fcb2163d820a9607c838")
 
     on_load("windows", function (package)
         if package:config("shared") then

--- a/packages/l/libtiff/xmake.lua
+++ b/packages/l/libtiff/xmake.lua
@@ -8,23 +8,44 @@ package("libtiff")
     add_versions("v4.1.0", "fddd8838e7e57ba20a93b17706c3f9fe68c8711a6321f04b9ce9a9c24196ac74")
     add_versions("v4.2.0", "f87463ac8984b43e8dd84a04c14816f5f217796d9f1f459756239c499857e75a")
     add_versions("v4.3.0", "5abe48cb2ea469fefb36d85718ddb1b9f28f95c87063e006696c83f23f5b8e41")
+    add_versions("v4.4.0", "d118fc97748333ae6c53302ea06584148b72e128e924253d346b802d2a80a567")
 
-    add_deps("zlib")
+    add_configs("tools",      {description = "build TIFF tools", default = false, type = "boolean"})
+    add_configs("zlib",       {description = "use zlib (required for Deflate compression)", default = false, type = "boolean"})
+    add_configs("libdeflate", {description = "use libdeflate (optional for faster Deflate support, still requires zlib)", default = false, type = "boolean"})
+    add_configs("jpeg",       {description = "use libjpeg (required for JPEG compression)", default = false, type = "boolean"})
+    add_configs("zstd",       {description = "use libzstd (required for ZSTD compression)", default = false, type = "boolean"})
+    add_configs("webp",       {description = "use libwebp (required for WEBP compression)", default = false, type = "boolean"})
+    local configdeps = {zlib       = "zlib",
+                        libdeflate = "libdeflate",
+                        jpeg       = "libjpeg-turbo",
+                        zstd       = "zstd",
+                        webp       = "libwebp"}
+
     add_deps("cmake")
-    add_deps("libdeflate")
+    on_load("windows", "mingw", "macosx", "linux", "bsd", function (package)
+        for config, dep in pairs(configdeps) do
+            if package:config(config) then
+                package:add("deps", dep)
+            end
+        end
+    end)
 
     on_install("windows", "mingw", "macosx", "linux", "bsd", function (package)
-        local configs = {"-Dzstd=OFF", "-Dlzma=OFF", "-Dwebp=OFF", "-Djpeg=OFF", "-Djbig=OFF", "-Dpixarlog=OFF", "-Dlerc=OFF"}
+        local configs = {"-Dlzma=OFF", "-Djbig=OFF", "-Dpixarlog=OFF", "-Dlerc=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
+        for config, dep in pairs(configdeps) do
+            table.insert(configs, "-D" .. config .. "=" .. (package:config(config) and "ON" or "OFF"))
         end
-        io.replace("CMakeLists.txt", "add_subdirectory(contrib)", "", {plain = true})
         io.replace("CMakeLists.txt", "add_subdirectory(man)", "", {plain = true})
         io.replace("CMakeLists.txt", "add_subdirectory(html)", "", {plain = true})
         io.replace("CMakeLists.txt", "add_subdirectory(test)", "", {plain = true})
-        io.replace("CMakeLists.txt", "add_subdirectory(tools)", "", {plain = true})
+        if not package:config("tools") then
+            io.replace("CMakeLists.txt", "add_subdirectory(tools)", "", {plain = true})
+        else
+            package:addenv("PATH", "bin")
+        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/n/nlohmann_json/xmake.lua
+++ b/packages/n/nlohmann_json/xmake.lua
@@ -6,6 +6,7 @@ package("nlohmann_json")
 
     add_urls("https://github.com/nlohmann/json/archive/$(version).tar.gz",
              "https://github.com/nlohmann/json.git")
+    add_versions("v3.11.2", "d69f9deb6a75e2580465c6c4c5111b89c4dc2fa94e3a85fcd2ffcd9a143d9273")
     add_versions("v3.10.5", "5daca6ca216495edf89d167f808d1d03c4a4d929cef7da5e10f135ae1540c7e4")
     add_versions("v3.10.0", "eb8b07806efa5f95b349766ccc7a8ec2348f3b2ee9975ad879259a371aea8084")
     add_versions("v3.9.1", "4cf0df69731494668bdd6460ed8cb269b68de9c19ad8c27abc24cd72605b2d5b")

--- a/packages/s/simage/xmake.lua
+++ b/packages/s/simage/xmake.lua
@@ -4,8 +4,10 @@ package("simage")
     set_description("Simage is a library capable of loading, manipulating and saving images, creating and saving movies (AVI and MPEG), and loading audio.")
     set_license("MIT")
 
-    add_urls("https://github.com/coin3d/simage/releases/download/v$(version)/simage-$(version)-src.zip")
+    add_urls("https://github.com/coin3d/simage/releases/download/v$(version)/simage-$(version)-src.zip",
+             "https://github.com/coin3d/simage.git")
     add_versions("1.8.1", "308a8712c1f28cf6e662acab2e1fdd263fbfcb11323869806f4fef435653d4d3")
+    add_versions("1.8.3", "48fd116bf8493df08729ad8468ce42d7c9c73ddbb21feff48bf6aac187294f1b")
 
     if is_plat("windows") then
         add_syslinks("gdiplus")

--- a/packages/s/sqlite3/xmake.lua
+++ b/packages/s/sqlite3/xmake.lua
@@ -41,6 +41,9 @@ package("sqlite3")
                 if is_kind("shared") and is_plat("windows") then
                     add_defines("SQLITE_API=__declspec(dllexport)")
                 end
+                if is_plat("macosx", "linux", "bsd") then
+                    add_syslinks("pthread", "dl")
+                end
         ]]
         if is_plat(os.host()) and is_arch(os.arch()) then
             xmake_lua = xmake_lua .. [[

--- a/packages/s/sqlite3/xmake.lua
+++ b/packages/s/sqlite3/xmake.lua
@@ -31,7 +31,7 @@ package("sqlite3")
     end
 
     on_install(function (package)
-        io.writefile("xmake.lua", [[
+        local xmake_lua = [[
             add_rules("mode.debug", "mode.release")
             target("sqlite3")
                 set_kind("$(kind)")
@@ -41,15 +41,19 @@ package("sqlite3")
                 if is_kind("shared") and is_plat("windows") then
                     add_defines("SQLITE_API=__declspec(dllexport)")
                 end
-        ]])
-        local configs = {}
-        if package:config("shared") then
-            configs.kind = "shared"
+        ]]
+        if is_plat(os.host()) and is_arch(os.arch()) then
+            xmake_lua = xmake_lua .. [[
+                target("sqlite3_shell")
+                    set_kind("binary")
+                    set_basename("sqlite3")
+                    add_files("shell.c")
+                    add_deps("sqlite3")
+            ]]
         end
-        if not package:is_plat("windows", "mingw") and package:config("pic") ~= false then
-            configs.cxflags = "-fPIC"
-        end
-        import("package.tools.xmake").install(package, configs)
+        io.writefile("xmake.lua", xmake_lua)
+        import("package.tools.xmake").install(package)
+        package:addenv("PATH", "bin")
     end)
 
     on_test(function (package)


### PR DESCRIPTION
libtiff 本身可以不依赖第三方库编译，而在启用zlib等第三方库时会导致其他依赖tiff的cmake包找不到zlib等，从而导致链接错误。这里参考vcpkg，默认禁用了这些第三方codec，加入了选项控制