### PR TITLE
Add configs to Raylib xmake.lua

### DIFF
--- a/packages/r/raylib/xmake.lua
+++ b/packages/r/raylib/xmake.lua
@@ -42,6 +42,10 @@ package("raylib")
     end
     add_deps("opengl", {optional = true})
 
+    add_configs("use_external_glfw", {...})
+    add_configs("platform", {...})
+    add_configs("opengl_version", {...})
+
     on_install("macosx|x86_64", function (package)
         os.cp("include/*.h", package:installdir("include"))
         os.cp("lib/libraylib.a", package:installdir("lib"))


### PR DESCRIPTION
Adds following configs: USE_EXTERNAL_GLFW, PLATFORM, OPENGL_VERSION
