### PR TITLE
[commonlibsse-ng] Set `fmt_external` for spdlog

### DIFF
--- a/packages/c/commonlibsse-ng/port/xmake.lua
+++ b/packages/c/commonlibsse-ng/port/xmake.lua
@@ -43,7 +43,7 @@ option_end()
 
 -- add packages
 add_requires("fmt", "rapidcsv")
-add_requires("spdlog", { configs = { header_only = false } })
+add_requires("spdlog", { configs = { header_only = false, fmt_external = true } })
 
 if has_config("skse_xbyak") then
     add_requires("xbyak")

--- a/packages/c/commonlibsse-ng/xmake.lua
+++ b/packages/c/commonlibsse-ng/xmake.lua
@@ -16,7 +16,7 @@ package("commonlibsse-ng")
     add_configs("skse_xbyak", {description = "Enable trampoline support for Xbyak", default = false, type = "boolean"})
 
     add_deps("fmt", "rapidcsv")
-    add_deps("spdlog", { configs = { header_only = false } })
+    add_deps("spdlog", { configs = { header_only = false, fmt_external = true } })
 
     add_syslinks("version", "user32", "shell32", "ole32", "advapi32")
 


### PR DESCRIPTION
Forgot to add this when I fixed `spdlog`'s `fmt_external` option. This is necessary because the library always included external fmt

