### PR TITLE
libiconv: re-add support for macosx

### DIFF
--- a/packages/l/libiconv/xmake.lua
+++ b/packages/l/libiconv/xmake.lua
@@ -46,7 +46,7 @@ package("libiconv")
         })
     end)
 
-    on_install("linux", "cross", "android", function (package)
+    on_install("macosx", "linux", "cross", "android", function (package)
         local configs = {"--disable-dependency-tracking", "--enable-extra-encodings"}
         if not package:is_plat("macosx") then
             table.insert(configs, "--enable-relocatable")


### PR DESCRIPTION
macosx support for libiconv is removed in #1784 , re-add the macosx support