### PR TITLE
Fix wayland installation if pkg-config is not installed

### DIFF
--- a/packages/w/wayland/xmake.lua
+++ b/packages/w/wayland/xmake.lua
@@ -1,5 +1,4 @@
 package("wayland")
-
     set_homepage("https://wayland.freedesktop.org/")
     set_description("Wayland is a protocol for a compositor to talk to its clients as well as a C library implementation of that protocol.")
     set_license("MIT")
@@ -15,9 +14,9 @@ package("wayland")
         add_extsources("apt::libwayland-dev", "pacman::wayland")
     end
 
-    add_deps("meson", "libxml2", "libffi", "expat", "bison")
-    on_install("linux", function (package)
+    add_deps("meson", "libxml2", "libffi", "expat", "bison", "pkg-config")
 
+    on_install("linux", function (package)
         -- imports
         import("package.tools.meson")
         import("package.tools.autoconf")


### PR DESCRIPTION
Fixes this:
```
/usr/bin/tar -xf wayland-1.19.0.tar.xz -C source.tmp
downloading resource(protocols: https://wayland.freedesktop.org/releases/wayland-protocols-1.21.tar.xz) to wayland-1.19.0 ..
/usr/bin/tar -xf /home/lynix/.xmake/cache/packages/2212/w/wayland/1.19.0/resources/protocols/wayland-protocols-1.21.tar.xz -C /home/lynix/.xmake/cache/packages/2212/w/wayland/1.19.0/resources/protocols/wayland-protocols-1.21.tar.xz.dir.tmp
meson -Ddocumentation=false -Dc_link_args=-lm --libdir=lib --prefix=/home/lynix/.xmake/packages/w/wayland/1.19.0/d4813a414d234036bb8606e1e07c959d --libdir=lib -Dbuildtype=release -Db_staticpic=true build_d4813a41
The Meson build system
Version: 0.62.1
Source dir: /home/lynix/.xmake/cache/packages/2212/w/wayland/1.19.0/source
Build dir: /home/lynix/.xmake/cache/packages/2212/w/wayland/1.19.0/source/build_d4813a41
Build type: native build
Project name: wayland
Project version: 1.19.0
C compiler for the host machine: cc (gcc 11.3.0 "cc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0")
C linker for the host machine: cc ld.bfd 2.38
C++ compiler for the host machine: c++ (gcc 11.3.0 "c++ (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0")
C++ linker for the host machine: c++ ld.bfd 2.38
Host machine cpu family: x86_64
Host machine cpu: x86_64
Compiler for C supports arguments -Wno-unused-parameter: YES
Compiler for C supports arguments -Wstrict-prototypes: YES
Compiler for C supports arguments -Wmissing-prototypes: YES
Compiler for C supports arguments -fvisibility=hidden: YES
Has header "sys/prctl.h" : YES
Checking for function "accept4" : YES
Checking for function "mkostemp" : YES
Checking for function "posix_fallocate" : YES
Checking for function "prctl" : YES
Checking for function "memfd_create" : YES
Checking for function "strndup" : YES
Did not find pkg-config by name 'pkg-config'
Found Pkg-config: NO
Found CMake: /home/lynix/.xmake/packages/c/cmake/3.24.2/68b116f83c5c4fb1b93d0f5f7a07021e/bin/cmake (3.24.2)
Run-time dependency libffi found: NO (tried cmake)

meson.build:46:1: ERROR: Pkg-config binary for machine 1 not found. Giving up.

A full log can be found at /home/lynix/.xmake/cache/packages/2212/w/wayland/1.19.0/source/build_d4813a41/meson-logs/meson-log.txt
error: execv(meson -Ddocumentation=false -Dc_link_args=-lm --libdir=lib --prefix=/home/lynix/.xmake/packages/w/wayland/1.19.0/d4813a414d234036bb8606e1e07c959d --libdir=lib -Dbuildtype=release -Db_staticpic=true build_d4813a41) failed(1)
  => install wayland 1.19.0 .. failed
error: install failed!
```