### PR TITLE
[commonlibsse-ng] Don't enforce `lto`

### DIFF
--- a/packages/c/commonlibsse-ng/port/xmake.lua
+++ b/packages/c/commonlibsse-ng/port/xmake.lua
@@ -16,9 +16,6 @@ set_warnings("allextra", "error")
 -- set optimization
 set_optimize("faster")
 
--- set policies
-set_policy("build.optimization.lto", true)
-
 -- add options
 option("skyrim_se")
     set_default(true)


### PR DESCRIPTION
This shouldn't have been left in as it prevents user choice.
