### PR TITLE
add yy-thunks

### DIFF
--- a/packages/y/yy-thunks/rules/link.lua
+++ b/packages/y/yy-thunks/rules/link.lua
@@ -1,30 +1,32 @@
 rule("xp")
     on_config(function (target)
-        import("core.project.project")
-
         local objectfile = "YY_Thunks_for_WinXP.obj"
-        local installdir = project.required_package("yy-thunks"):installdir()
-        table.insert(target:objectfiles(), path.join(installdir, "lib", objectfile))
+        local thunks = target:pkg("yy-thunks")
+        if thunks then
+            local installdir = thunks:installdir()
+            table.insert(target:objectfiles(), path.join(installdir, "lib", objectfile))
+        end
     end)
 
 rule("vista")
     on_config(function (target)
-        import("core.project.project")
-
         local objectfile = "YY_Thunks_for_Vista.obj"
-        local installdir = project.required_package("yy-thunks"):installdir()
-        table.insert(target:objectfiles(), path.join(installdir, "lib", objectfile))
+        local thunks = target:pkg("yy-thunks")
+        if thunks then
+            local installdir = thunks:installdir()
+            table.insert(target:objectfiles(), path.join(installdir, "lib", objectfile))
+        end
     end)
 
 rule("2k")
     on_config(function (target)
-        import("core.project.project")
-
         if not target:is_arch("x86") then
             raise("Win2K only supports x86 architecture")
         end
 
-        local objectfile = "YY_Thunks_for_Win2K.obj"
-        local installdir = project.required_package("yy-thunks"):installdir()
-        table.insert(target:objectfiles(), path.join(installdir, "lib", objectfile))
+        local thunks = target:pkg("yy-thunks")
+        if thunks then
+            local installdir = thunks:installdir()
+            table.insert(target:objectfiles(), path.join(installdir, "lib", objectfile))
+        end
     end)

--- a/packages/y/yy-thunks/rules/link.lua
+++ b/packages/y/yy-thunks/rules/link.lua
@@ -1,0 +1,30 @@
+rule("xp")
+    on_config(function (target)
+        import("core.project.project")
+
+        local objectfile = "YY_Thunks_for_WinXP.obj"
+        local installdir = project.required_package("yy-thunks"):installdir()
+        table.insert(target:objectfiles(), path.join(installdir, "lib", objectfile))
+    end)
+
+rule("vista")
+    on_config(function (target)
+        import("core.project.project")
+
+        local objectfile = "YY_Thunks_for_Vista.obj"
+        local installdir = project.required_package("yy-thunks"):installdir()
+        table.insert(target:objectfiles(), path.join(installdir, "lib", objectfile))
+    end)
+
+rule("2k")
+    on_config(function (target)
+        import("core.project.project")
+
+        if not target:is_arch("x86") then
+            raise("Win2K only supports x86 architecture")
+        end
+
+        local objectfile = "YY_Thunks_for_Win2K.obj"
+        local installdir = project.required_package("yy-thunks"):installdir()
+        table.insert(target:objectfiles(), path.join(installdir, "lib", objectfile))
+    end)

--- a/packages/y/yy-thunks/xmake.lua
+++ b/packages/y/yy-thunks/xmake.lua
@@ -7,7 +7,7 @@ package("yy-thunks")
     add_urls("https://github.com/Chuyu-Team/YY-Thunks/releases/download/v$(version)/YY-Thunks-$(version)-Binary.zip")
     add_versions("1.0.7", "3607a79ac37f141cbcbf00aaea8d82a4c2628d81d8dad9e2a4dce4c8c17a025b")
 
-    on_install("windows", function (package)
+    on_install("windows|x64", "windows|x86", function (package)
         import("core.tool.toolchain")
 
         -- check vs version

--- a/packages/y/yy-thunks/xmake.lua
+++ b/packages/y/yy-thunks/xmake.lua
@@ -1,0 +1,31 @@
+package("yy-thunks")
+
+    set_homepage("https://github.com/Chuyu-Team/YY-Thunks")
+    set_description("Fix DecodePointer, EncodePointer,RegDeleteKeyEx etc. APIs not found in Windows XP RTM.")
+    set_license("MIT")
+
+    add_urls("https://github.com/Chuyu-Team/YY-Thunks/releases/download/v$(version)/YY-Thunks-$(version)-Binary.zip")
+    add_versions("1.0.7", "3607a79ac37f141cbcbf00aaea8d82a4c2628d81d8dad9e2a4dce4c8c17a025b")
+
+    on_install("windows", function (package)
+        import("core.tool.toolchain")
+
+        -- check vs version
+        local vs = toolchain.load("msvc"):config("vs")
+        if tonumber(vs) < 2005 then
+            raise("YY-Thunks only supports VS2008 or later versions")
+        end
+
+        if package:is_arch("x64") then
+            os.cp("objs/x64/*.obj", package:installdir("lib"))
+        elseif package:is_arch("x86") then
+            os.cp("objs/x86/*.obj", package:installdir("lib"))
+        else
+            raise("Unsupported architecture!")
+        end
+    end)
+
+    on_test(function (package)
+        local obj = path.join(package:installdir("lib"), "YY_Thunks_for_WinXP.obj")
+        assert(os.isfile(obj))
+    end)


### PR DESCRIPTION
Fix DecodePointer, EncodePointer,RegDeleteKeyEx etc. APIs not found in Windows XP RTM.

usage:

```lua
add_requires("yy-thunks")
add_packages("yy-thunks")

add_rules("@yy-thunks/xp")
-- add_rules("@yy-thunks/2k")
-- add_rules("@yy-thunks/vista")
```