### PR TITLE
Fix ImGui-SFML on macosx

### DIFF
--- a/packages/i/imgui-sfml/patches/v2.5/macosx.patch
+++ b/packages/i/imgui-sfml/patches/v2.5/macosx.patch
@@ -1,7 +1,46 @@
-diff --git CMakeLists.txt CMakeLists.txt
---- CMakeLists.txt
-+++ CMakeLists.txt
-@@ -164,6 +165,9 @@
+diff --git "a/CMakeLists.txt" "b/CMakesLists.txt"
+index 3e06336..73a3636 100644
+--- "a/CMakeLists.txt"
++++ "b/CMakesLists.txt"
+@@ -38,14 +38,14 @@ set(IMGUI_SFML_CONFIG_INSTALL_DIR "" CACHE PATH "Path where user's config header
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+ 
+ if (IMGUI_SFML_FIND_SFML)
+-	if (NOT BUILD_SHARED_LIBS)
+-		set(SFML_STATIC_LIBRARIES ON)
+-	endif()
+-	find_package(SFML 2.5 COMPONENTS graphics system window)
++  if (NOT BUILD_SHARED_LIBS)
++    set(SFML_STATIC_LIBRARIES ON)
++  endif()
++  find_package(SFML 2.5 COMPONENTS graphics system window)
+ 
+-	if(NOT SFML_FOUND)
++  if(NOT SFML_FOUND)
+     message(FATAL_ERROR "SFML 2 directory not found. Set SFML_DIR to directory where SFML was built (or one which ccontains SFMLConfig.cmake)")
+-	endif()
++  endif()
+ endif()
+ 
+ # ImGui does not provide native support for CMakeLists, workaround for now to have
+@@ -71,14 +71,14 @@ set(IMGUI_PUBLIC_HEADERS
+ )
+ 
+ if (IMGUI_SFML_IMGUI_DEMO)
+-    list(APPEND IMGUI_SOURCES ${IMGUI_DEMO_SOURCES})
++  list(APPEND IMGUI_SOURCES ${IMGUI_DEMO_SOURCES})
+ endif()
+ 
+ # CMake 3.11 and later prefer to choose GLVND, but we choose legacy OpenGL just because it's safer
+ # (unless the OpenGL_GL_PREFERENCE was explicitly set)
+ # See CMP0072 for more details (cmake --help-policy CMP0072)
+ if ((NOT ${CMAKE_VERSION} VERSION_LESS 3.11) AND (NOT OpenGL_GL_PREFERENCE))
+-    set(OpenGL_GL_PREFERENCE "LEGACY")
++  set(OpenGL_GL_PREFERENCE "LEGACY")
+ endif()
+ 
+ find_package(OpenGL REQUIRED)
+@@ -164,6 +164,9 @@ set_target_properties(ImGui-SFML PROPERTIES
    PUBLIC_HEADER "${IMGUI_SFML_PUBLIC_HEADERS}"
  )
  

--- a/packages/i/imgui-sfml/patches/v2.5/macosx.patch
+++ b/packages/i/imgui-sfml/patches/v2.5/macosx.patch
@@ -1,6 +1,6 @@
-diff --git CMakeLists.txt
---- CMakeLists.txt	2022-10-04 20:01:23.821330724 +0000
-+++ CMakeLists.txt	2022-10-04 19:46:28.639576320 +0000
+diff --git CMakeLists.txt CMakeLists.txt
+--- CMakeLists.txt
++++ CMakeLists.txt
 @@ -164,6 +165,9 @@
    PUBLIC_HEADER "${IMGUI_SFML_PUBLIC_HEADERS}"
  )

--- a/packages/i/imgui-sfml/patches/v2.5/macosx.patch
+++ b/packages/i/imgui-sfml/patches/v2.5/macosx.patch
@@ -1,6 +1,6 @@
 diff --git CMakeLists.txt
---- /home/charlie/Documents/CMakeLists_1.txt	2022-10-04 20:01:23.821330724 +0000
-+++ /home/charlie/Documents/CMakeLists.txt	2022-10-04 19:46:28.639576320 +0000
+--- CMakeLists.txt	2022-10-04 20:01:23.821330724 +0000
++++ CMakeLists.txt	2022-10-04 19:46:28.639576320 +0000
 @@ -164,6 +165,9 @@
    PUBLIC_HEADER "${IMGUI_SFML_PUBLIC_HEADERS}"
  )

--- a/packages/i/imgui-sfml/patches/v2.5/macosx.patch
+++ b/packages/i/imgui-sfml/patches/v2.5/macosx.patch
@@ -1,0 +1,13 @@
+diff --git CMakeLists.txt
+--- /home/charlie/Documents/CMakeLists_1.txt	2022-10-04 20:01:23.821330724 +0000
++++ /home/charlie/Documents/CMakeLists.txt	2022-10-04 19:46:28.639576320 +0000
+@@ -164,6 +165,9 @@
+   PUBLIC_HEADER "${IMGUI_SFML_PUBLIC_HEADERS}"
+ )
+ 
++# Set minimum required standard
++target_compile_features(ImGui-SFML PUBLIC cxx_std_11)
++
+ if(IMGUI_SFML_BUILD_EXAMPLES)
+   add_subdirectory(examples)
+ endif()

--- a/packages/i/imgui-sfml/xmake.lua
+++ b/packages/i/imgui-sfml/xmake.lua
@@ -7,7 +7,7 @@ package("imgui-sfml")
              "https://github.com/eliasdaler/imgui-sfml.git")
 
     add_versions("v2.5", "3775c9303f656297f2392e91ffae2021e874ee319b4139c60076d6f757ede109")
-    add_patches("v2.5", path.join(os.scriptdir(), "patches", "v2.5", "macosx.patch"), "bd43b76c041da5776aac54e946b561ac48ad1ad6f21c51586dfec0a9ab2d7264")
+    add_patches("v2.5", path.join(os.scriptdir(), "patches", "v2.5", "macosx.patch"), "5e4440802a58285b960bc1f6faa14a8d7b7fbe93b19dd88465059f982556b59a")
 
     add_deps("cmake")
     add_deps("imgui", {system = false, private = true})

--- a/packages/i/imgui-sfml/xmake.lua
+++ b/packages/i/imgui-sfml/xmake.lua
@@ -7,6 +7,7 @@ package("imgui-sfml")
              "https://github.com/eliasdaler/imgui-sfml.git")
 
     add_versions("v2.5", "3775c9303f656297f2392e91ffae2021e874ee319b4139c60076d6f757ede109")
+    add_patches("v2.5", path.join(os.scriptdir(), "patches", "v2.5", "macosx.patch"), de825d88e5a232c781c43c2b323c6ccc7e4c53033f005d186b52f0b981cf273e)
 
     add_deps("cmake")
     add_deps("imgui", {system = false, private = true})

--- a/packages/i/imgui-sfml/xmake.lua
+++ b/packages/i/imgui-sfml/xmake.lua
@@ -7,7 +7,7 @@ package("imgui-sfml")
              "https://github.com/eliasdaler/imgui-sfml.git")
 
     add_versions("v2.5", "3775c9303f656297f2392e91ffae2021e874ee319b4139c60076d6f757ede109")
-    add_patches("v2.5", path.join(os.scriptdir(), "patches", "v2.5", "macosx.patch"), de825d88e5a232c781c43c2b323c6ccc7e4c53033f005d186b52f0b981cf273e)
+    add_patches("v2.5", path.join(os.scriptdir(), "patches", "v2.5", "macosx.patch"), 4b493d45df41b6ce35c13a0434cf61b34886b4bbb315bfd5c2b7c5c9522246f6)
 
     add_deps("cmake")
     add_deps("imgui", {system = false, private = true})

--- a/packages/i/imgui-sfml/xmake.lua
+++ b/packages/i/imgui-sfml/xmake.lua
@@ -7,7 +7,7 @@ package("imgui-sfml")
              "https://github.com/eliasdaler/imgui-sfml.git")
 
     add_versions("v2.5", "3775c9303f656297f2392e91ffae2021e874ee319b4139c60076d6f757ede109")
-    add_patches("v2.5", path.join(os.scriptdir(), "patches", "v2.5", "macosx.patch"), "4b493d45df41b6ce35c13a0434cf61b34886b4bbb315bfd5c2b7c5c9522246f6")
+    add_patches("v2.5", path.join(os.scriptdir(), "patches", "v2.5", "macosx.patch"), "bd43b76c041da5776aac54e946b561ac48ad1ad6f21c51586dfec0a9ab2d7264")
 
     add_deps("cmake")
     add_deps("imgui", {system = false, private = true})

--- a/packages/i/imgui-sfml/xmake.lua
+++ b/packages/i/imgui-sfml/xmake.lua
@@ -7,7 +7,7 @@ package("imgui-sfml")
              "https://github.com/eliasdaler/imgui-sfml.git")
 
     add_versions("v2.5", "3775c9303f656297f2392e91ffae2021e874ee319b4139c60076d6f757ede109")
-    add_patches("v2.5", path.join(os.scriptdir(), "patches", "v2.5", "macosx.patch"), 4b493d45df41b6ce35c13a0434cf61b34886b4bbb315bfd5c2b7c5c9522246f6)
+    add_patches("v2.5", path.join(os.scriptdir(), "patches", "v2.5", "macosx.patch"), "4b493d45df41b6ce35c13a0434cf61b34886b4bbb315bfd5c2b7c5c9522246f6")
 
     add_deps("cmake")
     add_deps("imgui", {system = false, private = true})


### PR DESCRIPTION
Just add a patch file for ImGui-SFML because it doesn't work on macosx. This is my log when I do xmake -vDy :

[out.log](https://github.com/xmake-io/xmake-repo/files/9710234/out.log)

Normally this line in the CMakeFiles.txt will fix the issue