### PR TITLE
Add GDExtension library

### DIFF
--- a/packages/g/gdextension/xmake.lua
+++ b/packages/g/gdextension/xmake.lua
@@ -1,140 +1,147 @@
 package("gdextension")
 
-  set_homepage("https://godotengine.org/")
-  set_description("C++ bindings for the Godot 4 script API")
-  
-  set_urls("https://github.com/godotengine/godot-cpp.git")
-  add_versions("4.0", "9d1c396c54fc3bdfcc7da4f3abcb52b14f6cce8f")
-  
-  add_deps("scons")
-  add_includedirs("gen/include", "include")
+    set_homepage("https://godotengine.org/")
+    set_description("C++ bindings for the Godot 4 script API")
+    
+    set_urls("https://github.com/godotengine/godot-cpp.git")
+    add_versions("4.0", "9d1c396c54fc3bdfcc7da4f3abcb52b14f6cce8f")
+    
+    add_deps("scons")
+    add_includedirs("gen/include", "include")
 
-  on_load(function(package)
-    assert(not package:is_arch(
-        "mips",
-        "mip64",
-        "mips64",
-        "mipsel",
-        "mips64el",
-        "riscv",
-        "riscv64",
-        "s390x",
-        "sh4"),
-        "architecture " .. package:arch() .. " is not supported")
-  end)
+    on_load(function(package)
+        assert(not package:is_arch(
+                "mips",
+                "mip64",
+                "mips64",
+                "mipsel",
+                "mips64el",
+                "riscv",
+                "riscv64",
+                "s390x",
+                "sh4"),
+                "architecture " .. package:arch() .. " is not supported")
+    end)
  
-  on_install("linux", "windows", "macosx", "mingw", "iphoneos", "android", function(package)
-    import("core.base.option")
-    import("lib.detect.find_tool")
-  
-    local platform = package:plat()
-    if package:is_plat("mingw") then
-        platform = "windows"
-    elseif package:is_plat("macosx") then
-        platform = "macos"
-    elseif package:is_plat("iphoneos") then
-        platform = "ios"
-    end
+    on_install("linux", "windows", "macosx", "mingw", "iphoneos", "android", function(package)
+        import("core.base.option")
+        import("lib.detect.find_tool")
     
-    local arch = package:arch()
-    if package:is_arch("x64") then
-        arch = "x86_64"
-    elseif package:is_arch("x86", "i386") then
-        arch = "x86_32"
-    elseif package:is_arch("arm64-v8a") then
-        arch = "arm64"
-    elseif package:is_arch("arm", "armeabi", "armeabi-v7a", "armv7", "armv7s", "armv7k") then
-        arch = "arm32"
-    elseif package:is_arch("ppc") then
-        arch = "ppc32"
-    end
+        local platform = package:plat()
+        if package:is_plat("mingw") then
+                platform = "windows"
+        elseif package:is_plat("macosx") then
+                platform = "macos"
+        elseif package:is_plat("iphoneos") then
+                platform = "ios"
+        end
+        
+        local arch = package:arch()
+        if package:is_arch("x64") then
+                arch = "x86_64"
+        elseif package:is_arch("x86", "i386") then
+                arch = "x86_32"
+        elseif package:is_arch("arm64-v8a") then
+                arch = "arm64"
+        elseif package:is_arch("arm", "armeabi", "armeabi-v7a", "armv7", "armv7s", "armv7k") then
+                arch = "arm32"
+        elseif package:is_arch("ppc") then
+                arch = "ppc32"
+        end
+        
+        local configs = {
+            "-j " .. (option.get("jobs") or tostring(os.default_njob())),
+            "use_mingw=" .. (package:is_plat("mingw") and "yes" or "no"),
+            "target=" .. (package:debug() and "template_debug" or "template_release"),
+            "platform=" .. platform,
+            "arch=" .. arch,
+            "debug_symbols=" .. (package:debug() and "yes" or "no")
+        }
+        
+        local scons = assert(find_tool("scons"), "scons not found")
+        
+        os.execv(scons.program, configs)
+        os.cp("bin/*." .. (package:is_plat("windows") and "lib" or "a"), package:installdir("lib"))
+        os.cp("include/godot_cpp", package:installdir("include"))
+        os.cp("gen/include/godot_cpp", path.join(package:installdir("gen"), "include", "godot_cpp"))
+        os.cp("gdextension/gdextension_interface.h", package:installdir("include"))
+    end)
     
-    local configs = {
-      "-j " .. (option.get("jobs") or tostring(os.default_njob())),
-      "use_mingw=" .. (package:is_plat("mingw") and "yes" or "no"),
-      "target=" .. (package:debug() and "template_debug" or "template_release"),
-      "platform=" .. platform,
-      "arch=" .. arch,
-      "debug_symbols=" .. (package:debug() and "yes" or "no")
-    }
-    
-    local scons = assert(find_tool("scons"), "scons not found")
-    
-    os.execv(scons.program, configs)
-    os.cp("bin/*." .. (package:is_plat("windows") and "lib" or "a"), package:installdir("lib"))
-    os.cp("include/godot_cpp", package:installdir("include"))
-    os.cp("gen/include/godot_cpp", path.join(package:installdir("gen"), "include", "godot_cpp"))
-    os.cp("gdextension/gdextension_interface.h", package:installdir("include"))
-  end)
-  
-  on_test(function (package)
-    assert(package:check_cxxsnippets({test = [[
-      #include <godot_cpp/classes/global_constants.hpp>
-      #include <godot_cpp/classes/ref_counted.hpp>
-      #include <godot_cpp/core/binder_common.hpp>
-      #include <godot_cpp/variant/utility_functions.hpp>
-      
-      using namespace godot;
-      
-      class ExampleRef : public RefCounted {
-	     GDCLASS(ExampleRef, RefCounted);
-      
-      private:
-	     static int instance_count;
-	     static int last_id;
-      
-	     int id;
-      
-      protected:
-	     static void _bind_methods() {
-		      ClassDB::bind_method(D_METHOD("get_id"), &ExampleRef::get_id);
-	     }
-      
-      public:
-	     ExampleRef() {
-		      id = ++last_id;
-		      instance_count++;
-      
-		      UtilityFunctions::print("ExampleRef ", itos(id), " created, current instance count: ", itos(instance_count));
-	     }
-	     ~ExampleRef() {
-		      instance_count--;
-		      UtilityFunctions::print("ExampleRef ", itos(id), " destroyed, current instance count: ", itos(instance_count));
-	     }
-      
-	     int get_id() const {
-		      return id;
-	     }
-      };
-      
-      int ExampleRef::instance_count = 0;
-      int ExampleRef::last_id = 1;
-      
-      void initialize_example_module(ModuleInitializationLevel p_level) {
-	     if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		      return;
-	     }
-      
-	     ClassDB::register_class<ExampleRef>();
-      }
-      
-      void uninitialize_example_module(ModuleInitializationLevel p_level) {
-	     if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		      return;
-	     }
-      }
-      
-      extern "C" {
-      // Initialization.
-      GDExtensionBool GDE_EXPORT example_library_init(const GDExtensionInterface *p_interface, GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
-	     godot::GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
-      
-	     init_obj.register_initializer(initialize_example_module);
-	     init_obj.register_terminator(uninitialize_example_module);
-	     init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
-      
-	     return init_obj.init();
-      }
-      }
-    ]]}, {configs = {languages = "cxx17"}}))
-  end)
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+        #include <godot_cpp/classes/global_constants.hpp>
+        #include <godot_cpp/classes/ref_counted.hpp>
+        #include <godot_cpp/core/binder_common.hpp>
+        #include <godot_cpp/variant/utility_functions.hpp>
+
+        using namespace godot;
+
+        class ExampleRef : public RefCounted {
+          GDCLASS(ExampleRef, RefCounted);
+
+        private:
+          static int instance_count;
+          static int last_id;
+
+          int id;
+
+        protected:
+          static void _bind_methods() {
+            ClassDB::bind_method(D_METHOD("get_id"), &ExampleRef::get_id);
+          }
+
+        public:
+          ExampleRef() {
+            id = ++last_id;
+            instance_count++;
+
+            UtilityFunctions::print(
+                "ExampleRef ", itos(id),
+                " created, current instance count: ", itos(instance_count));
+          }
+          ~ExampleRef() {
+            instance_count--;
+            UtilityFunctions::print(
+                "ExampleRef ", itos(id),
+                " destroyed, current instance count: ", itos(instance_count));
+          }
+
+          int get_id() const { return id; }
+        };
+
+        int ExampleRef::instance_count = 0;
+        int ExampleRef::last_id = 1;
+
+        void initialize_example_module(ModuleInitializationLevel p_level) {
+          if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+            return;
+          }
+
+          ClassDB::register_class<ExampleRef>();
+        }
+
+        void uninitialize_example_module(ModuleInitializationLevel p_level) {
+          if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+            return;
+          }
+        }
+
+        extern "C" {
+        // Initialization.
+        GDExtensionBool GDE_EXPORT
+        example_library_init(const GDExtensionInterface *p_interface,
+                            GDExtensionClassLibraryPtr p_library,
+                            GDExtensionInitialization *r_initialization) {
+          godot::GDExtensionBinding::InitObject init_obj(p_interface, p_library,
+                                                        r_initialization);
+
+          init_obj.register_initializer(initialize_example_module);
+          init_obj.register_terminator(uninitialize_example_module);
+          init_obj.set_minimum_library_initialization_level(
+              MODULE_INITIALIZATION_LEVEL_SCENE);
+
+          return init_obj.init();
+        }
+        }
+        ]]}, {configs = {languages = "cxx17"}}))
+    end)

--- a/packages/g/gdextension/xmake.lua
+++ b/packages/g/gdextension/xmake.lua
@@ -8,8 +8,22 @@ package("gdextension")
   
   add_deps("scons")
   add_includedirs("gen/include", "include")
+
+  on_load(function(package)
+    assert(not package:is_arch(
+        "mips",
+        "mip64",
+        "mips64",
+        "mipsel",
+        "mips64el",
+        "riscv",
+        "riscv64",
+        "s390x",
+        "sh4"),
+        "architecture " .. package:arch() .. " is not supported")
+  end)
  
-  on_install("linux", "windows", "macosx", "mingw", "iphoneos", "android", "wasm", function(package)
+  on_install("linux", "windows", "macosx", "mingw", "iphoneos", "android", function(package)
     import("core.base.option")
     import("lib.detect.find_tool")
   
@@ -25,11 +39,11 @@ package("gdextension")
     local arch = package:arch()
     if package:is_arch("x64") then
         arch = "x86_64"
-    elseif package:is_arch("x86") then
+    elseif package:is_arch("x86", "i386") then
         arch = "x86_32"
     elseif package:is_arch("arm64-v8a") then
         arch = "arm64"
-    elseif package:is_arch("arm") then
+    elseif package:is_arch("arm", "armeabi", "armeabi-v7a", "armv7", "armv7s", "armv7k") then
         arch = "arm32"
     elseif package:is_arch("ppc") then
         arch = "ppc32"
@@ -41,6 +55,7 @@ package("gdextension")
       "target=" .. (package:debug() and "template_debug" or "template_release"),
       "platform=" .. platform,
       "arch=" .. arch,
+      "debug_symbols=" .. (package:debug() and "yes" or "no")
     }
     
     local scons = assert(find_tool("scons"), "scons not found")

--- a/packages/g/gdextension/xmake.lua
+++ b/packages/g/gdextension/xmake.lua
@@ -1,0 +1,116 @@
+package("gdextension")
+
+  set_homepage("https://godotengine.org/")
+  set_description("C++ bindings for the Godot 4 script API")
+  
+  set_urls("https://github.com/godotengine/godot-cpp.git")
+  add_versions("4.0", "2f07eb07eea9e5ef3a6e9f8707f08cec77db579f")
+  
+  add_deps("scons")
+  add_includedirs("gen/include", "include")
+ 
+  on_install("linux", "windows", "macosx", "mingw", "iphoneos", "android", function(package)
+    local platform = package:plat()
+    if package:is_plat("mingw") then
+        platform = "windows"
+    elseif package:is_plat("macosx") then
+        platform = "macos"
+    elseif package:is_plat("iphoneos") then
+        platform = "ios"
+    end
+    
+    local arch = package:arch()
+    if package:is_arch("x64") then
+    	arch = "x86_64"
+    end
+    
+    local configs = {
+      "-j " .. tostring(os.default_njob()),
+      "use_mingw=" .. (package:is_plat("mingw") and "yes" or "no"),
+      "target=" .. (package:debug() and "template_debug" or "template_release"),
+      "platform=" .. platform,
+      "arch=" .. ((package:is_arch("x64") or package:is_arch("x86_64")) and "x86_64" or "x86_32"),
+    }
+    
+    import("lib.detect.find_tool")
+    local scons = assert(find_tool("scons"), "scons not found")
+    -- assert(scons, "scons not found")
+    
+    os.execv(scons.program, configs)
+    os.cp("bin/*." .. (package:is_plat("windows") and "lib" or "a"), package:installdir("lib"))
+    os.cp("include/godot_cpp", package:installdir("include"))
+    os.cp("gen/include/godot_cpp", path.join(package:installdir("gen"), "include", "godot_cpp"))
+    os.cp("gdextension/gdextension_interface.h", package:installdir("include"))
+  end)
+  
+  on_test(function (package)
+    assert(package:check_cxxsnippets({test = [[
+      #include <godot_cpp/classes/global_constants.hpp>
+      #include <godot_cpp/classes/ref_counted.hpp>
+      #include <godot_cpp/core/binder_common.hpp>
+      #include <godot_cpp/variant/utility_functions.hpp>
+      
+      using namespace godot;
+      
+      class ExampleRef : public RefCounted {
+	     GDCLASS(ExampleRef, RefCounted);
+      
+      private:
+	     static int instance_count;
+	     static int last_id;
+      
+	     int id;
+      
+      protected:
+	     static void _bind_methods() {
+		      ClassDB::bind_method(D_METHOD("get_id"), &ExampleRef::get_id);
+	     }
+      
+      public:
+	     ExampleRef() {
+		      id = ++last_id;
+		      instance_count++;
+      
+		      UtilityFunctions::print("ExampleRef ", itos(id), " created, current instance count: ", itos(instance_count));
+	     }
+	     ~ExampleRef() {
+		      instance_count--;
+		      UtilityFunctions::print("ExampleRef ", itos(id), " destroyed, current instance count: ", itos(instance_count));
+	     }
+      
+	     int get_id() const {
+		      return id;
+	     }
+      };
+      
+      int ExampleRef::instance_count = 0;
+      int ExampleRef::last_id = 1;
+      
+      void initialize_example_module(ModuleInitializationLevel p_level) {
+	     if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		      return;
+	     }
+      
+	     ClassDB::register_class<ExampleRef>();
+      }
+      
+      void uninitialize_example_module(ModuleInitializationLevel p_level) {
+	     if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		      return;
+	     }
+      }
+      
+      extern "C" {
+      // Initialization.
+      GDExtensionBool GDE_EXPORT example_library_init(const GDExtensionInterface *p_interface, GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+	     godot::GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
+      
+	     init_obj.register_initializer(initialize_example_module);
+	     init_obj.register_terminator(uninitialize_example_module);
+	     init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
+      
+	     return init_obj.init();
+      }
+      }
+    ]]}, {configs = {languages = "cxx17"}}))
+  end)

--- a/packages/g/gdextension/xmake.lua
+++ b/packages/g/gdextension/xmake.lua
@@ -4,7 +4,7 @@ package("gdextension")
   set_description("C++ bindings for the Godot 4 script API")
   
   set_urls("https://github.com/godotengine/godot-cpp.git")
-  add_versions("4.0", "2f07eb07eea9e5ef3a6e9f8707f08cec77db579f")
+  add_versions("4.0", "9d1c396c54fc3bdfcc7da4f3abcb52b14f6cce8f")
   
   add_deps("scons")
   add_includedirs("gen/include", "include")
@@ -21,7 +21,7 @@ package("gdextension")
     
     local arch = package:arch()
     if package:is_arch("x64") then
-    	arch = "x86_64"
+        arch = "x86_64"
     end
     
     local configs = {
@@ -29,12 +29,11 @@ package("gdextension")
       "use_mingw=" .. (package:is_plat("mingw") and "yes" or "no"),
       "target=" .. (package:debug() and "template_debug" or "template_release"),
       "platform=" .. platform,
-      "arch=" .. ((package:is_arch("x64") or package:is_arch("x86_64")) and "x86_64" or "x86_32"),
+      "arch=" .. arch,
     }
     
     import("lib.detect.find_tool")
     local scons = assert(find_tool("scons"), "scons not found")
-    -- assert(scons, "scons not found")
     
     os.execv(scons.program, configs)
     os.cp("bin/*." .. (package:is_plat("windows") and "lib" or "a"), package:installdir("lib"))

--- a/packages/g/godotcpp4/xmake.lua
+++ b/packages/g/godotcpp4/xmake.lua
@@ -2,10 +2,10 @@ package("godotcpp4")
 
     set_homepage("https://godotengine.org/")
     set_description("C++ bindings for the Godot 4 script API")
-    
+
     set_urls("https://github.com/godotengine/godot-cpp.git")
     add_versions("4.0", "9d1c396c54fc3bdfcc7da4f3abcb52b14f6cce8f")
-    
+
     add_deps("scons")
     add_includedirs("gen/include", "include")
 
@@ -27,44 +27,44 @@ package("godotcpp4")
             package:add("defines", "DEBUG_ENABLED", "DEBUG_METHODS_ENABLED")
         end
     end)
- 
+
     on_install("linux", "windows|x64", "windows|x86", "macosx", "mingw", "iphoneos", "android", function(package)
         if package:is_plat("windows") then
             io.replace("tools/targets.py", "/MD", "/" .. package:config("vs_runtime"), {plain = true})
         end
-    
+
         local platform = package:plat()
         if package:is_plat("mingw") then
-                platform = "windows"
+            platform = "windows"
         elseif package:is_plat("macosx") then
-                platform = "macos"
+            platform = "macos"
         elseif package:is_plat("iphoneos") then
-                platform = "ios"
+            platform = "ios"
         end
-        
+
         local arch = package:arch()
         if package:is_arch("x86", "i386") then
-                arch = "x86_32"
+            arch = "x86_32"
         elseif package:is_arch("arm64-v8a") then
-                arch = "arm64"
+            arch = "arm64"
         elseif package:is_arch("arm", "armeabi", "armeabi-v7a", "armv7s", "armv7k") then
-                arch = "arm32"
+            arch = "arm32"
         end
-        
+
         local configs = {
             "target=" .. (package:is_debug() and "template_debug" or "template_release"),
             "platform=" .. platform,
             "arch=" .. arch,
             "debug_symbols=" .. (package:is_debug() and "yes" or "no")
         }
-        
+
         import("package.tools.scons").build(package, configs)
         os.cp("bin/*." .. (package:is_plat("windows") and "lib" or "a"), package:installdir("lib"))
         os.cp("include/godot_cpp", package:installdir("include"))
         os.cp("gen/include/godot_cpp", path.join(package:installdir("gen"), "include", "godot_cpp"))
         os.cp("gdextension/gdextension_interface.h", package:installdir("include"))
     end)
-    
+
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
         #include <godot_cpp/classes/global_constants.hpp>

--- a/packages/g/godotcpp4/xmake.lua
+++ b/packages/g/godotcpp4/xmake.lua
@@ -29,9 +29,6 @@ package("godotcpp4")
     end)
  
     on_install("linux", "windows|x64", "windows|x86", "macosx", "mingw", "iphoneos", "android", function(package)
-        import("core.base.option")
-        import("lib.detect.find_tool")
-
         if package:is_plat("windows") then
             io.replace("tools/targets.py", "/MD", "/" .. package:config("vs_runtime"), {plain = true})
         end
@@ -55,17 +52,13 @@ package("godotcpp4")
         end
         
         local configs = {
-            "-j " .. (option.get("jobs") or tostring(os.default_njob())),
-            "use_mingw=" .. (package:is_plat("mingw") and "yes" or "no"),
             "target=" .. (package:is_debug() and "template_debug" or "template_release"),
             "platform=" .. platform,
             "arch=" .. arch,
             "debug_symbols=" .. (package:is_debug() and "yes" or "no")
         }
         
-        local scons = assert(find_tool("scons"), "scons not found")
-        
-        os.execv(scons.program, configs)
+        import("package.tools.scons").build(package, configs)
         os.cp("bin/*." .. (package:is_plat("windows") and "lib" or "a"), package:installdir("lib"))
         os.cp("include/godot_cpp", package:installdir("include"))
         os.cp("gen/include/godot_cpp", path.join(package:installdir("gen"), "include", "godot_cpp"))

--- a/packages/g/godotcpp4/xmake.lua
+++ b/packages/g/godotcpp4/xmake.lua
@@ -28,7 +28,7 @@ package("godotcpp4")
         end
     end)
 
-    on_install("linux", "windows|x64", "windows|x86", "macosx", "mingw", "iphoneos", "android", function(package)
+    on_install("linux", "windows|x64", "windows|x86", "macosx", "iphoneos", "android", function(package)
         if package:is_plat("windows") then
             io.replace("tools/targets.py", "/MD", "/" .. package:config("vs_runtime"), {plain = true})
         end

--- a/packages/g/godotcpp4/xmake.lua
+++ b/packages/g/godotcpp4/xmake.lua
@@ -19,11 +19,22 @@ package("godotcpp4")
                 "s390x",
                 "sh4"),
                 "architecture " .. package:arch() .. " is not supported")
+
+        if package:is_plat("windows") then
+            package:add("defines", "TYPED_METHOD_BIND", "NOMINMAX")
+        end
+        if package:is_debug() then
+            package:add("defines", "DEBUG_ENABLED", "DEBUG_METHODS_ENABLED")
+        end
     end)
  
     on_install("linux", "windows", "macosx", "mingw", "iphoneos", "android", function(package)
         import("core.base.option")
         import("lib.detect.find_tool")
+
+        if package:is_plat("windows") then
+            io.replace("tools/targets.py", "/MD", "/" .. package:config("vs_runtime"), {plain = true})
+        end
     
         local platform = package:plat()
         if package:is_plat("mingw") then
@@ -46,10 +57,10 @@ package("godotcpp4")
         local configs = {
             "-j " .. (option.get("jobs") or tostring(os.default_njob())),
             "use_mingw=" .. (package:is_plat("mingw") and "yes" or "no"),
-            "target=" .. (package:debug() and "template_debug" or "template_release"),
+            "target=" .. (package:is_debug() and "template_debug" or "template_release"),
             "platform=" .. platform,
             "arch=" .. arch,
-            "debug_symbols=" .. (package:debug() and "yes" or "no")
+            "debug_symbols=" .. (package:is_debug() and "yes" or "no")
         }
         
         local scons = assert(find_tool("scons"), "scons not found")

--- a/packages/g/godotcpp4/xmake.lua
+++ b/packages/g/godotcpp4/xmake.lua
@@ -28,7 +28,7 @@ package("godotcpp4")
         end
     end)
  
-    on_install("linux", "windows", "macosx", "mingw", "iphoneos", "android", function(package)
+    on_install("linux", "windows|x64", "windows|x86", "macosx", "mingw", "iphoneos", "android", function(package)
         import("core.base.option")
         import("lib.detect.find_tool")
 

--- a/packages/g/godotcpp4/xmake.lua
+++ b/packages/g/godotcpp4/xmake.lua
@@ -16,8 +16,6 @@ package("godotcpp4")
                 "mips64",
                 "mipsel",
                 "mips64el",
-                "riscv",
-                "riscv64",
                 "s390x",
                 "sh4"),
                 "architecture " .. package:arch() .. " is not supported")
@@ -37,16 +35,12 @@ package("godotcpp4")
         end
         
         local arch = package:arch()
-        if package:is_arch("x64") then
-                arch = "x86_64"
-        elseif package:is_arch("x86", "i386") then
+        if package:is_arch("x86", "i386") then
                 arch = "x86_32"
         elseif package:is_arch("arm64-v8a") then
                 arch = "arm64"
-        elseif package:is_arch("arm", "armeabi", "armeabi-v7a", "armv7", "armv7s", "armv7k") then
+        elseif package:is_arch("arm", "armeabi", "armeabi-v7a", "armv7s", "armv7k") then
                 arch = "arm32"
-        elseif package:is_arch("ppc") then
-                arch = "ppc32"
         end
         
         local configs = {

--- a/packages/g/godotcpp4/xmake.lua
+++ b/packages/g/godotcpp4/xmake.lua
@@ -1,4 +1,4 @@
-package("gdextension")
+package("godotcpp4")
 
     set_homepage("https://godotengine.org/")
     set_description("C++ bindings for the Godot 4 script API")


### PR DESCRIPTION
This is the Godot 4 version of `godotcpp`, but since the API changed drastically I created a new package for it. I don't use `import("package.tools.scons")` directly, because this version of godotcpp uses different arguments. The different arguments such as `plat`, `arch`, `use_mingw` and so on are not universal to scons. They are unique to godot. Therefore the build function for scons needs to be reworked accordingly.
In the mean time I am just using `import("lib.detect.find_tool")` directly and then generate the arguments manually.