### PR TITLE
libzip: Add Advapi32 syslink

### DIFF
--- a/packages/l/libzip/xmake.lua
+++ b/packages/l/libzip/xmake.lua
@@ -19,6 +19,10 @@ package("libzip")
         add_configs(config, {description = "Enable " .. config .. " support.", default = false, type = "boolean"})
     end
 
+    if is_plat("windows") then
+        add_syslinks("Advapi32")
+    end
+
     on_load("windows", "macosx", "linux", function (package)
         for config, dep in pairs(configdeps) do
             if package:config(config) then

--- a/packages/l/libzip/xmake.lua
+++ b/packages/l/libzip/xmake.lua
@@ -19,7 +19,7 @@ package("libzip")
         add_configs(config, {description = "Enable " .. config .. " support.", default = false, type = "boolean"})
     end
 
-    if is_plat("windows") then
+    if is_plat("windows", "mingw") then
         add_syslinks("Advapi32")
     end
 


### PR DESCRIPTION
Fixes unresolved symbol when using libzip on Windows
```
[ 88%]: linking.release odttomd.exe
error: zip.lib(zip_source_file_win32_named.obj) : error LNK2019: symbole externe non résolu __imp_GetSecurityInfo référencé dans la fonction _zip_win32_named_op_create_temp_output
build\windows\x64\release\odttomd.exe : fatal error LNK1120: 1 externes non résolus`
```