### PR TITLE
[commonlibsse-ng] Improve `clang-cl` support

### DIFF
--- a/packages/c/commonlibsse-ng/port/xmake.lua
+++ b/packages/c/commonlibsse-ng/port/xmake.lua
@@ -83,39 +83,45 @@ target("CommonLibSSE")
     set_pcxxheader("include/SKSE/Impl/PCH.h")
 
     -- add defines
-    if is_plat("windows") then
-        add_defines("WIN32_LEAN_AND_MEAN", "NOMINMAX", "UNICODE", "_UNICODE")
-    end
+    add_defines("WIN32_LEAN_AND_MEAN", "NOMINMAX", "UNICODE", "_UNICODE")
 
     -- add flags
-    if is_plat("windows") then
-        add_cxflags("/permissive-", "/EHsc", "/W4", "/WX")
-        add_cxflags("/MP", "/Zc:preprocessor", "/external:anglebrackets", "/external:W0", "/bigobj")
-    end
+    add_cxxflags("/permissive-")
 
-    -- warnings -> errors
-    add_cxflags("/we4715") -- `function` : not all control paths return a value
+    on_config(function(target)
+        if target:has_tool("cxx", "cl") then
+            target:add("cxxflags", "/Zc:preprocessor", "/external:W0", "/bigobj")
 
-    -- disable warnings
-    add_cxflags("/wd4005") -- macro redefinition
-    add_cxflags("/wd4061") -- enumerator `identifier` in switch of enum `enumeration` is not explicitly handled by a case label
-    add_cxflags("/wd4200") -- nonstandard extension used : zero-sized array in struct/union
-    add_cxflags("/wd4201") -- nonstandard extension used : nameless struct/union
-    add_cxflags("/wd4265") -- 'type': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly
-    add_cxflags("/wd4266") -- 'function' : no override available for virtual member function from base 'type'; function is hidden
-    add_cxflags("/wd4371") -- 'classname': layout of class may have changed from a previous version of the compiler due to better packing of member 'member'
-    add_cxflags("/wd4514") -- 'function' : unreferenced inline function has been removed
-    add_cxflags("/wd4582") -- 'type': constructor is not implicitly called
-    add_cxflags("/wd4583") -- 'type': destructor is not implicitly called
-    add_cxflags("/wd4623") -- 'derived class' : default constructor was implicitly defined as deleted because a base class default constructor is inaccessible or deleted
-    add_cxflags("/wd4625") -- 'derived class' : copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted
-    add_cxflags("/wd4626") -- 'derived class' : assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted
-    add_cxflags("/wd4710") -- 'function' : function not inlined
-    add_cxflags("/wd4711") -- function 'function' selected for inline expansion
-    add_cxflags("/wd4820") -- 'bytes' bytes padding added after construct 'member_name'
-    add_cxflags("/wd5026") -- 'type': move constructor was implicitly defined as deleted
-    add_cxflags("/wd5027") -- 'type': move assignment operator was implicitly defined as deleted
-    add_cxflags("/wd5045") -- compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
-    add_cxflags("/wd5053") -- support for 'explicit(<expr>)' in C++17 and earlier is a vendor extension
-    add_cxflags("/wd5204") -- 'type-name': class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
-    add_cxflags("/wd5220") -- 'member': a non-static data member with a volatile qualified type no longer implies that compiler generated copy / move constructors and copy / move assignment operators are not trivial
+            -- warnings -> errors
+            target:add("cxxflags", "/we4715") -- `function` : not all control paths return a value
+
+            -- disable warnings
+            target:add("cxxflags", "/wd4005") -- macro redefinition
+            target:add("cxxflags", "/wd4061") -- enumerator `identifier` in switch of enum `enumeration` is not explicitly handled by a case label
+            target:add("cxxflags", "/wd4200") -- nonstandard extension used : zero-sized array in struct/union
+            target:add("cxxflags", "/wd4201") -- nonstandard extension used : nameless struct/union
+            target:add("cxxflags", "/wd4265") -- 'type': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly
+            target:add("cxxflags", "/wd4266") -- 'function' : no override available for virtual member function from base 'type'; function is hidden
+            target:add("cxxflags", "/wd4371") -- 'classname': layout of class may have changed from a previous version of the compiler due to better packing of member 'member'
+            target:add("cxxflags", "/wd4514") -- 'function' : unreferenced inline function has been removed
+            target:add("cxxflags", "/wd4582") -- 'type': constructor is not implicitly called
+            target:add("cxxflags", "/wd4583") -- 'type': destructor is not implicitly called
+            target:add("cxxflags", "/wd4623") -- 'derived class' : default constructor was implicitly defined as deleted because a base class default constructor is inaccessible or deleted
+            target:add("cxxflags", "/wd4625") -- 'derived class' : copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted
+            target:add("cxxflags", "/wd4626") -- 'derived class' : assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted
+            target:add("cxxflags", "/wd4710") -- 'function' : function not inlined
+            target:add("cxxflags", "/wd4711") -- function 'function' selected for inline expansion
+            target:add("cxxflags", "/wd4820") -- 'bytes' bytes padding added after construct 'member_name'
+            target:add("cxxflags", "/wd5026") -- 'type': move constructor was implicitly defined as deleted
+            target:add("cxxflags", "/wd5027") -- 'type': move assignment operator was implicitly defined as deleted
+            target:add("cxxflags", "/wd5045") -- compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
+            target:add("cxxflags", "/wd5053") -- support for 'explicit(<expr>)' in C++17 and earlier is a vendor extension
+            target:add("cxxflags", "/wd5204") -- 'type-name': class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
+            target:add("cxxflags", "/wd5220") -- 'member': a non-static data member with a volatile qualified type no longer implies that compiler generated copy / move constructors and copy / move assignment operators are not trivial
+        else
+            -- disable warnings
+            target:add("cxxflags", "-Wno-overloaded-virtual")
+            target:add("cxxflags", "-Wno-delete-non-abstract-non-virtual-dtor")
+            target:add("cxxflags", "-Wno-reinterpret-base-class")
+        end
+    end)

--- a/packages/c/commonlibsse-ng/rules/plugin.lua
+++ b/packages/c/commonlibsse-ng/rules/plugin.lua
@@ -96,14 +96,9 @@ rule("plugin")
 
         target:add("defines", "UNICODE", "_UNICODE")
 
-        target:add("cxxflags", "/MP", "/permissive-")
-        target:add("cxxflags",
-            "/Zc:alignedNew",
-            "/Zc:__cplusplus",
-            "/Zc:externConstexpr",
-            "/Zc:forScope",
-            "/Zc:hiddenFriend",
-            "/Zc:preprocessor",
-            "/Zc:referenceBinding",
-            "/Zc:ternary")
+        target:add("cxxflags", "/permissive-", "/Zc:alignedNew", "/Zc:__cplusplus", "/Zc:forScope", "/Zc:ternary")
+
+        if target:has_tool("cxx", "cl") then
+            target:add("cxxflags", "/Zc:externConstexpr", "/Zc:hiddenFriend", "/Zc:preprocessor", "/Zc:referenceBinding")
+        end
     end)


### PR DESCRIPTION
Doesn't build with `clang-cl` yet due to a known problem causing warnings, such as `argument unused during compilation: '-external:W0'`. Will look into further in the future.

Also removed a few redundant/unnecessary flags.