### PR TITLE
Update `scnlib` to v1.1.2

### DIFF
--- a/packages/s/scnlib/xmake.lua
+++ b/packages/s/scnlib/xmake.lua
@@ -4,6 +4,7 @@ package("scnlib")
     set_description("scnlib is a modern C++ library for replacing scanf and std::istream")
 
     set_urls("https://github.com/eliaskosunen/scnlib/archive/refs/tags/v$(version).zip")
+    add_versions("1.1.2", "72BF304662B03E00DE5B438B9D4697A081E786D589E067817C356174FB2CB06C")
     add_versions("0.4", "49a84f1439e52666532fbd5da3fa1d652622fc7ac376070e330e15c528d38190")
 
     add_configs("header_only", {description = "Use header only version.", default = false, type = "boolean"})


### PR DESCRIPTION
`scnlib` is up to v1.1.2: https://github.com/eliaskosunen/scnlib/releases