### PR TITLE
Support to control `lto` flag in boost

### DIFF
--- a/packages/b/boost/xmake.lua
+++ b/packages/b/boost/xmake.lua
@@ -166,6 +166,10 @@ package("boost")
             "debug-symbols=" .. (package:debug() and "on" or "off"),
             "link=" .. (package:config("shared") and "shared" or "static")
         }
+
+        if package:config("lto") then
+            table.insert(argv, "lto=on")
+        end
         if package:is_arch(".+64.*") then
             table.insert(argv, "address-model=64")
         else


### PR DESCRIPTION
Allow to control whether turn on `lto` for the package via `add_requireconfg`

