### PR TITLE
wayland: ensure ninja >= 1.8.2 is present

### DIFF
--- a/packages/w/wayland/xmake.lua
+++ b/packages/w/wayland/xmake.lua
@@ -14,7 +14,7 @@ package("wayland")
         add_extsources("apt::libwayland-dev", "pacman::wayland")
     end
 
-    add_deps("meson", "libxml2", "libffi", "expat", "bison", "pkg-config")
+    add_deps("meson", "ninja >=1.8.2", "libxml2", "libffi", "expat", "bison", "pkg-config")
 
     on_install("linux", function (package)
         -- imports


### PR DESCRIPTION
Should fix this:
```
  => download https://wayland.freedesktop.org/releases/wayland-1.19.0.tar.xz .. ok
downloading resource(protocols: https://wayland.freedesktop.org/releases/wayland-protocols-1.21.tar.xz) to wayland-1.19.0 ..
/usr/bin/curl -SL -A "Xmake/2.7.6+HEAD.7fd2cec12 (Linux;5.15.0-1031-azure) curl/7.81.0" https://wayland.freedesktop.org/releases/wayland-protocols-1.21.tar.xz -o /home/runner/work/NazaraEngine/xmake-global/.xmake/cache/packages/2302/w/wayland/1.19.0/resources/protocols/wayland-protocols-1.21.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  114k  100  114k    0     0   236k      0 --:--:-- --:--:-- --:--:--  236k
/usr/bin/tar -xf /home/runner/work/NazaraEngine/xmake-global/.xmake/cache/packages/2302/w/wayland/1.19.0/resources/protocols/wayland-protocols-1.21.tar.xz -C /home/runner/work/NazaraEngine/xmake-global/.xmake/cache/packages/2302/w/wayland/1.19.0/resources/protocols/wayland-protocols-1.21.tar.xz.dir.tmp
meson -Ddocumentation=false -Dc_link_args=-lm --libdir=lib --prefix=/home/runner/work/NazaraEngine/xmake-global/.xmake/packages/w/wayland/1.19.0/d4813a414d234036bb8606e1e07c959d --libdir=lib -Dbuildtype=release -Db_staticpic=true build_d4813a41
The Meson build system
Version: 1.0.0
Source dir: /home/runner/work/NazaraEngine/xmake-global/.xmake/cache/packages/2302/w/wayland/1.19.0/source
Build dir: /home/runner/work/NazaraEngine/xmake-global/.xmake/cache/packages/2302/w/wayland/1.19.0/source/build_d4813a41
Build type: native build
Project name: wayland
Project version: 1.19.0
C compiler for the host machine: cc (gcc 11.3.0 "cc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0")
C linker for the host machine: cc ld.bfd 2.38
C++ compiler for the host machine: c++ (gcc 11.3.0 "c++ (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0")
C++ linker for the host machine: c++ ld.bfd 2.38
Host machine cpu family: x86_64
Host machine cpu: x86_64
Compiler for C supports arguments -Wno-unused-parameter: YES 
Compiler for C supports arguments -Wstrict-prototypes: YES 
Compiler for C supports arguments -Wmissing-prototypes: YES 
Compiler for C supports arguments -fvisibility=hidden: YES 
Has header "sys/prctl.h" : YES 
Checking for function "accept4" : YES 
Checking for function "mkostemp" : YES 
Checking for function "posix_fallocate" : YES 
Checking for function "prctl" : YES 
Checking for function "memfd_create" : YES 
Checking for function "strndup" : YES 
Found pkg-config: /usr/bin/pkg-config (0.29.2)
Run-time dependency libffi found: YES 3.4.2
Header "sys/signalfd.h" has symbol "SFD_CLOEXEC" : YES 
Header "sys/timerfd.h" has symbol "TFD_CLOEXEC" : YES 
Header "time.h" has symbol "CLOCK_MONOTONIC" : YES 
Checking for function "clock_gettime" : YES 
Run-time dependency expat found: YES 2.4.7
Run-time dependency libxml-2.0 found: YES 2.9.13
Configuring config.h using configuration
Configuring wayland-version.h using configuration
Library m found: YES
Run-time dependency threads found: YES
Program nm found: YES (/usr/bin/nm)
Program wayland-egl-symbols-check found: YES (/home/runner/work/NazaraEngine/xmake-global/.xmake/cache/packages/2302/w/wayland/1.19.0/source/egl/wayland-egl-symbols-check)
Library dl found: YES
Dependency threads found: YES unknown (cached)
Dependency threads found: YES unknown (cached)
Library dl found: YES
Program sed found: YES (/usr/bin/sed)
Program scanner-test.sh found: YES (/home/runner/work/NazaraEngine/xmake-global/.xmake/cache/packages/2302/w/wayland/1.19.0/source/tests/scanner-test.sh)
Build targets in project: 40
NOTICE: Future-deprecated features used:
 * 0.55.0: {'ExternalProgram.path'}
 * 0.62.0: {'pkgconfig.generate variable for builtin directories'}
 * 0.64.0: {'copy arg in configure_file'}

wayland 1.19.0

  User defined options
    buildtype    : release
    libdir       : lib
    prefix       : /home/runner/work/NazaraEngine/xmake-global/.xmake/packages/w/wayland/1.19.0/d4813a414d234036bb8606e1e07c959d
    b_staticpic  : true
    c_link_args  : -lm
    documentation: false


ERROR: Could not detect Ninja v1.8.2 or newer
```