### PR TITLE
Python: Dismiss local python installation if pip is not present

### DIFF
--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -103,7 +103,7 @@ package("python")
         end
     end)
 
-    on_install("@windows", "@msys", "@cygwin", function (package)
+    on_install("@windows|x86", "@windows|x64", "@msys", "@cygwin", function (package)
         if package:version():ge("3.0") then
             os.cp("python.exe", path.join(package:installdir("bin"), "python3.exe"))
         else

--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -87,6 +87,18 @@ package("python")
             if not result then
                 result = package:find_tool("python", opt)
             end
+            if result then
+                -- check if pip, setuptools and wheel are installed
+                local ok = try { function () 
+                    os.vrunv(result.program, {"-c", "import pip"})
+                    os.vrunv(result.program, {"-c", "import setuptools"})
+                    os.vrunv(result.program, {"-c", "import wheel"})
+                    return true
+                end}
+                if not ok then
+                    return false
+                end
+            end
             return result
         end
     end)


### PR DESCRIPTION
Python can be installed without pip/setuptools/wheel that python package otherwise guarantees.

This PR requires https://github.com/xmake-io/xmake/pull/3059 to work