### PR TITLE
Add Windows Console port for pdcurses

### DIFF
--- a/packages/p/pdcurses/xmake.lua
+++ b/packages/p/pdcurses/xmake.lua
@@ -20,35 +20,26 @@ package("pdcurses")
         end
     end)
     
-
     on_install("linux", "macosx", "mingw", "windows", function (package)
-        if package:config("port") == "wincon" then
-            io.writefile("xmake.lua", [[
-                add_rules("mode.debug", "mode.release")
+        io.writefile("xmake.lua", [[
+            add_rules("mode.debug", "mode.release")
+            option("port", {description = "Set the target port."})
+            if is_config("port", "sdl2") then
                 add_requires("libsdl")
-                target("pdcurses")
-                    set_kind("$(kind)")
-                    add_files("pdcurses/*.c", "wincon/*.c")
-                    add_includedirs(".", "wincon")
-                    add_headerfiles("*.h", "wincon/*.h")
-                    add_defines("PDC_WIDE", "PDC_FORCE_UTF8")
-            ]])
-        else
-            io.writefile("xmake.lua", [[
-                add_rules("mode.debug", "mode.release")
-                add_requires("libsdl")
-                target("pdcurses")
-                    set_kind("$(kind)")
-                    add_files("pdcurses/*.c", "sdl2/*.c")
-                    add_includedirs(".", "sdl2")
-                    add_headerfiles("*.h", "sdl2/*.h")
-                    add_packages("libsdl")
-            ]])
-        end
+            end
+            target("pdcurses")
+                set_kind("$(kind)")
+                add_files("pdcurses/*.c", "$(port)/*.c")
+                add_includedirs(".", "$(port)")
+                add_headerfiles("*.h", "$(port)/*.h")
+                add_defines("PDC_WIDE", "PDC_FORCE_UTF8")
+                add_packages("libsdl")
+        ]])
         local configs = {}
         if package:config("shared") then 
             configs.kind = "shared"
         end
+        configs.port = package:config("port")
         import("package.tools.xmake").install(package, configs)
     end)
 

--- a/packages/p/pdcurses/xmake.lua
+++ b/packages/p/pdcurses/xmake.lua
@@ -32,7 +32,9 @@ package("pdcurses")
                 add_files("pdcurses/*.c", "$(port)/*.c")
                 add_includedirs(".", "$(port)")
                 add_headerfiles("*.h", "$(port)/*.h")
-                add_defines("PDC_WIDE", "PDC_FORCE_UTF8")
+                if is_config("port", "wincon") then
+                    add_defines("PDC_WIDE", "PDC_FORCE_UTF8")
+                end
                 add_packages("libsdl")
         ]])
         local configs = {}

--- a/packages/p/pdcurses/xmake.lua
+++ b/packages/p/pdcurses/xmake.lua
@@ -9,20 +9,42 @@ package("pdcurses")
     if not is_plat("windows") then
         add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
     end
+
+    add_configs("port", {description = "Set the target port.", default = "sdl2", values = {"sdl2", "wincon"}})
+
+    on_load(function (package)
+        if package:config("port") == "sdl2" then
+            package:add("deps", "libsdl")
+        else
+            package:add("syslinks", "user32", "advapi32")
+        end
+    end)
     
-    add_deps("libsdl")
 
     on_install("linux", "macosx", "mingw", "windows", function (package)
-        io.writefile("xmake.lua", [[
-            add_rules("mode.debug", "mode.release")
-            add_requires("libsdl")
-            target("pdcurses")
-                set_kind("$(kind)")
-                add_files("pdcurses/*.c", "sdl2/*.c")
-                add_includedirs(".", "sdl2")
-                add_headerfiles("*.h", "sdl2/*.h")
-                add_packages("libsdl")
-        ]])
+        if package:config("port") == "wincon" then
+            io.writefile("xmake.lua", [[
+                add_rules("mode.debug", "mode.release")
+                add_requires("libsdl")
+                target("pdcurses")
+                    set_kind("$(kind)")
+                    add_files("pdcurses/*.c", "wincon/*.c")
+                    add_includedirs(".", "wincon")
+                    add_headerfiles("*.h", "wincon/*.h")
+                    add_defines("PDC_WIDE", "PDC_FORCE_UTF8")
+            ]])
+        else
+            io.writefile("xmake.lua", [[
+                add_rules("mode.debug", "mode.release")
+                add_requires("libsdl")
+                target("pdcurses")
+                    set_kind("$(kind)")
+                    add_files("pdcurses/*.c", "sdl2/*.c")
+                    add_includedirs(".", "sdl2")
+                    add_headerfiles("*.h", "sdl2/*.h")
+                    add_packages("libsdl")
+            ]])
+        end
         local configs = {}
         if package:config("shared") then 
             configs.kind = "shared"


### PR DESCRIPTION
原 `pdcurses` 包描述只支持 SDL2 端口，现添加 Windows Console 端口。

另：配置 `port = "wincon"` 只在 Windows 下支持，我不清楚这里是否应该做一些限制（比如不在 Windows 下加载的时候报错？）
