### PR TITLE
Add cppast, debug_assert and type_safe (WIP)

### DIFF
--- a/packages/c/cppast/xmake.lua
+++ b/packages/c/cppast/xmake.lua
@@ -6,7 +6,7 @@ package("cppast")
     add_versions("2023.02.07", "3fb7c24bc22d129e9f5cce80c7358fd725b94105")
 
     add_deps("cmake", "debug_assert", "tiny-process-library", "type_safe")
-    add_deps("llvm", { kind = "library", components = "clang" })
+    add_deps("llvm", { kind = "library", configs = {clang = true} })
     add_links("cppast")
 
     on_install("linux", function (package)

--- a/packages/c/cppast/xmake.lua
+++ b/packages/c/cppast/xmake.lua
@@ -1,0 +1,41 @@
+package("cppast")
+    set_homepage("https://github.com/foonathan/cppast")
+    set_description("Library to parse and work with the C++ AST")
+
+    add_urls("https://github.com/foonathan/cppast.git")
+    add_versions("2023.02.07", "3fb7c24bc22d129e9f5cce80c7358fd725b94105")
+
+    add_deps("cmake", "debug_assert", "tiny-process-library", "type_safe")
+    add_deps("llvm", { kind = "library", components = "clang" })
+    add_links("cppast")
+
+    on_install("linux", function (package)
+        io.replace("CMakeLists.txt", [[ OR (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)]], "", { plain = true })
+        local configs = {"-DCPPAST_BUILD_TOOL=ON"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            #include <iostream>
+
+            void test(const char* filepath)
+            {
+                cppast::libclang_compilation_database database(filepath); // the compilation database
+
+                // simple_file_parser allows parsing multiple files and stores the results for us
+                cppast::cpp_entity_index index;
+                cppast::simple_file_parser<cppast::libclang_parser> parser(type_safe::ref(index));
+                try
+                {
+                    cppast::parse_database(parser, database); // parse all files in the database
+                }
+                catch (cppast::libclang_error& ex)
+                {
+                    std::cerr << "fatal libclang error: " << ex.what() << '\n';
+                }
+            }
+        ]]}, {configs = {languages = "c++11"}, includes = {"cppast/libclang_parser.hpp"}}))
+    end)

--- a/packages/c/cppast/xmake.lua
+++ b/packages/c/cppast/xmake.lua
@@ -11,6 +11,7 @@ package("cppast")
 
     on_install("linux", function (package)
         io.replace("CMakeLists.txt", [[ OR (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)]], "", { plain = true })
+        io.replace("src/CMakeLists.txt", "-Werror -Wall -Wextra", "-Wall -Wextra", { plain = true })
         local configs = {"-DCPPAST_BUILD_TOOL=ON"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))

--- a/packages/c/cppast/xmake.lua
+++ b/packages/c/cppast/xmake.lua
@@ -6,7 +6,7 @@ package("cppast")
     add_versions("2023.02.07", "3fb7c24bc22d129e9f5cce80c7358fd725b94105")
 
     add_deps("cmake", "debug_assert", "tiny-process-library", "type_safe")
-    add_deps("llvm", { kind = "library", configs = {clang = true} })
+    add_deps("llvm", {kind = "library"})
     add_links("cppast")
 
     on_install("linux", function (package)

--- a/packages/d/debug_assert/xmake.lua
+++ b/packages/d/debug_assert/xmake.lua
@@ -1,0 +1,35 @@
+package("debug_assert")
+    set_kind("library", {headeronly = true})
+    set_homepage("http://foonathan.net/blog/2016/09/16/assertions.html")
+    set_description("Simple, flexible and modular assertion macro.")
+    set_license("zlib")
+
+    add_urls("https://github.com/foonathan/debug_assert.git")
+    add_versions("2022.11.13", "7ea47091830eec9a9c6a338c8a29da70494692a5")
+
+    add_deps("cmake")
+
+    on_install(function (package)
+        import("package.tools.cmake").install(package)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            #include <iostream>
+
+            struct module_a : 
+            debug_assert::default_handler,          // it uses the default handler
+            debug_assert::set_level<1> // and this level
+            {
+            };
+
+            void module_a_func(void* ptr)
+            {
+            DEBUG_ASSERT(ptr, module_a{});                                  // minimal assertion
+            DEBUG_ASSERT(2 + 2 == 4, module_a{}, debug_assert::level<2>{}); // assertion with level
+            DEBUG_ASSERT(1 == 0, module_a{},
+                    "this should be true"); // assertion with additional parameters, i.e. a message
+            DEBUG_UNREACHABLE(module_a{});       // mark unreachable statements
+            }
+        ]]}, {configs = {languages = "c++11"}, includes = {"debug_assert.hpp"}}))
+    end)

--- a/packages/t/type_safe/xmake.lua
+++ b/packages/t/type_safe/xmake.lua
@@ -1,0 +1,25 @@
+package("type_safe")
+    set_kind("library", {headeronly = true})
+    set_homepage("https://type_safe.foonathan.net")
+    set_description("Zero overhead utilities for preventing bugs at compile time")
+    set_license("MIT")
+
+    add_urls("https://github.com/foonathan/type_safe/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/foonathan/type_safe.git")
+    add_versions("v0.2.2", "34d97123fb9bca04a333565c4a2498425d602ec0c759de4be1b8cfae77d05823")
+
+    add_deps("cmake", "debug_assert")
+
+    on_install(function (package)
+        io.replace("CMakeLists.txt", [[ OR (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)]], "", { plain = true })
+        local configs = {"-DTYPE_SAFE_BUILD_TEST_EXAMPLE=OFF"}
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            void only_unsigned(type_safe::unsigned_t val)
+            {
+            }
+        ]]}, {configs = {languages = "c++11"}, includes = {"type_safe/types.hpp"}}))
+    end)


### PR DESCRIPTION
I'm trying to add [cppast](https://github.com/foonathan/cppast) which is based on LLVM, I couldn't make the llvm package work on Windows (as a library) so I'm working on Linux, however I'm not sure how to link properly LLVM (I only need clang-cpp, clang and clangAST libraries for this example)