### PR TITLE
add aws-sdk-cpp

### DIFF
--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -6,7 +6,7 @@ package("aws-sdk-cpp")
     add_versions("1.9.362", "e9372218a2c8fab756ecaa6e4fefcdb33c3670c1")
 
     if is_plat("macosx") then
-        add_frameworks("SystemConfiguration")
+        add_frameworks("Foundation", "CoreFoundation", "SystemConfiguration")
     end
 
     add_configs("build_only",  {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -6,11 +6,11 @@ package("aws-sdk-cpp")
     add_versions("1.9.362", "e9372218a2c8fab756ecaa6e4fefcdb33c3670c1")
 
     add_configs("build_only",  {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
-    add_configs("http_client", {description = 'If disabled, no platform-default http client will be included in the library.', default = false, type = "boolean"})
+    add_configs("http_client", {description = 'If disabled, no platform-default http client will be included in the library.', default = true, type = "boolean"})
     add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = false, type = "boolean"})
 
     add_deps("zlib")
-    add_deps("cmake")
+    add_deps("cmake", "ninja")
 
     on_load(function (package)
         if package:config("http_client") then
@@ -31,7 +31,7 @@ package("aws-sdk-cpp")
         if package:config("build_only") then
             table.insert(configs, "-DBUILD_ONLY=" .. package:config("build_only"))
         end
-        import("package.tools.cmake").install(package, configs)
+        import("package.tools.cmake").install(package, configs, {cmake_generator = "Ninja"})
     end)
 
     on_test(function (package)

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -7,7 +7,7 @@ package("aws-sdk-cpp")
 
     add_configs("build_only", {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
     add_deps("cmake")
-    add_deps("curl")
+    add_deps("libcurl")
 
     on_install("linux", "macosx", function (package)
         local configs = {}

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -10,7 +10,7 @@ package("aws-sdk-cpp")
     add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = false, type = "boolean"})
 
     add_deps("zlib")
-    add_deps("cmake", "ninja")
+    add_deps("cmake")
 
     on_load(function (package)
         if package:config("http_client") then
@@ -31,7 +31,7 @@ package("aws-sdk-cpp")
         if package:config("build_only") then
             table.insert(configs, "-DBUILD_ONLY=" .. package:config("build_only"))
         end
-        import("package.tools.cmake").install(package, configs, {cmake_generator = "Ninja"})
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -7,6 +7,7 @@ package("aws-sdk-cpp")
 
     add_configs("build_only", {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
     add_deps("cmake")
+    add_deps("curl")
 
     on_install("linux", "macosx", function (package)
         local configs = {}

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -5,13 +5,9 @@ package("aws-sdk-cpp")
     add_urls("https://github.com/aws/aws-sdk-cpp.git")
     add_versions("1.9.362", "e9372218a2c8fab756ecaa6e4fefcdb33c3670c1")
 
-    if is_plat("macosx") then
-        add_frameworks("Foundation", "CoreFoundation", "Security", "SystemConfiguration")
-    end
-
     add_configs("build_only",  {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
     add_configs("http_client", {description = 'If disabled, no platform-default http client will be included in the library.', default = true, type = "boolean"})
-    add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = true, type = "boolean"})
+    add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = false, type = "boolean"})
 
     add_deps("zlib")
     add_deps("cmake")
@@ -26,16 +22,6 @@ package("aws-sdk-cpp")
     end)
 
     on_install("linux", "macosx", function (package)
-        local configs = {"-DENABLE_TESTING=OFF", "-DAUTORUN_UNIT_TESTS=OFF"}
-        table.insert(configs, "-DMINIMIZE_SIZE=ON")
-        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        table.insert(configs, "-DNO_HTTP_CLIENT=" .. (package:config("http_client") and "OFF" or "ON"))
-        table.insert(configs, "-DNO_ENCRYPTION=" .. (package:config("encryption") and "OFF" or "ON"))
-        if package:config("build_only") then
-            table.insert(configs, "-DBUILD_ONLY=" .. package:config("build_only"))
-        end
-
         io.replace("cmake/Findcrypto.cmake",
             "if (BUILD_SHARED_LIBS)\n            set(crypto_LIBRARY ${crypto_SHARED_LIBRARY})",
             [[
@@ -46,7 +32,21 @@ package("aws-sdk-cpp")
                         set(crypto_LIBRARY ${crypto_STATIC_LIBRARY})
                     endif()
             ]], {plain = true})
-        import("package.tools.cmake").install(package, configs)
+        local configs = {"-DENABLE_TESTING=OFF", "-DAUTORUN_UNIT_TESTS=OFF"}
+        table.insert(configs, "-DMINIMIZE_SIZE=ON")
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        table.insert(configs, "-DNO_HTTP_CLIENT=" .. (package:config("http_client") and "OFF" or "ON"))
+        table.insert(configs, "-DNO_ENCRYPTION=" .. (package:config("encryption") and "OFF" or "ON"))
+        if package:config("build_only") then
+            table.insert(configs, "-DBUILD_ONLY=" .. package:config("build_only"))
+        end
+        if package:config("http_client") and package:is_plat("macosx") then
+            local exflags = {"-framework", "CoreFoundation", "-framework", "Security", "-framework", "SystemConfiguration"}
+            import("package.tools.cmake").install(package, configs, {shflags = exflags, ldflags = exflags})
+        else
+            import("package.tools.cmake").install(package, configs)
+        end
     end)
 
     on_test(function (package)

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -5,12 +5,26 @@ package("aws-sdk-cpp")
     add_urls("https://github.com/aws/aws-sdk-cpp.git")
     add_versions("1.9.333", "6ec095fa11379174da20bf1523c93c92503eb8e2")
 
-    add_configs("build_only", {description = 'By default, all SDKS are built, if AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
+    add_configs("build_only", {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
     add_deps("cmake")
+
     on_install("linux", "macosx", function (package)
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        table.insert(configs, "-DBUILD_ONLY=" .. (package:config("build_only") or ""))
+        if package:config("build_only") then
+            table.insert(configs, "-DBUILD_ONLY=" .. package:config("build_only"))
+        end
         import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({
+            test = [[
+              #include <aws/core/Aws.h>
+              static void test() {
+                Aws::SDKOptions options;
+              }
+            ]]
+        }, {configs = {languages = "c++11"}}))
     end)

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -11,14 +11,14 @@ package("aws-sdk-cpp")
 
     add_configs("build_only",  {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
     add_configs("http_client", {description = 'If disabled, no platform-default http client will be included in the library.', default = true, type = "boolean"})
-    add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = true, type = "boolean"})
+    add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = false, type = "boolean"})
 
     add_deps("zlib")
     add_deps("cmake")
 
     on_load(function (package)
         if package:config("http_client") then
-            package:add("deps", "libcurl", {configs = {openssl = false}})
+            package:add("deps", "libcurl")
         end
         if package:config("encryption") then
             package:add("deps", "openssl")

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -5,6 +5,10 @@ package("aws-sdk-cpp")
     add_urls("https://github.com/aws/aws-sdk-cpp.git")
     add_versions("1.9.362", "e9372218a2c8fab756ecaa6e4fefcdb33c3670c1")
 
+    if is_plat("macosx") then
+        add_frameworks("SystemConfiguration")
+    end
+
     add_configs("build_only",  {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
     add_configs("http_client", {description = 'If disabled, no platform-default http client will be included in the library.', default = true, type = "boolean"})
     add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = true, type = "boolean"})

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -6,8 +6,9 @@ package("aws-sdk-cpp")
     add_versions("1.9.333", "6ec095fa11379174da20bf1523c93c92503eb8e2")
 
     add_configs("build_only", {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
-    add_deps("cmake")
+    add_deps("zlib")
     add_deps("libcurl")
+    add_deps("cmake")
 
     on_install("linux", "macosx", function (package)
         local configs = {}

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -5,6 +5,10 @@ package("aws-sdk-cpp")
     add_urls("https://github.com/aws/aws-sdk-cpp.git")
     add_versions("1.9.362", "e9372218a2c8fab756ecaa6e4fefcdb33c3670c1")
 
+    if is_plat("macosx") then
+        add_frameworks("Foundation", "CoreFoundation", "Security", "SystemConfiguration")
+    end
+
     add_configs("build_only",  {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
     add_configs("http_client", {description = 'If disabled, no platform-default http client will be included in the library.', default = true, type = "boolean"})
     add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = false, type = "boolean"})

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -31,7 +31,7 @@ package("aws-sdk-cpp")
         if package:config("build_only") then
             table.insert(configs, "-DBUILD_ONLY=" .. package:config("build_only"))
         end
-        import("package.tools.cmake").install(package, configs, {jobs = 1})
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -15,7 +15,7 @@ package("aws-sdk-cpp")
     on_load(function (package)
         if package:config("http_client") then
             package:add("deps", "libcurl")
-            if is_plat("macosx") then
+            if package:is_plat("macosx") then
                 add_frameworks("Foundation", "CoreFoundation", "Security", "SystemConfiguration")
             end
         end

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -6,17 +6,15 @@ package("aws-sdk-cpp")
     add_versions("1.9.362", "e9372218a2c8fab756ecaa6e4fefcdb33c3670c1")
 
     add_configs("build_only", {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
+
     add_deps("libcurl", "openssl", "zlib")
     add_deps("cmake")
 
     on_install("linux", "macosx", function (package)
-        local configs = {}
+        local configs = {"-DENABLE_TESTING=OFF", "-DAUTORUN_UNIT_TESTS=OFF"}
         table.insert(configs, "-DMINIMIZE_SIZE=ON")
-        table.insert(configs, "-DCMAKE_PREFIX_PATH=" .. package:installdir())
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        table.insert(configs, "-DENABLE_TESTING=" .. (package:config("enable_testing") and "ON" or "OFF"))
-        table.insert(configs, "-DAUTORUN_UNIT_TESTS=" .. (package:config("autorun_unit_tests") and "ON" or "OFF"))
         if package:config("build_only") then
             table.insert(configs, "-DBUILD_ONLY=" .. package:config("build_only"))
         end

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -6,12 +6,12 @@ package("aws-sdk-cpp")
     add_versions("1.9.362", "e9372218a2c8fab756ecaa6e4fefcdb33c3670c1")
 
     if is_plat("macosx") then
-        add_frameworks("Foundation", "CoreFoundation", "SystemConfiguration")
+        add_frameworks("Foundation", "CoreFoundation", "Security", "SystemConfiguration")
     end
 
     add_configs("build_only",  {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
     add_configs("http_client", {description = 'If disabled, no platform-default http client will be included in the library.', default = true, type = "boolean"})
-    add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = false, type = "boolean"})
+    add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = true, type = "boolean"})
 
     add_deps("zlib")
     add_deps("cmake")

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -16,7 +16,7 @@ package("aws-sdk-cpp")
         if package:config("http_client") then
             package:add("deps", "libcurl")
             if package:is_plat("macosx") then
-                add_frameworks("Foundation", "CoreFoundation", "Security", "SystemConfiguration")
+                package:add("frameworks", "Foundation", "CoreFoundation", "Security", "SystemConfiguration")
             end
         end
         if package:config("encryption") then

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -15,6 +15,9 @@ package("aws-sdk-cpp")
     on_load(function (package)
         if package:config("http_client") then
             package:add("deps", "libcurl")
+            if is_plat("macosx") then
+                add_frameworks("Foundation", "CoreFoundation", "Security", "SystemConfiguration")
+            end
         end
         if package:config("encryption") then
             package:add("deps", "openssl")

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -5,10 +5,6 @@ package("aws-sdk-cpp")
     add_urls("https://github.com/aws/aws-sdk-cpp.git")
     add_versions("1.9.362", "e9372218a2c8fab756ecaa6e4fefcdb33c3670c1")
 
-    if is_plat("macosx") then
-        add_frameworks("Foundation", "CoreFoundation", "Security", "SystemConfiguration")
-    end
-
     add_configs("build_only",  {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
     add_configs("http_client", {description = 'If disabled, no platform-default http client will be included in the library.', default = true, type = "boolean"})
     add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = false, type = "boolean"})

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -7,7 +7,7 @@ package("aws-sdk-cpp")
 
     add_configs("build_only",  {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
     add_configs("http_client", {description = 'If disabled, no platform-default http client will be included in the library.', default = true, type = "boolean"})
-    add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = false, type = "boolean"})
+    add_configs("encryption",  {description = 'If disabled, no platform-default encryption will be included in the library.', default = true, type = "boolean"})
 
     add_deps("zlib")
     add_deps("cmake")
@@ -31,6 +31,17 @@ package("aws-sdk-cpp")
         if package:config("build_only") then
             table.insert(configs, "-DBUILD_ONLY=" .. package:config("build_only"))
         end
+
+        io.replace("cmake/Findcrypto.cmake",
+            "if (BUILD_SHARED_LIBS)\n            set(crypto_LIBRARY ${crypto_SHARED_LIBRARY})",
+            [[
+                if (BUILD_SHARED_LIBS)
+                    if (crypto_SHARED_LIBRARY)
+                        set(crypto_LIBRARY ${crypto_SHARED_LIBRARY})
+                    else()
+                        set(crypto_LIBRARY ${crypto_STATIC_LIBRARY})
+                    endif()
+            ]], {plain = true})
         import("package.tools.cmake").install(package, configs)
     end)
 
@@ -44,4 +55,3 @@ package("aws-sdk-cpp")
             ]]
         }, {configs = {languages = "c++11"}}))
     end)
-

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -1,0 +1,16 @@
+package("aws-sdk-cpp")
+    set_homepage("https://github.com/aws/aws-sdk-cpp")
+    set_description("AWS SDK for C++")
+
+    add_urls("https://github.com/aws/aws-sdk-cpp.git")
+    add_versions("1.9.333", "6ec095fa11379174da20bf1523c93c92503eb8e2")
+
+    add_configs("build_only", {description = 'By default, all SDKS are built, if AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
+    add_deps("cmake")
+    on_install("linux", "macosx", function (package)
+        local configs = {}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        table.insert(configs, "-DBUILD_ONLY=" .. (package:config("build_only") or ""))
+        import("package.tools.cmake").install(package, configs)
+    end)

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -31,7 +31,7 @@ package("aws-sdk-cpp")
         if package:config("build_only") then
             table.insert(configs, "-DBUILD_ONLY=" .. package:config("build_only"))
         end
-        import("package.tools.cmake").install(package, configs)
+        import("package.tools.cmake").install(package, configs, {jobs = 1})
     end)
 
     on_test(function (package)

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -6,14 +6,15 @@ package("aws-sdk-cpp")
     add_versions("1.9.333", "6ec095fa11379174da20bf1523c93c92503eb8e2")
 
     add_configs("build_only", {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
-    add_deps("zlib")
-    add_deps("libcurl")
+    add_deps("libcurl", "openssl", "zlib")
     add_deps("cmake")
 
     on_install("linux", "macosx", function (package)
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_TESTING=" .. (package:config("enable_testing") and "ON" or "OFF"))
+        table.insert(configs, "-DAUTORUN_UNIT_TESTS=" .. (package:config("autorun_unit_tests") and "ON" or "OFF"))
         if package:config("build_only") then
             table.insert(configs, "-DBUILD_ONLY=" .. package:config("build_only"))
         end

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -18,7 +18,7 @@ package("aws-sdk-cpp")
 
     on_load(function (package)
         if package:config("http_client") then
-            package:add("deps", "libcurl")
+            package:add("deps", "libcurl", {configs = {openssl = false}})
         end
         if package:config("encryption") then
             package:add("deps", "openssl")

--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -3,7 +3,7 @@ package("aws-sdk-cpp")
     set_description("AWS SDK for C++")
 
     add_urls("https://github.com/aws/aws-sdk-cpp.git")
-    add_versions("1.9.333", "6ec095fa11379174da20bf1523c93c92503eb8e2")
+    add_versions("1.9.362", "e9372218a2c8fab756ecaa6e4fefcdb33c3670c1")
 
     add_configs("build_only", {description = 'By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.'})
     add_deps("libcurl", "openssl", "zlib")
@@ -11,6 +11,8 @@ package("aws-sdk-cpp")
 
     on_install("linux", "macosx", function (package)
         local configs = {}
+        table.insert(configs, "-DMINIMIZE_SIZE=ON")
+        table.insert(configs, "-DCMAKE_PREFIX_PATH=" .. package:installdir())
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DENABLE_TESTING=" .. (package:config("enable_testing") and "ON" or "OFF"))


### PR DESCRIPTION
* By default, all SDKS are built, if only AWS S3 is required, then set build_only="s3", with multiple SDKS separated by commas.

------

* 默认情况下，构建所有的SDK，如果只需要AWS S3，那么设置build_only=" s3 "，多个SDK用逗号分隔。
