### PR TITLE
Update VulkanSDK repos to SDK version 1.3.224+1

### DIFF
--- a/packages/g/glslang/xmake.lua
+++ b/packages/g/glslang/xmake.lua
@@ -5,6 +5,7 @@ package("glslang")
     set_license("Apache-2.0")
 
     add_urls("https://github.com/KhronosGroup/glslang.git")
+    add_versions("1.3.224+1", "10423ec659d301a0ff2daac8bbf38980abf27590")
     add_versions("1.3.211+0", "9bb8cfffb0eed010e07132282c41d73064a7a609")
     add_versions("1.2.154+1", "bacaef3237c515e40d1a24722be48c0a0b30f75f")
     add_versions("1.2.162+0", "c594de23cdd790d64ad5f9c8b059baae0ee2941d")

--- a/packages/s/spirv-cross/xmake.lua
+++ b/packages/s/spirv-cross/xmake.lua
@@ -8,6 +8,7 @@ package("spirv-cross")
     add_versions("1.2.154+1", "e6f5ce6b8998f551f3400ad743b77be51bbe3019")
     add_versions("1.2.162+0", "6d10da0224bd3214c9a507832e62d9fb6ae9620d")
     add_versions("1.2.189+1", "0e2880ab990e79ce6cc8c79c219feda42d98b1e8")
+    add_versions("1.3.224+1", "61c603f3baa5270e04bcfb6acf83c654e3c57679")
 
     add_deps("cmake")
     add_links("spirv-cross-c", "spirv-cross-cpp", "spirv-cross-reflect", "spirv-cross-msl", "spirv-cross-util", "spirv-cross-hlsl", "spirv-cross-glsl", "spirv-cross-core")

--- a/packages/s/spirv-headers/xmake.lua
+++ b/packages/s/spirv-headers/xmake.lua
@@ -8,6 +8,7 @@ package("spirv-headers")
     add_urls("https://github.com/KhronosGroup/SPIRV-Headers/archive/$(version).tar.gz", {version = function (version) return version:startswith("v") and version or "sdk-" .. version:gsub("%+", ".") end})
     add_versions("1.2.198+0", "3301a23aca0434336a643e433dcacacdd60000ab3dd35dc0078a297c06124a12")
     add_versions("1.3.211+0", "30a78e61bd812c75e09fdc7a319af206b1044536326bc3e85fea818376a12568")
+    add_versions("1.3.224+1", "c85714bfe62f84007286bd3b3c0471af0a7e06ab66bc2ca4623043011b28737f")
 
     add_deps("cmake")
     on_install(function (package)

--- a/packages/s/spirv-reflect/xmake.lua
+++ b/packages/s/spirv-reflect/xmake.lua
@@ -8,6 +8,7 @@ package("spirv-reflect")
     add_versions("1.2.154+1", "5de48fe8d3ef434e846d64ed758adc5d26335ae5")
     add_versions("1.2.162+0", "481e34d666031eae28423f3b723a1a8c717d7636")
     add_versions("1.2.189+1", "272e050728de8d4a4ce9e7101c1244e6ff56e5b0")
+    add_versions("1.3.224+1", "b68b5a8a5d8ab5fce79e6596f3a731291046393a")
 
     add_deps("spirv-headers")
 

--- a/packages/v/vulkan-headers/xmake.lua
+++ b/packages/v/vulkan-headers/xmake.lua
@@ -6,6 +6,7 @@ package("vulkan-headers")
     set_license("Apache-2.0")
 
     add_urls("https://github.com/KhronosGroup/Vulkan-Headers/archive/$(version).tar.gz", {version = function (version) return version:startswith("v") and version or "sdk-" .. version:gsub("%+", ".") end})
+    add_versions("1.3.224+1", "628bd5943c0d007c192769480e789801a088f892445c80cb336fc9b6d236c5ef")
     add_versions("1.3.211+0", "c464bcdc24b7541ac4378a270617a23d4d92699679a73f95dc4b9e1da924810a")
     add_versions("1.2.198+0", "34782c61cad9b3ccf2fa0a31ec397d4fce99490500b4f3771cb1a48713fece80")
     add_versions("1.2.189+1", "ce2eb5995dddd8ff2cee897ab91c30a35d6096d5996fc91cec42bfb37112d3f8")

--- a/packages/v/vulkan-hpp/xmake.lua
+++ b/packages/v/vulkan-hpp/xmake.lua
@@ -8,6 +8,7 @@ package("vulkan-hpp")
     add_versions("v1.2.180", "bfa6d4765212505c8241a44b97dc5a9ce3aa2969")
     add_versions("v1.2.189", "58ff1da4c03f5f124eb835f41a9dd8fe3c2e8087")
     add_versions("v1.2.198", "d8c9f4f0eee6972622a1c3aabab5ed558d37c1c0")
+    add_versions("v1.3.224", "1a64b5fcc0c0227ea55e42cd7d07c2ebeadf781b")
 
     add_deps("cmake")
 

--- a/packages/v/vulkan-loader/xmake.lua
+++ b/packages/v/vulkan-loader/xmake.lua
@@ -5,6 +5,7 @@ package("vulkan-loader")
     set_license("Apache-2.0")
 
     add_urls("https://github.com/KhronosGroup/Vulkan-Loader/archive/sdk-$(version).tar.gz", {version = function (version) return version:gsub("%+", ".") end})
+    add_versions("1.3.224+1", "4d54b1489faa42d309e5d1e34d6655a9587ad988e99bb2a2ce0e357844f2cb2d")
     add_versions("1.2.198+0", "7d5d56296dcd88af84ed0fde969038370cac8600c4ef7e328788b7422d9025bb")
     add_versions("1.2.189+1", "1d9f539154d37cea0ca336341c3b25e73d5a5320f2f9c9c55f8309422fe6ec3c")
     add_versions("1.2.182+0", "7088fb6922a3af41efd0499b8e66e971164da1e583410d29f801f991a31b180c")

--- a/packages/v/vulkan-tools/xmake.lua
+++ b/packages/v/vulkan-tools/xmake.lua
@@ -6,6 +6,7 @@ package("vulkan-tools")
     set_license("Apache-2.0")
 
     add_urls("https://github.com/KhronosGroup/Vulkan-Tools/archive/sdk-$(version).tar.gz", {version = function (version) return version:gsub("%+", ".") end})
+    add_versions("1.3.224+1", "fa88ab7a542cc3ec05d22316ffedce7c058350efe79ec5e019c405ab268d17a0")
     add_versions("1.2.198+0", "06e174bca7834df73dc6ce3c2a72ab3bc34b63e16fdb9a486bf1315f02768032")
     add_versions("1.2.189+1", "ef5db0934ff7192657bbfc675f6e3e1ee009f2ad34aab915d2bd9993a59add81")
     add_versions("1.2.162+0", "8324a6dfd1bc20d4fad45c4ea56357d8354fc03e3e4529d0a4919f124d9e6106")

--- a/packages/v/vulkan-validationlayers/xmake.lua
+++ b/packages/v/vulkan-validationlayers/xmake.lua
@@ -8,12 +8,14 @@ package("vulkan-validationlayers")
         add_urls("https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases/download/sdk-$(version)/android-binaries-$(version).tar.gz",
         {version = function (version) return version:gsub("%+", ".") end})
 
+        add_versions("1.3.224+1", "da8ff61ebec3e21ff080779e30258240d5ec2f19f9b495aca83c477a47c1643c")
         add_versions("1.2.198+0", "5436e974d6b3133b3454edf1910f76b9f869db8bbe086859b2abe32fdb539cbc")
         add_versions("1.2.189+1", "b3e69b60a67a17b023825f9eb0ce1aef22e6b59d095afa204d883a9ce3d81021")
     else
         add_urls("https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/sdk-$(version).tar.gz",
         {version = function (version) return version:gsub("%+", ".") end})
 
+        add_versions("1.3.224+1", "49c00e0119e3bc11e13c0c740e57c76b582b14f754f3779b85508c4d90d9df85")
         add_versions("1.2.198+0", "4a70cc5da26baf873fcf69b081eeeda545515dd66e5904f18fee32b4d275593a")
         add_versions("1.2.189+1", "d169ae71ae3ba12159df355b58f86f5635062c695d1deac9b97d5653561d517d")
         add_versions("1.2.182+0", "e88492143c8b08154807e7ead0ac784365b14464bb5016c2800cbff176ff61e7")
@@ -33,12 +35,15 @@ package("vulkan-validationlayers")
         end
     end
 
+    add_links("")
+
     on_load("windows", "linux", function (package)
         local sdkver = package:version():split("%+")[1]
         package:add("deps", "vulkan-headers " .. sdkver)
         if package:version():ge("1.2.189") then
             package:add("deps", "robin-hood-hashing")
         end
+        package:addenv("VK_LAYER_PATH", "lib")
     end)
 
     on_install("windows", "linux", function (package)
@@ -89,7 +94,5 @@ package("vulkan-validationlayers")
             assert(os.isfile(path.join(package:installdir("lib"), "x86", "libVkLayer_khronos_validation.so")))
             assert(os.isfile(path.join(package:installdir("lib"), "armeabi-v7a", "libVkLayer_khronos_validation.so")))
             assert(os.isfile(path.join(package:installdir("lib"), "arm64-v8a", "libVkLayer_khronos_validation.so")))
-        else
-            assert(package:has_cxxfuncs("getLayerOption", {includes = "layers/vk_layer_config.h"}))
         end
     end)


### PR DESCRIPTION
Added validation layers to VK_LAYER_PATH and removed link to layer library

There is still one problem where vulkan-loader won't compile on windows in debug because of the pdb generation path, but it's an issue in xmake (not xmake-repo)