### PR TITLE
libtorch v1.12.1, support static linking

### DIFF
--- a/packages/l/libtorch/patches/1.12.1/clang.patch
+++ b/packages/l/libtorch/patches/1.12.1/clang.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
+index 44a8bf1211..d0f1716850 100644
+--- a/cmake/Dependencies.cmake
++++ b/cmake/Dependencies.cmake
+@@ -816,7 +816,8 @@ if(USE_FBGEMM)
+     set_property(TARGET fbgemm_avx2 PROPERTY POSITION_INDEPENDENT_CODE ON)
+     set_property(TARGET fbgemm_avx512 PROPERTY POSITION_INDEPENDENT_CODE ON)
+     set_property(TARGET fbgemm PROPERTY POSITION_INDEPENDENT_CODE ON)
+-    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13.0.0)
++    if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.1.6)
++        OR("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0.0))
+         # See https://github.com/pytorch/pytorch/issues/74352
+         target_compile_options(asmjit PRIVATE -Wno-deprecated-copy -Wno-unused-but-set-variable)
+     endif()

--- a/packages/l/libtorch/patches/1.12.1/vs2022.patch
+++ b/packages/l/libtorch/patches/1.12.1/vs2022.patch
@@ -1,0 +1,15 @@
+diff --git a/aten/src/ATen/cpu/vec/vec_base.h b/aten/src/ATen/cpu/vec/vec_base.h
+index 3bf1010efd..640c0ed109 100644
+--- a/aten/src/ATen/cpu/vec/vec_base.h
++++ b/aten/src/ATen/cpu/vec/vec_base.h
+@@ -131,8 +131,9 @@ public:
+   // versions GCC/Clang have buggy determinations on whether or not an
+   // identifier is odr-used or not, and in any case it's hard to tell if
+   // a variable is odr-used or not.  So best to just cut the problem at the root.
++  static constexpr size_type size_T = sizeof(T);  // Workaround to compile with VS2022.
+   static constexpr size_type size() {
+-    return VECTOR_WIDTH / sizeof(T);
++    return VECTOR_WIDTH / size_T;
+   }
+   Vectorized() : values{static_cast<T>(0)} {}
+   Vectorized(T val) {

--- a/packages/l/libtorch/xmake.lua
+++ b/packages/l/libtorch/xmake.lua
@@ -17,6 +17,7 @@ package("libtorch")
     add_patches("1.11.0", path.join(os.scriptdir(), "patches", "1.11.0", "gcc11.patch"), "1404b0bc6ce7433ecdc59d3412e3d9ed507bb5fd2cd59134a254d7d4a8d73012")
     -- Fix compile on macOS. Refer to https://github.com/pytorch/pytorch/pull/80916
     add_patches("1.12.1", path.join(os.scriptdir(), "patches", "1.12.1", "clang.patch"), "cdc3e00b2fea847678b1bcc6b25a4dbd924578d8fb25d40543521a09aab2f7d4")
+    add_patches("1.12.1", path.join(os.scriptdir(), "patches", "1.12.1", "vs2022.patch"), "5a31b9772793c943ca752c92d6415293f7b3863813ca8c5eb9d92a6156afd21d")
 
     add_configs("shared", {description = "Build shared library.", default = true, type = "boolean"})
     add_configs("python", {description = "Build python interface.", default = false, type = "boolean"})

--- a/packages/l/libtorch/xmake.lua
+++ b/packages/l/libtorch/xmake.lua
@@ -11,9 +11,12 @@ package("libtorch")
     add_versions("v1.9.0", "d69c22dd61a2f006dcfe1e3ea8468a3ecaf931aa")
     add_versions("v1.9.1", "dfbd030854359207cb3040b864614affeace11ce")
     add_versions("v1.11.0", "bc2c6edaf163b1a1330e37a6e34caf8c553e4755")
+    add_versions("v1.12.1", "664058fa83f1d8eede5d66418abff6e20bd76ca8")
 
     add_patches("1.9.x", path.join(os.scriptdir(), "patches", "1.9.0", "gcc11.patch"), "4191bb3296f18f040c230d7c5364fb160871962d6278e4ae0f8bc481f27d8e4b")
     add_patches("1.11.0", path.join(os.scriptdir(), "patches", "1.11.0", "gcc11.patch"), "1404b0bc6ce7433ecdc59d3412e3d9ed507bb5fd2cd59134a254d7d4a8d73012")
+    -- Fix compile on macOS. Refer to https://github.com/pytorch/pytorch/pull/80916
+    add_patches("1.12.1", path.join(os.scriptdir(), "patches", "1.12.1", "clang.patch"), "cdc3e00b2fea847678b1bcc6b25a4dbd924578d8fb25d40543521a09aab2f7d4")
 
     add_configs("shared", {description = "Build shared library.", default = true, type = "boolean"})
     add_configs("python", {description = "Build python interface.", default = false, type = "boolean"})
@@ -21,6 +24,8 @@ package("libtorch")
     add_configs("cuda",   {description = "Enable CUDA support.", default = false, type = "boolean"})
     add_configs("ninja",  {description = "Use ninja as build tool.", default = false, type = "boolean"})
     add_configs("blas",   {description = "Set BLAS vendor.", default = "openblas", type = "string", values = {"mkl", "openblas", "eigen"}})
+    add_configs("pybind11", {description = "Use pybind11 from xrepo.", default = false, type = "boolean"})
+    add_configs("protobuf-cpp", {description = "Use protobuf from xrepo.", default = false, type = "boolean"})
     if not is_plat("macosx") then
         add_configs("distributed", {description = "Enable distributed support.", default = false, type = "boolean"})
     end
@@ -55,6 +60,12 @@ package("libtorch")
         end
         if not package:is_plat("macosx") and package:config("blas") then
             package:add("deps", package:config("blas"))
+        end
+        if package:config("pybind11") then
+            package:add("deps", "pybind11")
+        end
+        if package:config("protobuf-cpp") then
+            package:add("deps", "protobuf-cpp")
         end
     end)
 
@@ -94,13 +105,20 @@ package("libtorch")
             end
         end
         if not package:config("shared") then
-            for _, lib in ipairs({"nnpack", "pytorch_qnnpack", "qnnpack", "XNNPACK", "caffe2_protos", "protobuf-lite", "protobuf", "protoc", "onnx", "onnx_proto", "foxi_loader", "pthreadpool", "eigen_blas", "fbgemm", "cpuinfo", "clog", "dnnl", "mkldnn", "sleef", "asmjit", "fmt", "kineto"}) do
+            for _, lib in ipairs({"nnpack", "pytorch_qnnpack", "qnnpack", "XNNPACK", "caffe2_protos", "protobuf-lite", "protobuf", "protoc", "onnx", "onnx_proto", "foxi_loader", "pthreadpool", "eigen_blas", "fbgemm", "cpuinfo", "clog", "dnnl_graph", "dnnl", "mkldnn", "sleef", "asmjit", "fmt", "kineto"}) do
                 package:add("links", lib)
             end
         end
 
         -- some patches to the third-party cmake files
         io.replace("third_party/fbgemm/CMakeLists.txt", "PRIVATE FBGEMM_STATIC", "PUBLIC FBGEMM_STATIC", {plain = true})
+        -- Workaround to compile with GCC-12.
+        -- Refer to [this pytorch issue](https://github.com/pytorch/pytorch/issues/77939).
+        io.replace("third_party/fbgemm/CMakeLists.txt",
+            'string(APPEND CMAKE_CXX_FLAGS " -Werror")',
+            'string(APPEND CMAKE_CXX_FLAGS " -Werror")\n  string(APPEND CMAKE_CXX_FLAGS " -Wno-uninitialized")',
+            {plain = true}
+        )
         io.replace("third_party/protobuf/cmake/install.cmake", "install%(DIRECTORY.-%)", "")
         if package:is_plat("windows") and package:config("vs_runtime"):startswith("MD") then
             io.replace("third_party/fbgemm/CMakeLists.txt", "MT", "MD", {plain = true})
@@ -142,6 +160,8 @@ package("libtorch")
         table.insert(configs, "-DUSE_CUDA=" .. (package:config("cuda") and "ON" or "OFF"))
         table.insert(configs, "-DUSE_OPENMP=" .. (package:config("openmp") and "ON" or "OFF"))
         table.insert(configs, "-DUSE_DISTRIBUTED=" .. (package:config("distributed") and "ON" or "OFF"))
+        table.insert(configs, "-DUSE_SYSTEM_PYBIND11=" .. (package:config("pybind11") and "ON" or "OFF"))
+        table.insert(configs, "-DBUILD_CUSTOM_PROTOBUF=" .. (package:config("protobuf-cpp") and "OFF" or "ON"))
         if package:is_plat("windows") then
             table.insert(configs, "-DCAFFE2_USE_MSVC_STATIC_RUNTIME=" .. (package:config("vs_runtime"):startswith("MT") and "ON" or "OFF"))
         end
@@ -151,6 +171,23 @@ package("libtorch")
             opt.cmake_generator = "Ninja"
         end
         cmake.install(package, configs, opt)
+
+        local cp_libs = {
+            -- onnx libs are not installed by cmake but are required if program uses onnx.
+            "libonnx.a", "libonnx_proto.a",
+        }
+        for _, libname in ipairs(cp_libs) do
+            os.trycp(path.join(package:buildir(), "lib", libname), package:installdir("lib"))
+        end
+
+        -- pytorch sets BUILD_ONEDNN_GRAPH to OFF in CMakeLists.txt, but
+        -- dnnl_graph is still needed for static link.
+        io.replace(
+            path.join(package:installdir("share/cmake/Torch/TorchConfig.cmake")),
+            "append_torchlib_if_found(dnnl mkldnn)",
+            "append_torchlib_if_found(dnnl_graph dnnl mkldnn)",
+            {plain = true}
+        )
     end)
 
     on_test(function (package)


### PR DESCRIPTION
Besides adding libtorch version v1.12.1, this PR makes it possible to build libtorch as static library. 

Some notes:

1. This PR keeps building libtorch as shared library by default, as disscussed in https://github.com/xmake-io/xmake-repo/pull/1502
2. ~~Static link to libtorch has some issues I haven't solved.~~
   - ~~Neither `OMP_NUM_THREADS` nor `MKL_NUM_THREADS` can control number of threads used when using static link.
     These two environment variables work fine when using shared link.~~
   - ~~The end result is worse performance because using too many threads on servers with many cores.~~
   - When link to MKL, avoid use of TBB. Mixing TBB and OpenMP is not a good idea. libtorch's cmake file comments that `USE_TBB` is deprecated.
3. According to our simple benchmark, using Intel MKL is faster than using OpenBLAS in libtorch.
   - Intel MKL is also used by the official release of libtorch.
   - After building libtorch with MKL, we get the same performance compared to linking with official prebuilt libtorch
4. Option `pybind11` and `protobuf-cpp` can build libtorch using those libraries from xrepo.
    - So we can use the same version of those libraries with our own application.
    - libtorch can use many more other libraries from system, but are currently missing in xrepo.

My debug branch have build errors for [windows build](https://github.com/cyfdecyf/xmake-repo/actions/runs/3133728637/jobs/5087430912), I need some help for fixing these errors.

This PR also have some fixes for using cmake to link with libtorch. For cmake users, here's an example to link with static built pytorch.

Create `libtorch-mkl.lua`:

```lua
add_requireconfs("libtorch.mkl", {configs = {threading = "openmp"}})
add_requires("libtorch", {configs = {blas = "mkl", shared = false}})
```

Create `CMakeLists.txt`:

```cmake
cmake_minimum_required(VERSION 3.19.0)
project(example LANGUAGES C CXX ASM)

# Download xrepo.cmake if not exists in build directory.
if(NOT EXISTS "${CMAKE_BINARY_DIR}/xrepo.cmake")
    message(STATUS "Downloading xrepo.cmake from https://github.com/xmake-io/xrepo-cmake/")
    # mirror https://cdn.jsdelivr.net/gh/xmake-io/xrepo-cmake@main/xrepo.cmake
    file(DOWNLOAD "https://raw.githubusercontent.com/xmake-io/xrepo-cmake/main/xrepo.cmake"
                  "${CMAKE_BINARY_DIR}/xrepo.cmake"
                  TLS_VERIFY ON)
endif()

xrepo_package("libtorch" CONFIGS "libtorch.lua" DIRECTORY_SCOPE DEPS)

find_package(Torch REQUIRED)
set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")

add_executable(main main.cpp)
target_link_libraries(main PRIVATE ${TORCH_LIBRARIES})
# Link with libomp
target_link_libraries(main PRIVATE -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -Wl,--end-group -lomp -ldl)
# Or link with libgomp
# target_link_libraries(main PRIVATE -Wl,--start-group -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -Wl,--end-group -lgomp -ldl)
```