### PR TITLE
Fixes compilation issues of glslang and spirv-tools under debug mode msvc

### DIFF
--- a/packages/g/glslang/xmake.lua
+++ b/packages/g/glslang/xmake.lua
@@ -46,6 +46,10 @@ package("glslang")
         io.replace("SPIRV/CMakeLists.txt", "target_link_libraries(SPIRV PRIVATE MachineIndependent SPIRV-Tools-opt)", [[
             target_link_libraries(SPIRV PRIVATE MachineIndependent SPIRV-Tools-opt SPIRV-Tools-link SPIRV-Tools-reduce SPIRV-Tools)
         ]], {plain = true})
+        -- glslang will add a debug lib postfix for win32 platform, disable this to fix compilation issues under windows
+        io.replace("CMakeLists.txt", 'set(CMAKE_DEBUG_POSTFIX "d")', [[
+            message(WARNING "Disabled CMake Debug Postfix for xmake package generation")
+        ]], {plain = true})
         if package:is_plat("wasm") then
             -- wasm-ld doesn't support --no-undefined
             io.replace("CMakeLists.txt", [[add_link_options("-Wl,--no-undefined")]], "", {plain = true})
@@ -54,6 +58,9 @@ package("glslang")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         if package:is_plat("windows") then
             table.insert(configs, "-DBUILD_SHARED_LIBS=OFF")
+            if package:debug() then
+                table.insert(configs, "-DCMAKE_COMPILE_PDB_OUTPUT_DIRECTORY=''")
+            end
         else
             table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         end

--- a/packages/s/spirv-tools/xmake.lua
+++ b/packages/s/spirv-tools/xmake.lua
@@ -44,6 +44,10 @@ package("spirv-tools")
     on_install(function (package)
         package:addenv("PATH", "bin")
         local configs = {"-DSPIRV_SKIP_TESTS=ON", "-DSPIRV_WERROR=OFF"}
+        -- walkaround for potential conflict with parallel build & debug pdb generation
+        if package:debug() then
+            table.insert(configs, "-DCMAKE_COMPILE_PDB_OUTPUT_DIRECTORY=''")
+        end
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         local spirv = package:dep("spirv-headers")


### PR DESCRIPTION
Fixes compilation issues of glslang and spirv-tools under debug mode msvc.

The issue itself is discussed in #2031 and #2032, here's a short summarization:
- Both `spirv-tools` and `glslang` have multiple CMake targets, and while building with msvc the pdb directory set by [modules/package/tools/cmake.lua](https://github.com/xmake-io/xmake/blob/v2.7.7/xmake/modules/package/tools/cmake.lua) is `pdb`. This fails the build under parallel build jobs, with fatal error C1041.
- `glslang` have dedicated CMake debug postfix setting (a `d`) for win32 platform, which renames the actual library generated. The debug build then fails to link.

I've tested this builds under `xmake l .\scripts\test.lua -v -D --shallow -m debug  "spirv-tools"` and `xmake l .\scripts\test.lua -v -D --shallow -m debug  "glslang"`, respectively.
