### PR TITLE
Add -static-libstdc++ ldflag

### DIFF
--- a/packages/b/brpc/xmake.lua
+++ b/packages/b/brpc/xmake.lua
@@ -15,6 +15,7 @@ package("brpc")
         add_ldflags("-Wl,-U,_ProfilerStart", "-Wl,-U,_ProfilerStop")
     elseif is_plat("linux") then
         add_syslinks("rt", "dl")
+        add_ldflags("-static-libstdc++")
     end
 
     on_install("linux", "macosx", function (package)


### PR DESCRIPTION
* Github Action ci/cd之后时常遇到与生产环境libstdc++版本差异造成无法运行的情况，加上此选项，方便多机部署