### PR TITLE
Add latest releases to catch2 package

### DIFF
--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -6,7 +6,11 @@ package("catch2")
 
     add_urls("https://github.com/catchorg/Catch2/archive/refs/tags/$(version).zip",
              "https://github.com/catchorg/Catch2.git")
+    add_versions("v3.2.1", "bfee681eaa920c6ddbe05c1eef1912440d38c5f9a7924f68a6aa219ed1a39c0f")
+    add_versions("v3.2.0", "b9f3887915f32eb732140af6a153065a11fabcd3f3e9355f3abff3d3618fd0fe")
+    add_versions("v3.1.1", "eec6c327cd9187c63bbaaa8486f715e31544000bf8876c0543e1181a2a52a5de")
     add_versions("v3.1.0", "7219c2ca75a6b2a157b1b162e4ad819fb32585995cac32542a4f72d950dd96f7")
+    add_versions("v2.13.10", "121e7488912c2ce887bfe4699ebfb983d0f2e0d68bcd60434cdfd6bb0cf78b43")
     add_versions("v2.13.9", "860e3917f07d7ee75654f86900d50a03acf0047f6fe5ba31d437e1e9cda5b456")
     add_versions("v2.13.8", "de0fd1f4c51a1021ffcb33a4d42028545bf1a0665a4ab59ddb839a0cc93f03a5")
     add_versions("v2.13.7", "3f3ccd90ad3a8fbb1beeb15e6db440ccdcbebe378dfd125d07a1f9a587a927e9")


### PR DESCRIPTION
Adds catch2 versions 2.13.10, 3.1.1, 3.2.0, and 3.2.1
