### PR TITLE
update xmake.lua

### DIFF
--- a/packages/v/vulkan-headers/xmake.lua
+++ b/packages/v/vulkan-headers/xmake.lua
@@ -24,6 +24,17 @@ package("vulkan-headers")
         import("package.tools.cmake").install(package)
     end)
 
+    on_fetch(function (package, opt)
+        if opt.system then
+            import("detect.sdks.find_vulkansdk")
+
+            local vulkansdk = find_vulkansdk()
+            if vulkansdk then
+                return {includedirs = vulkansdk.includedirs, linkdirs = vulkansdk.linkdirs, links = {}}        
+            end
+        end
+    end)
+
     on_test(function (package)
         assert(package:check_csnippets({test = [[
             void test() {


### PR DESCRIPTION
To solve the problem #1733  that vulkan-headers conflicts with the local vulkansdk, add new logic in xmake.lua to first search the local vulkansdk and use the local vulkansdk‘s header files.

