### PR TITLE
fix: static build for packages with shared=true as default.

### DIFF
--- a/scripts/test.lua
+++ b/scripts/test.lua
@@ -113,10 +113,10 @@ function _require_packages(argv, packages)
     if argv.mode == "debug" then
         extra.debug = true
     end
-    if argv.kind == "shared" then
-        extra.configs = extra.configs or {}
-        extra.configs.shared = true
-    end
+    -- Some packages set shared=true as default, so we need to force set
+    -- shared=false to test static build.
+    extra.configs = extra.configs or {}
+    extra.configs.shared = argv.kind == "shared"
     local configs = argv.configs
     if configs then
         extra.system  = false


### PR DESCRIPTION
libtorch 目前设置 `shared=true` 为默认值，对这种情况现有的 CI 脚本无法执行 static build。

这个改动通过总是设置 `shared` 配置来解决这个问题。

另一个问题，执行 `xrepo install --kind=static libtorch` 触发的依然是 shared build。是否 `--kind=static` 的处理有类似的问题，即假设包的 `shared` 选项默认为 `static` 因此没有再强制指定？