### PR TITLE
Port redis-plus-plus to Windows && Dump to 1.3.7

### DIFF
--- a/packages/r/redis-plus-plus/xmake.lua
+++ b/packages/r/redis-plus-plus/xmake.lua
@@ -5,6 +5,8 @@ package("redis-plus-plus")
     add_urls("https://github.com/sewenew/redis-plus-plus/archive/refs/tags/$(version).tar.gz",
              "https://github.com/sewenew/redis-plus-plus.git")
     add_versions("1.3.5", "a49a72fef26ed39d36a278fcc4e4d92822e111697b5992d8f26f70d16edc6c1f")
+    add_versions("1.3.6", "87dcadca50c6f0403cde47eb1f79af7ac8dd5a19c3cad2bb54ba5a34f9173a3e")
+    add_versions("1.3.7", "89cb83b0a23ac5825300c301814eab74aa3cdcfcd12e87d443c2692e367768ba")
 
     add_deps("hiredis")
     add_deps("cmake")
@@ -13,7 +15,7 @@ package("redis-plus-plus")
         add_syslinks("pthread")
     end
 
-    on_install("linux", "macosx", function (package)
+    on_install("linux", "macosx", "windows", function (package)
         local configs = {"-DREDIS_PLUS_PLUS_BUILD_TEST=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DREDIS_PLUS_PLUS_BUILD_STATIC=" .. (package:config("shared") and "OFF" or "ON"))


### PR DESCRIPTION
redis-plus-plus already supports Windows. (https://github.com/sewenew/redis-plus-plus#windows-support)
It has released v1.3.7 last week.