### PR TITLE
update rapidjson to master branch

### DIFF
--- a/packages/r/rapidjson/xmake.lua
+++ b/packages/r/rapidjson/xmake.lua
@@ -3,12 +3,7 @@ package("rapidjson")
     set_homepage("https://github.com/Tencent/rapidjson")
     set_description("RapidJSON is a JSON parser and generator for C++.")
 
-    set_urls("https://github.com/Tencent/rapidjson/archive/$(version).zip",
-             "https://github.com/Tencent/rapidjson.git")
-
-    add_versions("v1.1.0", "8e00c38829d6785a2dfb951bb87c6974fa07dfe488aa5b25deec4b8bc0f6a3ab")
-    -- This commit is used in arrow 7.0.0 https://github.com/apache/arrow/blob/release-7.0.0/cpp/thirdparty/versions.txt#L80
-    add_versions("v1.1.0-arrow", "1a803826f1197b5e30703afe4b9c0e7dd48074f5")
+    set_urls("https://github.com/Tencent/rapidjson.git")
 
     on_install(function (package)
         os.cp(path.join("include", "*"), package:installdir("include"))

--- a/packages/r/rapidjson/xmake.lua
+++ b/packages/r/rapidjson/xmake.lua
@@ -3,7 +3,13 @@ package("rapidjson")
     set_homepage("https://github.com/Tencent/rapidjson")
     set_description("RapidJSON is a JSON parser and generator for C++.")
 
-    set_urls("https://github.com/Tencent/rapidjson.git")
+    set_urls("https://github.com/Tencent/rapidjson/archive/$(version).zip",
+             "https://github.com/Tencent/rapidjson.git")
+
+    add_versions("2022.7.20", "27c3a8dc0e2c9218fe94986d249a12b5ed838f1d")
+    add_versions("v1.1.0", "8e00c38829d6785a2dfb951bb87c6974fa07dfe488aa5b25deec4b8bc0f6a3ab")
+    -- This commit is used in arrow 7.0.0 https://github.com/apache/arrow/blob/release-7.0.0/cpp/thirdparty/versions.txt#L80
+    add_versions("v1.1.0-arrow", "1a803826f1197b5e30703afe4b9c0e7dd48074f5")
 
     on_install(function (package)
         os.cp(path.join("include", "*"), package:installdir("include"))


### PR DESCRIPTION
Update rapidjson to git master branch.

The latest rapidjson release(v1.1.0) was published in 2016 which should not be used any more since it has not been updated for over 5 years. The v1.1.0 release is still using `std::iterator` which is marked as deprecated in C++17. Thus, the master branch should be used instead.
