### PR TITLE
开启mbedtls时需要链接advapi32

### DIFF
--- a/packages/l/libhv/xmake.lua
+++ b/packages/l/libhv/xmake.lua
@@ -32,6 +32,8 @@ package("libhv")
         add_syslinks("pthread")
     elseif is_plat("macosx", "iphoneos") then
         add_frameworks("CoreFoundation", "Security")
+    elseif is_plat("windows") then
+        add_syslinks("advapi32")
     end
 
     add_deps("cmake")


### PR DESCRIPTION
https://github.com/xmake-io/xmake-repo/issues/1535
本地已测试
![image](https://user-images.githubusercontent.com/97490782/196018696-7e647ab3-dbc3-47c8-a3be-29ca8696c06d.png)
