### PR TITLE
add custom main option for Catch2

### DIFF
--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -19,7 +19,7 @@ package("catch2")
     add_versions("v2.9.2", "dc486300de22b0d36ddba1705abb07b9e5780639d824ba172ddf7062b2a1bf8f")
 
     add_configs("cxx17", {description = "Compiles Catch as a C++17 library (requires a C++17 compiler).", default = true, type = "boolean"})
-    add_configs("catch2main",{description = "Use Catch2 entry point", default = true, type = "boolean"})
+    add_configs("catch2main", {description = "Use Catch2 entry point", default = true, type = "boolean"})
 
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::catch")

--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -30,25 +30,25 @@ package("catch2")
     end
 
     on_load(function (package)
+        package:add("deps", "cmake")
         if package:config("catch2main") then
             package:add("components", "main")
         end
         package:add("components", "lib")
+        if package:version():lt("3.0") then
+            package:set("kind", "library", {headeronly = true})
+        end
     end)
 
     on_component("main", function (package, component)
         if package:version():ge("3.0") then
-            component:add("deps", "cmake")
             component:add("links", "Catch2Main")
         end
     end)
 
     on_component("lib", function (package, component)
         if package:version():ge("3.0") then
-            component:add("deps", "cmake")
             component:add("links", "Catch2")
-        else
-            package:set("kind", "library", {headeronly = true})
         end
     end)
 

--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -30,26 +30,23 @@ package("catch2")
     end
 
     on_load(function (package)
-        package:add("deps", "cmake")
-        if package:config("catch2main") then
-            package:add("components", "main")
-        end
-        package:add("components", "lib")
-        if package:version():lt("3.0") then
+        if package:version():ge("3.0") then
+            package:add("deps", "cmake")
+            if package:config("catch2main") then
+                package:add("components", "main")
+            end
+            package:add("components", "lib")
+        else
             package:set("kind", "library", {headeronly = true})
         end
     end)
 
     on_component("main", function (package, component)
-        if package:version():ge("3.0") then
-            component:add("links", "Catch2Main")
-        end
+        component:add("links", "Catch2Main")
     end)
 
     on_component("lib", function (package, component)
-        if package:version():ge("3.0") then
-            component:add("links", "Catch2")
-        end
+        component:add("links", "Catch2")
     end)
 
     on_install(function (package)

--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -19,7 +19,7 @@ package("catch2")
     add_versions("v2.9.2", "dc486300de22b0d36ddba1705abb07b9e5780639d824ba172ddf7062b2a1bf8f")
 
     add_configs("cxx17", {description = "Compiles Catch as a C++17 library (requires a C++17 compiler).", default = true, type = "boolean"})
-    add_configs("main",{description = "Select which main function to link.",default = "catch2", values = {"catch2", "custom"}})
+    add_configs("use_catch2main",{description = "Use Catch2 entry point", default = true, type = "boolean"})
 
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::catch")
@@ -30,14 +30,23 @@ package("catch2")
     end
 
     on_load(function (package)
+       if package:config("use_catch2main") then
+            package:add("components", "main")
+        end
+        package:add("components", "lib")
+    end)
+
+    on_component("main", function (package, component)
         if package:version():ge("3.0") then
-            package:add("deps", "cmake")
-            if package:config("main") == "catch2" then
-                package:add("links", "Catch2Main")
-            end
-            package:add("links", "Catch2")
+            component:add("links", "Catch2Main")
+        end
+    end)
+
+    on_component("lib", function (package, component)
+        if package:version():ge("3.0") then
+            component:add("links", "Catch2")
         else
-            package:set("kind", "library", {headeronly = true})
+            component:set("kind", "library", {headeronly = true})
         end
     end)
 

--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -19,7 +19,6 @@ package("catch2")
     add_versions("v2.9.2", "dc486300de22b0d36ddba1705abb07b9e5780639d824ba172ddf7062b2a1bf8f")
 
     add_configs("cxx17", {description = "Compiles Catch as a C++17 library (requires a C++17 compiler).", default = true, type = "boolean"})
-    add_configs("catch2main", {description = "Use Catch2 entry point", default = true, type = "boolean"})
 
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::catch")
@@ -32,10 +31,7 @@ package("catch2")
     on_load(function (package)
         if package:version():ge("3.0") then
             package:add("deps", "cmake")
-            if package:config("catch2main") then
-                package:add("components", "main")
-            end
-            package:add("components", "lib")
+            package:add("components", "main", "lib")
         else
             package:set("kind", "library", {headeronly = true})
         end

--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -19,7 +19,7 @@ package("catch2")
     add_versions("v2.9.2", "dc486300de22b0d36ddba1705abb07b9e5780639d824ba172ddf7062b2a1bf8f")
 
     add_configs("cxx17", {description = "Compiles Catch as a C++17 library (requires a C++17 compiler).", default = true, type = "boolean"})
-    add_configs("use_catch2main",{description = "Use Catch2 entry point", default = true, type = "boolean"})
+    add_configs("catch2main",{description = "Use Catch2 entry point", default = true, type = "boolean"})
 
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::catch")
@@ -30,7 +30,7 @@ package("catch2")
     end
 
     on_load(function (package)
-       if package:config("use_catch2main") then
+        if package:config("catch2main") then
             package:add("components", "main")
         end
         package:add("components", "lib")
@@ -38,15 +38,17 @@ package("catch2")
 
     on_component("main", function (package, component)
         if package:version():ge("3.0") then
+            component:add("deps", "cmake")
             component:add("links", "Catch2Main")
         end
     end)
 
     on_component("lib", function (package, component)
         if package:version():ge("3.0") then
+            component:add("deps", "cmake")
             component:add("links", "Catch2")
         else
-            component:set("kind", "library", {headeronly = true})
+            package:set("kind", "library", {headeronly = true})
         end
     end)
 

--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -19,6 +19,7 @@ package("catch2")
     add_versions("v2.9.2", "dc486300de22b0d36ddba1705abb07b9e5780639d824ba172ddf7062b2a1bf8f")
 
     add_configs("cxx17", {description = "Compiles Catch as a C++17 library (requires a C++17 compiler).", default = true, type = "boolean"})
+    add_configs("main",{description = "Select which main function to link.",default = "catch2", values = {"catch2", "custom"}})
 
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::catch")
@@ -31,7 +32,10 @@ package("catch2")
     on_load(function (package)
         if package:version():ge("3.0") then
             package:add("deps", "cmake")
-            package:add("links", "Catch2Main", "Catch2")
+            if package:config("main") == "catch2" then
+                package:add("links", "Catch2Main")
+            end
+            package:add("links", "Catch2")
         else
             package:set("kind", "library", {headeronly = true})
         end


### PR DESCRIPTION
Add custom main option for Catch2. 
If set main == "catch2", it will link Catch2Main, which is the default option for catch2. 
If set main == "custom", it will link your custom main.

