### PR TITLE
fix: package:configs change to package:config

### DIFF
--- a/packages/d/discord/xmake.lua
+++ b/packages/d/discord/xmake.lua
@@ -17,7 +17,7 @@ package("discord")
     add_links("discordcpp")
 
     on_install("windows|x86", "windows|x64", "linux|x64", "macosx|x86_64", "macosx|arm64", function (package)
-        if package:configs("cppapi") then
+        if package:config("cppapi") then
             os.cp("cpp/*.h", package:installdir("include"))
         end
         os.cp("c/*.h", package:installdir("include"))
@@ -45,7 +45,7 @@ package("discord")
             package:add("links", "discord_game_sdk")
         end
 
-        if package:configs("cppapi") then
+        if package:config("cppapi") then
             os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         end
         import("package.tools.xmake").install(package, configs)

--- a/packages/t/tinyxml2/xmake.lua
+++ b/packages/t/tinyxml2/xmake.lua
@@ -28,7 +28,7 @@ package("tinyxml2")
                 add_headerfiles("tinyxml2.h")
                 add_files("tinyxml2.cpp")
         ]])
-        import("package.tools.xmake").install(package, {kind = package:configs("shared")  and "shared" or "static"})
+        import("package.tools.xmake").install(package, {kind = package:config("shared")  and "shared" or "static"})
     end)
 
     on_test(function (package)

--- a/packages/x/x264/xmake.lua
+++ b/packages/x/x264/xmake.lua
@@ -13,7 +13,7 @@ package("x264")
     add_syslinks("pthread", "dl")
     on_install("linux", "macosx", function (package)
         local configs = {"--disable-avs", "--disable-lsmash", "--disable-lavf", "--disable-bashcompletion"}
-        table.insert(configs, "--enable-" .. (package:configs("shared") and "shared" or "static"))
+        table.insert(configs, "--enable-" .. (package:config("shared") and "shared" or "static"))
         if package:config("pic") ~= false then
             table.insert(configs, "--enable-pic")
         end


### PR DESCRIPTION
package:configs 改为 package:config

[configs ](https://github.com/xmake-io/xmake/blob/master/xmake/core/package/package.lua#L1276) 返回是个元组而不是 config 的别名，导致有些库的 shared 开关永远是开的，外部无法切换到静态。
