### PR TITLE
Support bsd in python

### DIFF
--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -42,11 +42,11 @@ package("python")
         set_kind("binary")
     end
 
-    if is_host("macosx", "linux") then
+    if is_host("macosx", "linux", "bsd") then
         add_deps("openssl", "ca-certificates", {host = true})
     end
 
-    if is_host("linux") then
+    if is_host("linux", "bsd") then
         add_deps("libffi", "zlib", {host = true})
         add_syslinks("util", "pthread", "dl")
     end

--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -63,7 +63,7 @@ package("python")
         package:addenv("PATH", "Scripts")
     end)
 
-    on_load("@macosx", "@linux", function (package)
+    on_load("@macosx", "@linux", "@bsd", function (package)
 
         -- set includedirs
         local version = package:version()
@@ -112,7 +112,7 @@ package("python")
         os.vrunv(python, {"-m", "pip", "install", "wheel"})
     end)
 
-    on_install("@macosx", "@linux", function (package)
+    on_install("@macosx", "@bsd", "@linux", function (package)
 
         -- init configs
         local configs = {"--enable-ipv6", "--with-ensurepip", "--enable-optimizations"}


### PR DESCRIPTION
Adds support python package support for bsd

Currently it says
note: the following packages are unsupported on bsd/x86_64:
  -> python 3.9.13

but its supported according to the documentation