### PR TITLE
更新cpr包版本

### DIFF
--- a/packages/c/cpr/xmake.lua
+++ b/packages/c/cpr/xmake.lua
@@ -9,6 +9,8 @@ package("cpr")
     add_versions("1.6.2", "c45f9c55797380c6ba44060f0c73713fbd7989eeb1147aedb8723aa14f3afaa3")
     add_versions("1.7.2", "aa38a414fe2ffc49af13a08b6ab34df825fdd2e7a1213d032d835a779e14176f")
     add_versions("1.8.3", "0784d4c2dbb93a0d3009820b7858976424c56578ce23dcd89d06a1d0bf5fd8e2")
+    add_versions("1.9.3", "df53e7213d80fdc24583528521f7d3349099f5bb4ed05ab05206091a678cc53c")
+    --add_versions("1.10.0", "d669c028bd63a1c8827c32b348ecc85e46747bb33be3b00ce59b77717b91aee8") --require c++ 17
 
     add_configs("ssl", {description = "Enable SSL.", default = false, type = "boolean"})
 


### PR DESCRIPTION
cpr包版本更新至1.9.3
cpr包1.10.0需要c++ 17 故未添加