### PR TITLE
Making sure that debug builds work

### DIFF
--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -202,7 +202,7 @@ package("opencv")
             runtest = false
         end
         if runtest then
-            os.vrun("opencv_version")
+            os.vrun((package:debug() and "opencv_version" or "opencv_versiond"))
         end
         assert(package:check_cxxsnippets({test = [[
             #include <iostream>


### PR DESCRIPTION
on_test now calls appropriate opencv_version(d) executable upon installing. Previously the debug builds failed because the executable couldn't be found.
