### PR TITLE
Allow libsdl_<libs> to work in static (or with statically built libsdl)

### DIFF
--- a/.github/workflows/mingw_macos.yml
+++ b/.github/workflows/mingw_macos.yml
@@ -30,5 +30,5 @@ jobs:
 
       - name: Tests
         run: |
-          xmake l ./scripts/test.lua -D -p mingw -k ${{ matrix.kind }}
+          xmake l ./scripts/test.lua -D -p mingw -k ${{ matrix.kind }} -v
 

--- a/.github/workflows/mingw_msys2.yml
+++ b/.github/workflows/mingw_msys2.yml
@@ -47,8 +47,8 @@ jobs:
         shell: msys2 {0}
         run: |
           if [ "${{ matrix.arch }}" == "x86_64" ]; then
-            xmake l ./scripts/test.lua -D -p mingw -a x86_64 -k ${{ matrix.kind }}
+            xmake l ./scripts/test.lua -D -p mingw -a x86_64 -k ${{ matrix.kind }} -v
           else
-            xmake l ./scripts/test.lua -D -p mingw -a i386 -k ${{ matrix.kind }}
+            xmake l ./scripts/test.lua -D -p mingw -a i386 -k ${{ matrix.kind }} -v
           fi
 

--- a/packages/l/libsdl_gfx/xmake.lua
+++ b/packages/l/libsdl_gfx/xmake.lua
@@ -31,7 +31,7 @@ package("libsdl_gfx")
 
     add_includedirs("include", "include/SDL2")
 
-    on_install("windows", function(package)
+    on_install("windows|x86", "windows|x64", function(package)
         import("core.tool.toolchain")
         local vs = tonumber(toolchain.load("msvc"):config("vs"))
         if vs < 2019 then

--- a/packages/l/libsdl_gfx/xmake.lua
+++ b/packages/l/libsdl_gfx/xmake.lua
@@ -25,7 +25,7 @@ package("libsdl_gfx")
         add_extsources("brew::sdl2_gfx")
     end
 
-    add_deps("libsdl")
+    add_deps("libsdl", {configs = {shared = true} })
 
     add_links("SDL2_gfx")
 

--- a/packages/l/libsdl_image/xmake.lua
+++ b/packages/l/libsdl_image/xmake.lua
@@ -40,6 +40,11 @@ package("libsdl_image")
         local libsdl = package:dep("libsdl")
         if libsdl and not libsdl:is_system() then
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
+            local fetchinfo = libsdl:fetch()
+            if fetchinfo then
+                table.insert(configs, "-DSDL2_INCLUDE_DIR=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
+                table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+            end
         end
         import("package.tools.cmake").install(package, configs)
     end)

--- a/packages/l/libsdl_image/xmake.lua
+++ b/packages/l/libsdl_image/xmake.lua
@@ -42,8 +42,17 @@ package("libsdl_image")
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
             local fetchinfo = libsdl:fetch()
             if fetchinfo then
-                table.insert(configs, "-DSDL2_INCLUDE_DIR=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
-                table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+                for _, dir in ipairs(fetchinfo.includedirs or fetchinfo.sysincludedirs) do
+                    if os.isfile(path.join(dir, "SDL_version.h")) then
+                        table.insert(configs, "-DSDL2_INCLUDE_DIR=" .. dir)
+                        break                        
+                    end
+                end
+                for _, libfile in ipairs(fetchinfo.libfiles) do
+                    if libfile:match("SDL2%..+$") or libfile:match("SDL2-static%..+$") then
+                        table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+                    end
+                end
             end
         end
         import("package.tools.cmake").install(package, configs)

--- a/packages/l/libsdl_image/xmake.lua
+++ b/packages/l/libsdl_image/xmake.lua
@@ -37,6 +37,7 @@ package("libsdl_image")
         local configs = {"-DSDL2IMAGE_SAMPLES=OFF", "-DSDL2IMAGE_TESTS=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        local libsdl = package:dep("libsdl")
         if libsdl and not libsdl:is_system() then
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
         end

--- a/packages/l/libsdl_image/xmake.lua
+++ b/packages/l/libsdl_image/xmake.lua
@@ -1,5 +1,4 @@
 package("libsdl_image")
-
     set_homepage("http://www.libsdl.org/projects/SDL_image/")
     set_description("Simple DirectMedia Layer image loading library")
     set_license("zlib")
@@ -12,71 +11,29 @@ package("libsdl_image")
         add_extsources("brew::sdl2_image")
     end
 
-    if is_plat("windows", "mingw") then
-        set_urls("https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-$(version)-VC.zip")
-        add_urls("https://github.com/libsdl-org/SDL_image/releases/download/release-$(version)/SDL2_image-devel-$(version)-VC.zip")
-        add_versions("2.0.5", "a180f9b75c4d3fbafe02af42c42463cc7bc488e763cfd1ec2ffb75678b4387ac")
-        add_versions("2.6.0", "e8953ec28e689fdef7805d0dc6913b8038dc6e250fe340929e459f367e2e75fa")
-        add_versions("2.6.1", "b431347d039081b3ec065670d3037f106c8683f11491c45776cde7e69965a5f3")
-        add_versions("2.6.2", "f510a58b03ce2b74a68d4e6733c47c1931813ab1736e533ad576f4cecb3a8a4d")
-    else
-        set_urls("https://www.libsdl.org/projects/SDL_image/release/SDL2_image-$(version).zip")
-        add_urls("https://github.com/libsdl-org/SDL_image/releases/download/release-$(version)/SDL2_image-$(version).zip")
-        add_versions("2.0.5", "eee0927d1e7819d57c623fe3e2b3c6761c77c474fe9bc425e8674d30ac049b1c")
-        add_versions("2.6.0", "2252cdfd5be73cefaf727edc39c2ef3b7682e797acbd3126df117e925d46aaf6")
-        add_versions("2.6.1", "cbfea63a46715c63a1db9e41617e550749a95ffd33ef9bd5ba6e58b2bdca6ed3")
-        add_versions("2.6.2", "efe3c229853d0d40c35e5a34c3f532d5d9728f0abc623bc62c962bcef8754205")
-    end
+    add_urls("https://www.libsdl.org/projects/SDL_image/release/SDL2_image-$(version).zip",
+             "https://github.com/libsdl-org/SDL_image/releases/download/release-$(version)/SDL2_image-$(version).zip")
+    add_versions("2.6.0", "2252cdfd5be73cefaf727edc39c2ef3b7682e797acbd3126df117e925d46aaf6")
+    add_versions("2.6.1", "cbfea63a46715c63a1db9e41617e550749a95ffd33ef9bd5ba6e58b2bdca6ed3")
+    add_versions("2.6.2", "efe3c229853d0d40c35e5a34c3f532d5d9728f0abc623bc62c962bcef8754205")
 
     if is_plat("macosx") then
         add_frameworks("CoreFoundation", "CoreGraphics", "ImageIO", "CoreServices")
     end
 
-    add_deps("libsdl")
+    add_deps("cmake", "libsdl")
 
-    add_links("SDL2_image")
     add_includedirs("include", "include/SDL2")
 
-    on_load("macosx", "linux", function (package)
-        if package:version():ge("2.6") then
-            package:add("deps", "cmake")
-        else
-            package:add("deps", "automake", "autoconf")
+    on_install(function (package)
+        local configs = {"-DSDL_TEST=OFF"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DSDL_STATIC=" .. (package:config("shared") and "OFF" or "ON"))
+        table.insert(configs, "-DSDL_SHARED=" .. (package:config("shared") and "ON" or "OFF"))
+        if libsdl and not libsdl:is_system() then
+            table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
         end
-    end)
-
-    on_install("windows", "mingw", function (package)
-        local arch = package:arch()
-        if package:is_plat("mingw") then
-            arch = (arch == "x86_64") and "x64" or "x86"
-        end
-        os.cp("include/*", package:installdir("include/SDL2"))
-        os.cp(path.join("lib", arch, "*.lib"), package:installdir("lib"))
-        os.cp(path.join("lib", arch, "*.dll"), package:installdir("bin"))
-    end)
-
-    on_install("macosx", "linux", function (package)
-        if package:version():ge("2.6") then
-            local configs = {"-DSDL_TEST=OFF"}
-            table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-            table.insert(configs, "-DSDL_STATIC=" .. (package:config("shared") and "OFF" or "ON"))
-            table.insert(configs, "-DSDL_SHARED=" .. (package:config("shared") and "ON" or "OFF"))
-            if libsdl and not libsdl:is_system() then
-                table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
-            end
-            import("package.tools.cmake").install(package, configs)
-        else
-            local configs = {}
-            table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
-            table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
-            local libsdl = package:dep("libsdl")
-            if libsdl and not libsdl:is_system() then
-                table.insert(configs, "--with-sdl-prefix=" .. libsdl:installdir())
-            end
-            io.replace("Makefile.am", "noinst_PROGRAMS = showimage.-\n", "\n")
-            os.rm("./configure")
-            import("package.tools.autoconf").install(package, configs)
-        end
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/l/libsdl_image/xmake.lua
+++ b/packages/l/libsdl_image/xmake.lua
@@ -21,9 +21,17 @@ package("libsdl_image")
         add_frameworks("CoreFoundation", "CoreGraphics", "ImageIO", "CoreServices")
     end
 
-    add_deps("cmake", "libsdl")
+    add_deps("cmake")
 
     add_includedirs("include", "include/SDL2")
+
+    on_load(function (package)
+        if package:config("shared") then
+            package:add("deps", "libsdl", { configs = { shared = true }})
+        else
+            package:add("deps", "libsdl")
+        end
+    end)
 
     on_install(function (package)
         local configs = {"-DSDL2IMAGE_SAMPLES=OFF", "-DSDL2IMAGE_TESTS=OFF"}

--- a/packages/l/libsdl_image/xmake.lua
+++ b/packages/l/libsdl_image/xmake.lua
@@ -26,10 +26,9 @@ package("libsdl_image")
     add_includedirs("include", "include/SDL2")
 
     on_install(function (package)
-        local configs = {"-DSDL_TEST=OFF"}
+        local configs = {"-DSDL2IMAGE_SAMPLES=OFF", "-DSDL2IMAGE_TESTS=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-        table.insert(configs, "-DSDL_STATIC=" .. (package:config("shared") and "OFF" or "ON"))
-        table.insert(configs, "-DSDL_SHARED=" .. (package:config("shared") and "ON" or "OFF"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         if libsdl and not libsdl:is_system() then
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
         end

--- a/packages/l/libsdl_mixer/xmake.lua
+++ b/packages/l/libsdl_mixer/xmake.lua
@@ -34,6 +34,11 @@ package("libsdl_mixer")
         local libsdl = package:dep("libsdl")
         if libsdl and not libsdl:is_system() then
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
+            local fetchinfo = libsdl:fetch()
+            if fetchinfo then
+                table.insert(configs, "-DSDL2_INCLUDE_DIR=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
+                table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+            end
         end
         import("package.tools.cmake").install(package, configs)
     end)

--- a/packages/l/libsdl_mixer/xmake.lua
+++ b/packages/l/libsdl_mixer/xmake.lua
@@ -31,6 +31,7 @@ package("libsdl_mixer")
                          "-DSDL3MIXER_CMD=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        local libsdl = package:dep("libsdl")
         if libsdl and not libsdl:is_system() then
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
         end

--- a/packages/l/libsdl_mixer/xmake.lua
+++ b/packages/l/libsdl_mixer/xmake.lua
@@ -36,8 +36,17 @@ package("libsdl_mixer")
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
             local fetchinfo = libsdl:fetch()
             if fetchinfo then
-                table.insert(configs, "-DSDL2_INCLUDE_DIR=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
-                table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+                for _, dir in ipairs(fetchinfo.includedirs or fetchinfo.sysincludedirs) do
+                    if os.isfile(path.join(dir, "SDL_version.h")) then
+                        table.insert(configs, "-DSDL2_INCLUDE_DIR=" .. dir)
+                        break                        
+                    end
+                end
+                for _, libfile in ipairs(fetchinfo.libfiles) do
+                    if libfile:match("SDL2%..+$") or libfile:match("SDL2-static%..+$") then
+                        table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+                    end
+                end
             end
         end
         import("package.tools.cmake").install(package, configs)

--- a/packages/l/libsdl_mixer/xmake.lua
+++ b/packages/l/libsdl_mixer/xmake.lua
@@ -1,23 +1,14 @@
 package("libsdl_mixer")
-
     set_homepage("https://www.libsdl.org/projects/SDL_mixer/")
     set_description("Simple DirectMedia Layer mixer audio library")
+    set_license("zlib")
 
-    if is_plat("windows", "mingw") then
-        set_urls("https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-$(version)-VC.zip")
-        add_urls("https://github.com/libsdl-org/SDL_mixer/releases/download/release-$(version)/SDL2_mixer-devel-$(version)-VC.zip")
-        add_versions("2.0.4", "258788438b7e0c8abb386de01d1d77efe79287d9967ec92fbb3f89175120f0b0")
-        add_versions("2.6.0", "b8862b95340b8990177fdb3fb1f22fe5fd089d8b2ad0a30bf7d84e0f4a6138ae")
-        add_versions("2.6.1", "e086e1fed423a801e0e7573af063f2f51d3bcef0c9da356ed8a62a7a7f7a0815")
-        add_versions("2.6.2", "7f050663ccc7911bb9c57b11e32ca79578b712490186b8645ddbbe4e7d2fe1c9")
-    else
-        set_urls("https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-$(version).zip")
-        add_urls("https://github.com/libsdl-org/SDL_mixer/releases/download/release-$(version)/SDL2_mixer-$(version).zip")
-        add_versions("2.0.4", "9affb8c7bf6fbffda0f6906bfb99c0ea50dca9b188ba9e15be90042dc03c5ded")
-        add_versions("2.6.0", "aca0ffc96a4bf2a56a16536a269de28e341ce38a46a25180bc1ef75e19b08a3a")
-        add_versions("2.6.1", "788c748c1d3a87126511e60995b03526ed4e31e2ba053dffd9dcc8abde97b950")
-        add_versions("2.6.2", "61549615a67e731805ca1df553e005be966a625c1d20fb085bf99edeef6e0469")
-    end
+    add_urls("https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-$(version).zip",
+             "https://github.com/libsdl-org/SDL_mixer/releases/download/release-$(version)/SDL2_mixer-$(version).zip")
+    add_versions("2.0.4", "9affb8c7bf6fbffda0f6906bfb99c0ea50dca9b188ba9e15be90042dc03c5ded")
+    add_versions("2.6.0", "aca0ffc96a4bf2a56a16536a269de28e341ce38a46a25180bc1ef75e19b08a3a")
+    add_versions("2.6.1", "788c748c1d3a87126511e60995b03526ed4e31e2ba053dffd9dcc8abde97b950")
+    add_versions("2.6.2", "61549615a67e731805ca1df553e005be966a625c1d20fb085bf99edeef6e0469")
 
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::SDL2_mixer")
@@ -27,51 +18,22 @@ package("libsdl_mixer")
         add_extsources("brew::sdl2_mixer")
     end
 
-    add_deps("libsdl")
-
-    add_links("SDL2_mixer")
+    add_deps("cmake", "libsdl")
 
     add_includedirs("include", "include/SDL2")
 
-    on_load(function (package)
-        if package:version():ge("2.6") and package:is_plat("macosx", "linux") then
-            package:add("deps", "cmake")
+    on_install(function (package)
+        local configs = {"-DSDL2MIXER_SAMPLES=OFF",
+                         "-DSDL2MIXER_FLAC=OFF",
+                         "-DSDL2MIXER_OPUS=OFF",
+                         "-DSDL2MIXER_MOD=OFF",
+                         "-DSDL2MIXER_MIDI=OFF"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        if libsdl and not libsdl:is_system() then
+            table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
         end
-    end)
-
-    on_install("windows", "mingw", function (package)
-        local arch = package:arch()
-        if package:is_plat("mingw") then
-            arch = (arch == "x86_64") and "x64" or "x86"
-        end
-        os.cp("include/*", package:installdir("include/SDL2"))
-        os.cp(path.join("lib", arch, "*.lib"), package:installdir("lib"))
-        os.cp(path.join("lib", arch, "*.dll"), package:installdir("bin"))
-    end)
-
-    on_install("macosx", "linux", function (package)
-        if package:version():ge("2.6") then
-            local configs = {"-DSDL2MIXER_SAMPLES=OFF",
-                             "-DSDL2MIXER_FLAC=OFF",
-                             "-DSDL2MIXER_OPUS=OFF",
-                             "-DSDL2MIXER_MOD=OFF",
-                             "-DSDL2MIXER_MIDI=OFF"}
-            table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-            table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-            if libsdl and not libsdl:is_system() then
-                table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
-            end
-            import("package.tools.cmake").install(package, configs)
-        else
-            local configs = {}
-            table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
-            table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
-            local libsdl = package:dep("libsdl")
-            if libsdl and not libsdl:is_system() then
-                table.insert(configs, "--with-sdl-prefix=" .. libsdl:installdir())
-            end
-            import("package.tools.autoconf").install(package, configs)
-        end
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/l/libsdl_mixer/xmake.lua
+++ b/packages/l/libsdl_mixer/xmake.lua
@@ -28,7 +28,7 @@ package("libsdl_mixer")
                          "-DSDL2MIXER_OPUS=OFF",
                          "-DSDL2MIXER_MOD=OFF",
                          "-DSDL2MIXER_MIDI=OFF",
-                         "-DSDL3MIXER_CMD=OFF"}
+                         "-DSDL2MIXER_CMD=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         local libsdl = package:dep("libsdl")

--- a/packages/l/libsdl_mixer/xmake.lua
+++ b/packages/l/libsdl_mixer/xmake.lua
@@ -27,7 +27,8 @@ package("libsdl_mixer")
                          "-DSDL2MIXER_FLAC=OFF",
                          "-DSDL2MIXER_OPUS=OFF",
                          "-DSDL2MIXER_MOD=OFF",
-                         "-DSDL2MIXER_MIDI=OFF"}
+                         "-DSDL2MIXER_MIDI=OFF",
+                         "-DSDL3MIXER_CMD=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         if libsdl and not libsdl:is_system() then

--- a/packages/l/libsdl_net/xmake.lua
+++ b/packages/l/libsdl_net/xmake.lua
@@ -1,19 +1,11 @@
 package("libsdl_net")
-
     set_homepage("https://www.libsdl.org/projects/SDL_net/")
     set_description("Simple DirectMedia Layer networking library")
+    set_license("zlib")
 
-    if is_plat("windows", "mingw") then
-        set_urls("https://www.libsdl.org/projects/SDL_net/release/SDL2_net-devel-$(version)-VC.zip")
-        add_urls("https://github.com/libsdl-org/SDL_net/releases/download/release-$(version)/SDL2_net-devel-$(version)-VC.zip")
-        add_versions("2.0.1", "c1e423f2068adc6ff1070fa3d6a7886700200538b78fd5adc36903a5311a243e")
-        add_versions("2.2.0", "f364e55babb44e47b41d039a43c640aa1f76615b726855591b555321c7d870dd")
-    else
-        set_urls("https://www.libsdl.org/projects/SDL_net/release/SDL2_net-$(version).zip")
-        add_urls("https://github.com/libsdl-org/SDL_net/releases/download/release-$(version)/SDL2_net-$(version).zip")
-        add_versions("2.0.1", "52031ed9d08a5eb1eda40e9a0409248bf532dde5e8babff5780ef1925657d59f")
-        add_versions("2.2.0", "1eec3a9d43df019d7916a6ecce32f2a3ad5248c82c9c237948afc712399be36d")
-    end
+    add_urls("https://www.libsdl.org/projects/SDL_net/release/SDL2_net-$(version).zip",
+             "https://github.com/libsdl-org/SDL_net/releases/download/release-$(version)/SDL2_net-$(version).zip")
+    add_versions("2.2.0", "1eec3a9d43df019d7916a6ecce32f2a3ad5248c82c9c237948afc712399be36d")
 
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::SDL2_net")
@@ -23,47 +15,22 @@ package("libsdl_net")
         add_extsources("brew::sdl2_net")
     end
 
-    add_deps("libsdl")
+    add_deps("cmake", "libsdl")
 
-    add_links("SDL2_net")
+    if is_plat("windows", "mingw") then
+        add_syslinks("Iphlpapi", "ws2_32")
+    end
 
     add_includedirs("include", "include/SDL2")
 
-    on_load(function (package)
-        if package:version():ge("2.2") and package:is_plat("macosx", "linux") then
-            package:add("deps", "cmake")
+    on_install(function (package)
+        local configs = {"-DSDL2NET_SAMPLES=OFF"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        if libsdl and not libsdl:is_system() then
+            table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
         end
-    end)
-
-    on_install("windows", "mingw", function (package)
-        local arch = package:arch()
-        if package:is_plat("mingw") then
-            arch = (arch == "x86_64") and "x64" or "x86"
-        end
-        os.cp("include/*", package:installdir("include/SDL2"))
-        os.cp(path.join("lib", arch, "*.lib"), package:installdir("lib"))
-        os.cp(path.join("lib", arch, "*.dll"), package:installdir("bin"))
-    end)
-
-    on_install("macosx", "linux", function (package)
-        if package:version():ge("2.2") then
-            local configs = {"-DSDL2NET_SAMPLES=OFF"}
-            table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-            table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-            if libsdl and not libsdl:is_system() then
-                table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
-            end
-            import("package.tools.cmake").install(package, configs)
-        else
-            local configs = {}
-            table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
-            table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
-            local libsdl = package:dep("libsdl")
-            if libsdl and not libsdl:is_system() then
-                table.insert(configs, "--with-sdl-prefix=" .. libsdl:installdir())
-            end
-            import("package.tools.autoconf").install(package, configs)
-        end
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/l/libsdl_net/xmake.lua
+++ b/packages/l/libsdl_net/xmake.lua
@@ -32,8 +32,17 @@ package("libsdl_net")
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
             local fetchinfo = libsdl:fetch()
             if fetchinfo then
-                table.insert(configs, "-DSDL2_INCLUDE_DIR=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
-                table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+                for _, dir in ipairs(fetchinfo.includedirs or fetchinfo.sysincludedirs) do
+                    if os.isfile(path.join(dir, "SDL_version.h")) then
+                        table.insert(configs, "-DSDL2_INCLUDE_DIR=" .. dir)
+                        break                        
+                    end
+                end
+                for _, libfile in ipairs(fetchinfo.libfiles) do
+                    if libfile:match("SDL2%..+$") or libfile:match("SDL2-static%..+$") then
+                        table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+                    end
+                end
             end
         end
         import("package.tools.cmake").install(package, configs)

--- a/packages/l/libsdl_net/xmake.lua
+++ b/packages/l/libsdl_net/xmake.lua
@@ -27,6 +27,7 @@ package("libsdl_net")
         local configs = {"-DSDL2NET_SAMPLES=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        local libsdl = package:dep("libsdl")
         if libsdl and not libsdl:is_system() then
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
         end

--- a/packages/l/libsdl_net/xmake.lua
+++ b/packages/l/libsdl_net/xmake.lua
@@ -30,6 +30,11 @@ package("libsdl_net")
         local libsdl = package:dep("libsdl")
         if libsdl and not libsdl:is_system() then
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
+            local fetchinfo = libsdl:fetch()
+            if fetchinfo then
+                table.insert(configs, "-DSDL2_INCLUDE_DIR=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
+                table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+            end
         end
         import("package.tools.cmake").install(package, configs)
     end)

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -44,16 +44,7 @@ package("libsdl_ttf")
         end
 
         local freetype = package:dep("freetype")
-        local opt
         if freetype and not freetype:is_system() then
-
-            local ldflags = {}
-            opt = {
-                packagedeps = "freetype",
-                shflags = ldflags, 
-                ldflags = ldflags
-            }
-
             local freetypefetch = freetype:fetch()
             if freetypefetch and freetypefetch.static then
                 -- translate paths
@@ -99,9 +90,9 @@ package("libsdl_ttf")
                 end
 
                 if #links > 0 or #linkdirs > 0 then
-                    local targetconf = string.format("target_link_libraries(SDL2_ttf PRIVATE Freetype::Freetype %s)", links)
+                    local targetconf = string.format("target_link_libraries(SDL2_ttf PRIVATE Freetype::Freetype %s)", table.concat(links, " "))
                     if #linkdirs > 0 then
-                        targetconf = targetconf .. string.format("\ntarget_link_directories(SDL2_ttf PRIVATE %s)", linkdirs)
+                        targetconf = targetconf .. string.format("\ntarget_link_directories(SDL2_ttf PRIVATE %s)", table.concat(linkdirs, " "))
                     end
                     -- pass freetype ourselves to handle its dependencies properly
                     io.replace("CMakeLists.txt", "target_link_libraries(SDL2_ttf PRIVATE Freetype::Freetype)", targetconf, {plain = true})
@@ -109,8 +100,8 @@ package("libsdl_ttf")
             end
         end
         print("configs", configs)
-        print("opt", opt)
-        import("package.tools.cmake").install(package, configs, opt)
+        table.insert(configs, "--trace")
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -82,10 +82,10 @@ package("libsdl_ttf")
                     if fetchinfo then
                         print("fetchinfo ", fetchinfo)
                         linkdirs = linkdirs or {}
-                        table.join2(linkdirs, _translate_paths(_map_linkflags(package, "binary", {"cxx"}, "linkdir", fetchinfo.linkdirs)))
+                        table.join2(linkdirs, _translate_paths(fetchinfo.linkdirs))
                         links = links or {}
-                        table.join2(links, package, "binary", {"cxx"}, "link", fetchinfo.links)
-                        table.join2(links, _translate_paths(package, "binary", {"cxx"}, "syslink", fetchinfo.syslinks))
+                        table.join2(links, fetchinfo.links)
+                        table.join2(links, _translate_paths(fetchinfo.syslinks))
                         if fetchinfo.static then
                             for _, inner_dep in ipairs(dep:plaindeps()) do
                                 add_dep(inner_dep)

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -42,7 +42,7 @@ package("libsdl_ttf")
                 end
             end
         end
-        import("package.tools.cmake").install(package, configs, { opt = { packagedeps = "freetype" }})
+        import("package.tools.cmake").install(package, configs, { packagedeps = "freetype" })
     end)
 
     on_test(function (package)

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -27,6 +27,11 @@ package("libsdl_ttf")
         local libsdl = package:dep("libsdl")
         if libsdl and not libsdl:is_system() then
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
+            local fetchinfo = libsdl:fetch()
+            if fetchinfo then
+                table.insert(configs, "-DSDL2_INCLUDE_DIR=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
+                table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+            end
         end
         import("package.tools.cmake").install(package, configs, { opt = { packagedeps = "freetype" }})
     end)

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -47,7 +47,7 @@ package("libsdl_ttf")
         local freetype = package:dep("freetype")
         local opt
         if freetype and not freetype:is_system() then
-            print("freetype not static")
+            print("freetype not system")
             local fetchinfo = freetype:fetch()
             if fetchinfo then
                 table.insert(configs, "-DFREETYPE_INCLUDE_DIRS=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
@@ -85,7 +85,7 @@ package("libsdl_ttf")
                     local add_dep
                     add_dep = function (dep)
                         print("add_dep", dep:name())
-                        local fetchinfo = freetype:fetch({external = false})
+                        local fetchinfo = dep:fetch({external = false})
                         if fetchinfo then
                             print("fetchinfo ", fetchinfo)
                             shflags = shflags or {}

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -43,6 +43,7 @@ package("libsdl_ttf")
             end
         end
         local freetype = package:dep("freetype")
+        local opt
         if freetype and not freetype:is_system() then
             local fetchinfo = freetype:fetch()
             if fetchinfo then
@@ -53,10 +54,16 @@ package("libsdl_ttf")
                         break
                     end
                 end
+                if fetchinfo.static then
+                    local packagedeps = {}
+                    for _, dep in ipairs(freetype:librarydeps()) do
+                        packagedeps = packagedeps or {}
+                        table.insert(packagedeps, dep:name())
+                    end
+                    opt = { packagedeps = packagedeps }
+                end
             end
         end
-        -- keep freetype as a packagedeps so its own dependencies are bring along (ex: zlib)
-        local opt = { packagedeps = "freetype" }
         import("package.tools.cmake").install(package, configs, opt)
     end)
 

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -49,7 +49,7 @@ package("libsdl_ttf")
             -- pass freetype ourselves to handle its dependencies properly
             io.replace("CMakeLists.txt", "set(SDL2TTF_FREETYPE ON)", "set(SDL2TTF_FREETYPE OFF)", {plain = true})
 
-            local ldflags
+            local ldflags = {}
             opt = {
                 packagedeps = "freetype",
                 shflags = ldflags, 

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -29,8 +29,17 @@ package("libsdl_ttf")
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
             local fetchinfo = libsdl:fetch()
             if fetchinfo then
-                table.insert(configs, "-DSDL2_INCLUDE_DIR=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
-                table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+                for _, dir in ipairs(fetchinfo.includedirs or fetchinfo.sysincludedirs) do
+                    if os.isfile(path.join(dir, "SDL_version.h")) then
+                        table.insert(configs, "-DSDL2_INCLUDE_DIR=" .. dir)
+                        break                        
+                    end
+                end
+                for _, libfile in ipairs(fetchinfo.libfiles) do
+                    if libfile:match("SDL2%..+$") or libfile:match("SDL2-static%..+$") then
+                        table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+                    end
+                end
             end
         end
         import("package.tools.cmake").install(package, configs, { opt = { packagedeps = "freetype" }})

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -45,12 +45,11 @@ package("libsdl_ttf")
 
         local freetype = package:dep("freetype")
         local opt
-        if freetype then
+        if freetype and not freetype:is_system() then
             -- pass freetype ourselves to handle its dependencies properly
-            io.replace("CMakeLists.txt", "set(SDL2TTF_FREETYPE ON)", "set(SDL2TTF_FREETYPE OFF)", {plain = true})
+            io.replace("CMakeLists.txt", "target_link_libraries(SDL2_ttf PRIVATE Freetype::Freetype)", "", {plain = true})
 
-            print("freetype found")
-            --[[local fetchinfo = freetype:fetch()
+            local fetchinfo = freetype:fetch()
             if fetchinfo then
                 table.insert(configs, "-DFREETYPE_INCLUDE_DIRS=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
                 for _, libfile in ipairs(fetchinfo.libfiles) do
@@ -59,7 +58,7 @@ package("libsdl_ttf")
                         break
                     end
                 end
-            end]]
+            end
 
             -- translate paths
             function _translate_paths(paths)

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -24,10 +24,11 @@ package("libsdl_ttf")
         local configs = {"-DSDL2TTF_SAMPLES=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        local libsdl = package:dep("libsdl")
         if libsdl and not libsdl:is_system() then
             table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
         end
-        import("package.tools.cmake").install(package, configs)
+        import("package.tools.cmake").install(package, configs, { opt = { packagedeps = "freetype" }})
     end)
 
     on_test(function (package)

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -47,18 +47,14 @@ package("libsdl_ttf")
         local opt
         if freetype and not freetype:is_system() then
             -- pass freetype ourselves to handle its dependencies properly
-            io.replace("CMakeLists.txt", "target_link_libraries(SDL2_ttf PRIVATE Freetype::Freetype)", "", {plain = true})
+            io.replace("CMakeLists.txt", "set(SDL2TTF_FREETYPE ON)", "set(SDL2TTF_FREETYPE OFF)", {plain = true})
 
-            local fetchinfo = freetype:fetch()
-            if fetchinfo then
-                table.insert(configs, "-DFREETYPE_INCLUDE_DIRS=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
-                for _, libfile in ipairs(fetchinfo.libfiles) do
-                    if libfile:match("freetype%..+$") then
-                        table.insert(configs, "-DFREETYPE_LIBRARY=" .. libfile)
-                        break
-                    end
-                end
-            end
+            local ldflags
+            opt = {
+                packagedeps = "freetype",
+                shflags = ldflags, 
+                ldflags = ldflags
+            }
 
             -- translate paths
             function _translate_paths(paths)
@@ -81,7 +77,6 @@ package("libsdl_ttf")
                 return linker.map_flags(targetkind, sourcekinds, name, values, {target = package})
             end
 
-            local ldflags
             local add_dep
             add_dep = function (dep)
                 print("add_dep", dep:name())
@@ -102,10 +97,6 @@ package("libsdl_ttf")
             end
 
             add_dep(freetype)
-
-            if ldflags then
-                opt = { shflags = ldflags, ldflags = ldflags}
-            end
         end
         print("configs", configs)
         print("opt", opt)

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -106,7 +106,7 @@ package("libsdl_ttf")
                     end
 
                     if ldflags then
-                        opt = { ldflags = ldflags}
+                        opt = { shflags = ldflags, ldflags = ldflags}
                     end
                 end
             end

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -81,18 +81,18 @@ package("libsdl_ttf")
                         return linker.map_flags(targetkind, sourcekinds, name, values, {target = package})
                     end
 
-                    local shflags
+                    local ldflags
                     local add_dep
                     add_dep = function (dep)
                         print("add_dep", dep:name())
                         local fetchinfo = dep:fetch({external = false})
                         if fetchinfo then
                             print("fetchinfo ", fetchinfo)
-                            shflags = shflags or {}
-                            table.join2(shflags, _translate_paths(_map_linkflags(package, "binary", {"cxx"}, "linkdir", fetchinfo.linkdirs)))
-                            table.join2(shflags, _map_linkflags(package, "binary", {"cxx"}, "link", fetchinfo.links))
-                            table.join2(shflags, _translate_paths(_map_linkflags(package, "binary", {"cxx"}, "syslink", fetchinfo.syslinks)))
-                            table.join2(shflags, _map_linkflags(package, "binary", {"cxx"}, "framework", fetchinfo.frameworks))
+                            ldflags = ldflags or {}
+                            table.join2(ldflags, _translate_paths(_map_linkflags(package, "binary", {"cxx"}, "linkdir", fetchinfo.linkdirs)))
+                            table.join2(ldflags, _map_linkflags(package, "binary", {"cxx"}, "link", fetchinfo.links))
+                            table.join2(ldflags, _translate_paths(_map_linkflags(package, "binary", {"cxx"}, "syslink", fetchinfo.syslinks)))
+                            table.join2(ldflags, _map_linkflags(package, "binary", {"cxx"}, "framework", fetchinfo.frameworks))
                             if fetchinfo.static then
                                 for _, inner_dep in ipairs(dep:librarydeps()) do
                                     add_dep(inner_dep)
@@ -105,8 +105,8 @@ package("libsdl_ttf")
                         add_dep(dep)
                     end
 
-                    if shflags then
-                        opt = { shflags = shflags}
+                    if ldflags then
+                        opt = { ldflags = ldflags}
                     end
                 end
             end

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -47,10 +47,14 @@ package("libsdl_ttf")
             local fetchinfo = freetype:fetch()
             if fetchinfo then
                 table.insert(configs, "-DFREETYPE_INCLUDE_DIRS=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
-                table.insert(configs, "-DFREETYPE_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+                for _, libfile in ipairs(fetchinfo.libfiles) do
+                    if libfile:match("freetype%..+$") then
+                        table.insert(configs, "-DFREETYPE_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+                    end
+                end
             end
         end
-        -- keep freetype as a packagedeps so its own dependencies are bring along (zlib)
+        -- keep freetype as a packagedeps so its own dependencies are bring along (ex: zlib)
         local opt = { packagedeps = "freetype" }
         import("package.tools.cmake").install(package, configs, opt)
     end)

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -37,7 +37,7 @@ package("libsdl_ttf")
                 end
                 for _, libfile in ipairs(fetchinfo.libfiles) do
                     if libfile:match("SDL2%..+$") or libfile:match("SDL2-static%..+$") then
-                        table.insert(configs, "-DSDL2_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+                        table.insert(configs, "-DSDL2_LIBRARY=" .. libfile)
                     end
                 end
             end
@@ -49,7 +49,8 @@ package("libsdl_ttf")
                 table.insert(configs, "-DFREETYPE_INCLUDE_DIRS=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
                 for _, libfile in ipairs(fetchinfo.libfiles) do
                     if libfile:match("freetype%..+$") then
-                        table.insert(configs, "-DFREETYPE_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+                        table.insert(configs, "-DFREETYPE_LIBRARY=" .. libfile)
+                        break
                     end
                 end
             end

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -1,5 +1,4 @@
 package("libsdl_ttf")
-
     set_homepage("https://www.libsdl.org/projects/SDL_ttf/")
     set_description("Simple DirectMedia Layer text rendering library")
     set_license("zlib")
@@ -12,67 +11,23 @@ package("libsdl_ttf")
         add_extsources("brew::sdl2_ttf")
     end
 
-    if is_plat("windows", "mingw") then
-        set_urls("https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-$(version)-VC.zip")
-        add_urls("https://github.com/libsdl-org/SDL_ttf/releases/download/release-$(version)/SDL2_ttf-devel-$(version)-VC.zip")
-        add_versions("2.0.15", "aab0d81f1aa6fe654be412efc85829f2b188165dca6c90eb4b12b673f93e054b")
-        add_versions("2.0.18", "4e1404ac6095bbcd4cb133eb644a765885aa283ae45f36cfbc3cf5a77d7e1cbd")
-        add_versions("2.20.0", "bc206392a74d2b32f74d770a3a1e623e87c72374781c115478277ab4c722358b")
-        add_versions("2.20.1", "2facfa180f77bac381776376c7598ad504a84d99414418049bb106cb1705fe22")
-    else
-        set_urls("https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-$(version).zip")
-        add_urls("https://github.com/libsdl-org/SDL_ttf/releases/download/release-$(version)/SDL2_ttf-$(version).zip")
-        add_versions("2.0.15", "cdb72b5b1c3b27795fa128af36f369fee5d3e38a96c350855da0b81880555dbc")
-        add_versions("2.0.18", "64e6a93c7542aba1e32e1418413898dfde82be95fdd0c73ba265fbdada189b5f")
-        add_versions("2.20.0", "04e94fc5ecac3475ab35c1d5cf52650df691867e7e4befcc861bf982a747111a")
-        add_versions("2.20.1", "18d81ab399c8e39adababe8918691830ba6e0d6448e5baa141ee0ddf87ede2dc")
-    end
+    add_urls("https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-$(version).zip",
+             "https://github.com/libsdl-org/SDL_ttf/releases/download/release-$(version)/SDL2_ttf-$(version).zip")
+    add_versions("2.20.0", "04e94fc5ecac3475ab35c1d5cf52650df691867e7e4befcc861bf982a747111a")
+    add_versions("2.20.1", "18d81ab399c8e39adababe8918691830ba6e0d6448e5baa141ee0ddf87ede2dc")
 
-    add_deps("libsdl")
-    if is_plat("linux", "macosx") then
-        add_deps("freetype")
-    end
+    add_deps("cmake", "libsdl", "freetype")
 
-    add_links("SDL2_ttf")
     add_includedirs("include", "include/SDL2")
 
-    on_load("macosx", "linux", function (package)
-        if package:version():ge("2.20") then
-            package:add("deps", "cmake")
-        else
-            package:add("deps", "automake", "autoconf")
+    on_install(function (package)
+        local configs = {"-DSDL2TTF_SAMPLES=OFF"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        if libsdl and not libsdl:is_system() then
+            table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
         end
-    end)
-
-    on_install("windows", "mingw", function (package)
-        local arch = package:arch()
-        if package:is_plat("mingw") then
-            arch = (arch == "x86_64") and "x64" or "x86"
-        end
-        os.cp("include/*", package:installdir("include/SDL2"))
-        os.cp(path.join("lib", arch, "*.lib"), package:installdir("lib"))
-        os.cp(path.join("lib", arch, "*.dll"), package:installdir("bin"))
-    end)
-
-    on_install("macosx", "linux", function (package)
-        if package:version():ge("2.20") then
-            local configs = {"-DSDL2TTF_SAMPLES=OFF"}
-            table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-            table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-            if libsdl and not libsdl:is_system() then
-                table.insert(configs, "-DSDL2_DIR=" .. libsdl:installdir())
-            end
-            import("package.tools.cmake").install(package, configs)
-        else
-            local configs = {}
-            table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
-            table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
-            local libsdl = package:dep("libsdl")
-            if libsdl and not libsdl:is_system() then
-                table.insert(configs, "--with-sdl-prefix=" .. libsdl:installdir())
-            end
-            import("package.tools.autoconf").install(package, configs)
-        end
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/l/libsdl_ttf/xmake.lua
+++ b/packages/l/libsdl_ttf/xmake.lua
@@ -42,7 +42,17 @@ package("libsdl_ttf")
                 end
             end
         end
-        import("package.tools.cmake").install(package, configs, { packagedeps = "freetype" })
+        local freetype = package:dep("freetype")
+        if freetype and not freetype:is_system() then
+            local fetchinfo = freetype:fetch()
+            if fetchinfo then
+                table.insert(configs, "-DFREETYPE_INCLUDE_DIRS=" .. table.concat(fetchinfo.includedirs or fetchinfo.sysincludedirs, ";"))
+                table.insert(configs, "-DFREETYPE_LIBRARY=" .. table.concat(fetchinfo.libfiles, ";"))
+            end
+        end
+        -- keep freetype as a packagedeps so its own dependencies are bring along (zlib)
+        local opt = { packagedeps = "freetype" }
+        import("package.tools.cmake").install(package, configs, opt)
     end)
 
     on_test(function (package)


### PR DESCRIPTION
Since #1671 others SDL libs (like SDL_image/SDL_ttf) are having issues on Windows because the precompiled libraries are linked with SDL2.dll.

So I reworked every libsdl_xx to build using cmake even on Windows which allows them to correctly link libsdl, but I had to remove older versions that don't support cmake.