### PR TITLE
Add nholthaus/units v2.3.3

### DIFF
--- a/packages/u/units/xmake.lua
+++ b/packages/u/units/xmake.lua
@@ -1,0 +1,19 @@
+package("units")
+
+    set_homepage("https://nholthaus.github.io/units/")
+    set_description("A compile-time, header-only, dimensional analysis library built on c++14 with no dependencies.")
+
+    add_urls("https://github.com/nholthaus/units/archive/refs/tags/v2.3.3.tar.gz", "https://github.com/nholthaus/units.git")
+    add_versions("v2.3.3", "b1f3c1dd11afa2710a179563845ce79f13ebf0c8c090d6aa68465b18bd8bd5fc")
+
+    on_install(function (package)
+        io.writefile("xmake.lua", [[
+            add_rules("mode.debug", "mode.release")
+            target("units")
+                set_kind("headeronly")
+                add_includedirs("include", {public = true})
+                add_headerfiles("include/units.h")
+        ]])
+
+        os.cp("include/*.h", package:installdir("include"))
+    end)

--- a/packages/u/units/xmake.lua
+++ b/packages/u/units/xmake.lua
@@ -15,6 +15,7 @@ package("units")
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
             #include <units.h>
+            #include <cassert>
             static void test() {
                 constexpr units::angle::degree_t deg1{90};
                 constexpr units::angle::degree_t deg2{60};

--- a/packages/u/units/xmake.lua
+++ b/packages/u/units/xmake.lua
@@ -1,12 +1,10 @@
 package("units")
-
+    set_kind("library", {headeronly = true})
     set_homepage("https://nholthaus.github.io/units/")
     set_description("A compile-time, header-only, dimensional analysis library built on c++14 with no dependencies.")
 
     add_urls("https://github.com/nholthaus/units/archive/refs/tags/$(version).tar.gz", "https://github.com/nholthaus/units.git")
     add_versions("v2.3.3", "b1f3c1dd11afa2710a179563845ce79f13ebf0c8c090d6aa68465b18bd8bd5fc")
-
-    set_kind("library", {headeronly = true})
 
     on_install(function (package)
         os.cp("include", package:installdir())

--- a/packages/u/units/xmake.lua
+++ b/packages/u/units/xmake.lua
@@ -3,17 +3,24 @@ package("units")
     set_homepage("https://nholthaus.github.io/units/")
     set_description("A compile-time, header-only, dimensional analysis library built on c++14 with no dependencies.")
 
-    add_urls("https://github.com/nholthaus/units/archive/refs/tags/v2.3.3.tar.gz", "https://github.com/nholthaus/units.git")
+    add_urls("https://github.com/nholthaus/units/archive/refs/tags/$(version).tar.gz", "https://github.com/nholthaus/units.git")
     add_versions("v2.3.3", "b1f3c1dd11afa2710a179563845ce79f13ebf0c8c090d6aa68465b18bd8bd5fc")
 
-    on_install(function (package)
-        io.writefile("xmake.lua", [[
-            add_rules("mode.debug", "mode.release")
-            target("units")
-                set_kind("headeronly")
-                add_includedirs("include", {public = true})
-                add_headerfiles("include/units.h")
-        ]])
+    set_kind("library", {headeronly = true})
 
-        os.cp("include/*.h", package:installdir("include"))
+    on_install(function (package)
+        os.cp("include", package:installdir())
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            #include <units.h>
+            static void test() {
+                constexpr units::angle::degree_t deg1{90};
+                constexpr units::angle::degree_t deg2{60};
+            
+                assert(deg1 > deg2);
+                assert(deg1 + deg2 == units::angle::degree_t{150});
+            }
+        ]]}, {configs = {languages = "c++14"}}))
     end)


### PR DESCRIPTION
```
% xmake l scripts/test.lua -v -D units
{ 
  "units" 
}

create test ...
  [+]: xmake.lua
  [+]: src/main.cpp
  [+]: .gitignore
create ok!
/private/var/folders/gw/ygflm0814f14b9r3fdt77dyh0000gn/T/.xmake501/230506/xmake-repo/test
add local repository(local-repo): /Users/user/OSS/xmake-repo ok!
local repositories:
    local-repo /Users/user/OSS/xmake-repo 

global repositories:
    build-artifacts https://gitlab.com/xmake-mirror/build-artifacts.git main 
    xmake-repo https://gitlab.com/tboox/xmake-repo.git master 
    builtin-repo /Users/user/.local/share/xmake/repository 

4 repositories were found!
checking for platform ... macosx
checking for architecture ... arm64
checking for Xcode directory ... /Applications/Xcode.app
checking for Codesign Identity of Xcode ... no
checking for SDK version of Xcode for macosx (arm64) ... 13.1
checking for Minimal target version of Xcode for macosx (arm64) ... 13.1
checkinfo: cannot runv(zig version), No such file or directory
checking for zig ... no
checkinfo: cannot runv(zig version), No such file or directory
checking for zig ... no
configure
{
    plat = macosx
    host = macosx
    ndk_stdcxx = true
    xcode = /Applications/Xcode.app
    buildir = build
    kind = static
    mode = release
    arch = arm64
    ccache = true
    clean = true
}
checking for unzip ... /usr/bin/unzip
checking for git ... /usr/bin/git
checking for gzip ... /usr/bin/gzip
checking for tar ... /usr/bin/tar
/usr/bin/git rev-parse HEAD
checking for ping ... /sbin/ping
pinging for the host(github.com) ... 27 ms
/usr/bin/tar -xf v2.3.3.tar.gz -C source.tmp
finding units from xmake ..
checking for xmake::units ... units v2.3.3
{ 
  version = "v2.3.3",
  sysincludedirs = { 
    "/Users/user/.xmake/packages/u/units/v2.3.3/3ac74a599d0f49908f377480644de449/include" 
  } 
}

patching /Users/user/.xmake/packages/u/units/v2.3.3/3ac74a599d0f49908f377480644de449/lib/pkgconfig/units.pc ..
  => install units v2.3.3 .. ok
```