### PR TITLE
Use workflow xmake.lua to compile

### DIFF
--- a/packages/w/workflow/xmake.lua
+++ b/packages/w/workflow/xmake.lua
@@ -5,12 +5,7 @@ package("workflow")
 
     add_urls("https://github.com/sogou/workflow/archive/refs/tags/$(version).tar.gz",
              "https://github.com/sogou/workflow.git")
-    add_versions("v0.9.11", "71b5531728d6b4f3666176dbc45d680350518af8")
-    add_versions("v0.10.1", "315eb1b1b5411e807e5ecc45ba5aa7db1d4f7c28")
-    add_versions("v0.10.2", "42d87f4f9eaa80e882ccdd71cd81d20899050266")
-    add_versions("v0.10.3", "116e6772cd13b88a3fb8420bcfbef98921252a1a")
-    add_versions("v0.10.4", "83d6346ca2c1bcd003f67100a4c77418f8acfed5")
-    add_versions("v0.10.5", "2cbf7082b1ccfc51028e578109b93d0ff45414df")
+    add_versions("v0.10.5", "26725392bf4c6e1156a246c0f10f3c3e99e6efe5")
 
     add_deps("openssl")
 
@@ -39,4 +34,4 @@ package("workflow")
             }
         }
     ]]}, {configs = {languages = "c++11"}}))
-    end)
+   end)

--- a/packages/w/workflow/xmake.lua
+++ b/packages/w/workflow/xmake.lua
@@ -33,5 +33,5 @@ package("workflow")
                 server.stop();
             }
         }
-    ]]}, {configs = {languages = "c++11"}, includes = "workflow/WFHttpServer.h"}))
+    ]]}, {configs = {languages = "c++11"}}))
     end)

--- a/packages/w/workflow/xmake.lua
+++ b/packages/w/workflow/xmake.lua
@@ -35,4 +35,4 @@ package("workflow")
             }
         }
     ]]}, {configs = {languages = "c++11"}}))
-   end)
+    end)

--- a/packages/w/workflow/xmake.lua
+++ b/packages/w/workflow/xmake.lua
@@ -14,7 +14,8 @@ package("workflow")
     end
 
     on_install("linux", "macosx", "android", function (package)
-	local configs = {}
+        os.mkdir(package:installdir("lib"))
+        local configs = {}
         if package:config("shared") then
             configs.kind = "shared"
         end

--- a/packages/w/workflow/xmake.lua
+++ b/packages/w/workflow/xmake.lua
@@ -5,7 +5,7 @@ package("workflow")
 
     add_urls("https://github.com/sogou/workflow/archive/refs/tags/$(version).tar.gz",
              "https://github.com/sogou/workflow.git")
-    add_versions("v0.10.5", "26725392bf4c6e1156a246c0f10f3c3e99e6efe5")
+    add_versions("v0.10.6", "654fe336ebaa8e715aff1975e3276bb5fd637529")
 
     add_deps("openssl")
 
@@ -14,8 +14,6 @@ package("workflow")
     end
 
     on_install("linux", "macosx", "android", function (package)
-        os.mkdir(package:installdir("include"))
-        os.mkdir(package:installdir("lib"))
         local configs = {}
         if package:config("shared") then
             configs.kind = "shared"
@@ -27,7 +25,7 @@ package("workflow")
         assert(package:check_cxxsnippets({test = [[
         #include <stdio.h>
         #include "workflow/WFHttpServer.h"
-        static void test() {
+        void test() {
             WFHttpServer server([](WFHttpTask *task) {
                 task->get_resp()->append_output_body("<html>Hello World!</html>");
             });
@@ -35,5 +33,5 @@ package("workflow")
                 server.stop();
             }
         }
-    ]]}, {configs = {languages = "c++11"}}))
+    ]]}, {configs = {languages = "c++11"}, includes = "workflow/WFHttpServer.h"}))
     end)

--- a/packages/w/workflow/xmake.lua
+++ b/packages/w/workflow/xmake.lua
@@ -14,6 +14,7 @@ package("workflow")
     end
 
     on_install("linux", "macosx", "android", function (package)
+        os.mkdir(package:installdir("include"))
         os.mkdir(package:installdir("lib"))
         local configs = {}
         if package:config("shared") then

--- a/packages/w/workflow/xmake.lua
+++ b/packages/w/workflow/xmake.lua
@@ -10,28 +10,20 @@ package("workflow")
     add_versions("v0.10.2", "42d87f4f9eaa80e882ccdd71cd81d20899050266")
     add_versions("v0.10.3", "116e6772cd13b88a3fb8420bcfbef98921252a1a")
     add_versions("v0.10.4", "83d6346ca2c1bcd003f67100a4c77418f8acfed5")
-    add_versions("v0.10.5", "4216034831c142bb9be9a9ca781dea737c606919")
+    add_versions("v0.10.5", "2cbf7082b1ccfc51028e578109b93d0ff45414df")
 
-    add_deps("cmake", "openssl")
+    add_deps("openssl")
 
     if is_plat("linux") then
         add_syslinks("pthread", "dl")
     end
 
     on_install("linux", "macosx", "android", function (package)
-        local configs = {}
-        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if package:is_plat("android") then
-            io.replace("src/CMakeLists.txt", "add_subdirectory(client)", "add_subdirectory(client)\nlink_libraries(ssl crypto)", {plain = true})
-        end
-        import("package.tools.cmake").install(package, configs, {packagedeps = "openssl"})
+	local configs = {}
         if package:config("shared") then
-            os.tryrm(path.join(package:installdir("lib"), "*.a"))
-        else
-            os.tryrm(path.join(package:installdir("lib"), "*.so"))
-            os.tryrm(path.join(package:installdir("lib"), "*.dylib"))
+            configs.kind = "shared"
         end
+        import("package.tools.xmake").install(package, configs)
     end)
 
     on_test(function (package)


### PR DESCRIPTION
Since workflow adds xmake.lua to compile the project, it can greatly simplify the writing of our xrepo xmake.lua

https://github.com/xmake-io/xmake-repo/pull/1713