### PR TITLE
fix wchar32 option for imgui

### DIFF
--- a/packages/i/imgui/port/xmake.lua
+++ b/packages/i/imgui/port/xmake.lua
@@ -34,8 +34,6 @@ target("imgui")
     add_includedirs(".")
 
     if has_config("wchar32") then
-        add_headerfiles("misc/freetype/imgui_freetype.h")
-        add_files("misc/freetype/imgui_freetype.cpp")
         add_defines("IMGUI_USE_WCHAR32")
     end
 


### PR DESCRIPTION
这两行应该是原作者 https://github.com/xmake-io/xmake-repo/pull/1217 从下面freetype选项copy paste的时候忘记删除了，导致设置 wchar32=true 时候必须同时设置 freetype=true才能编译