### PR TITLE
Update imgui docking

### DIFF
--- a/packages/i/imgui/xmake.lua
+++ b/packages/i/imgui/xmake.lua
@@ -6,6 +6,7 @@ package("imgui")
 
     add_urls("https://github.com/ocornut/imgui/archive/$(version).tar.gz",
              "https://github.com/ocornut/imgui.git")
+    add_versions("v1.88-docking", "9cd9c2eff99877a3f10a7f9c2a3a5b9c15ea36c6")
     add_versions("v1.88", "9f14c788aee15b777051e48f868c5d4d959bd679fc5050e3d2a29de80d8fd32e")
     add_versions("v1.87-docking", "1ee252772ae9c0a971d06257bb5c89f628fa696a")
     add_versions("v1.87", "b54ceb35bda38766e36b87c25edf7a1cd8fd2cb8c485b245aedca6fb85645a20")


### PR DESCRIPTION
Use the merge master commit after release v1.88
https://github.com/ocornut/imgui/commit/9cd9c2eff99877a3f10a7f9c2a3a5b9c15ea36c6