### PR TITLE
stb: move includes to stb folder

### DIFF
--- a/packages/s/stb/xmake.lua
+++ b/packages/s/stb/xmake.lua
@@ -1,5 +1,4 @@
 package("stb")
-
     set_kind("library", {headeronly = true})
     set_homepage("https://github.com/nothings/stb")
     set_description("single-file public domain (or MIT licensed) libraries for C/C++")
@@ -15,12 +14,14 @@ package("stb")
         add_extsources("pacman::stb", "apt::libstb-dev")
     end
 
+    add_includedirs("include", "include/stb")
+
     on_install(function (package)
-        os.cp("*.h", package:installdir("include"))
-        os.cp("*.c", package:installdir("include"))
+        os.cp("*.h", package:installdir("include/stb"))
+        os.cp("*.c", package:installdir("include/stb"))
     end)
 
     on_test(function (package)
-        assert(package:has_cfuncs("stbi_load_from_memory", {includes = "stb_image.h"}))
-        assert(package:has_cfuncs("stb_include_string", {includes = "stb_include.h"}))
+        assert(package:has_cfuncs("stbi_load_from_memory", {includes = "stb/stb_image.h"}))
+        assert(package:has_cfuncs("stb_include_string", {includes = "stb/stb_include.h"}))
     end)


### PR DESCRIPTION
pacman::stb and apt::libstb-dev put stb includes in a stb/ folder. this commit updates stb to match this but keeps retrocompatibility using includedirs