### PR TITLE
Fix s7 link error on UOS 20 1050 using loongarch

### DIFF
--- a/packages/s/s7/port/xmake.lua
+++ b/packages/s/s7/port/xmake.lua
@@ -39,4 +39,8 @@ target("s7") do
     if not is_plat("macosx") then
         add_ldflags("-static", "-static-libgcc", {force = true})
     end
+    if is_plat("linux") and (linuxos.name() == "uos") then
+        add_syslinks("pthread")
+        add_ldflags("-ldl")
+    end
 end


### PR DESCRIPTION
## Description
Fix the following error message when linking:
```
error: /usr/bin/ld: build_9a28e489/.objs/s7/linux/loongarch64/release/s7.c.o: in function `.L29335':
(.text+0x8edac): undefined reference to `dlopen'
/usr/bin/ld: build_9a28e489/.objs/s7/linux/loongarch64/release/s7.c.o: in function `.L29343':
(.text+0x8ee20): undefined reference to `dlsym'
/usr/bin/ld: build_9a28e489/.objs/s7/linux/loongarch64/release/s7.c.o: in function `.L29393':
(.text+0x8ef58): undefined reference to `dlerror'
/usr/bin/ld: build_9a28e489/.objs/s7/linux/loongarch64/release/s7.c.o: in function `.L29344':
(.text+0x8f118): undefined reference to `dlerror'
/usr/bin/ld: (.text+0x8f158): undefined reference to `dlclose'
/usr/bin/ld: build_9a28e489/.objs/s7/linux/loongarch64/release/s7.c.o: in function `s7_init':
(.text+0x182038): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: (.text+0x1820b8): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: /usr/lib/gcc/loongarch64-linux-gnu/8/libgcc_eh.a(unwind-dw2-fde-dip.o): in function `.LM1286':
(.text+0x1a8c): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: (.text+0x1a90): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: (.text+0x1a90): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: /usr/lib/gcc/loongarch64-linux-gnu/8/libgcc_eh.a(unwind-dw2-fde-dip.o): in function `.LM1306':
(.text+0x1ad8): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: (.text+0x1adc): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: (.text+0x1adc): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: /usr/lib/gcc/loongarch64-linux-gnu/8/libgcc_eh.a(unwind-dw2-fde-dip.o): in function `.LM1358':
(.text+0x1bd4): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: (.text+0x1bd8): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: (.text+0x1bd8): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: /usr/lib/gcc/loongarch64-linux-gnu/8/libgcc_eh.a(unwind-dw2-fde-dip.o): in function `.LM1378':
(.text+0x1c20): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: (.text+0x1c24): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: (.text+0x1c24): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: /usr/lib/gcc/loongarch64-linux-gnu/8/libgcc_eh.a(unwind-dw2-fde-dip.o): in function `.LM1413':
(.text+0x1cd8): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: (.text+0x1cdc): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: (.text+0x1cdc): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: /usr/lib/gcc/loongarch64-linux-gnu/8/libgcc_eh.a(unwind-dw2-fde-dip.o): in function `.LM1452':
(.text+0x1d78): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: (.text+0x1d7c): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: (.text+0x1d7c): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: /usr/lib/gcc/loongarch64-linux-gnu/8/libgcc_eh.a(unwind-dw2-fde-dip.o): in function `.LM1463':
(.text+0x1dcc): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: (.text+0x1dd0): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: /usr/lib/gcc/loongarch64-linux-gnu/8/libgcc_eh.a(unwind-dw2-fde-dip.o):(.text+0x1dd0): more undefined references to `pthread_mutex_unlock' follow
/usr/bin/ld: /usr/lib/gcc/loongarch64-linux-gnu/8/libgcc_eh.a(unwind-dw2-fde-dip.o): in function `.LM1530':
(.text+0x1f04): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: (.text+0x1f08): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: (.text+0x1f08): undefined reference to `pthread_mutex_lock'
/usr/bin/ld: /usr/lib/gcc/loongarch64-linux-gnu/8/libgcc_eh.a(unwind-dw2-fde-dip.o): in function `.L523':
(.text+0x2028): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: (.text+0x202c): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: (.text+0x202c): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: /usr/lib/gcc/loongarch64-linux-gnu/8/libgcc_eh.a(unwind-dw2-fde-dip.o): in function `.LM1607':
(.text+0x205c): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: (.text+0x2060): undefined reference to `pthread_mutex_unlock'
/usr/bin/ld: /usr/lib/gcc/loongarch64-linux-gnu/8/libgcc_eh.a(unwind-dw2-fde-dip.o):(.text+0x2060): more undefined references to `pthread_mutex_unlock' follow
collect2: error: ld returned 1 exit status
```

## How to test
```
git clone git@github.com:xmake-mirror/s7.git
cd && cp the_new_xmake.lua xmake.lua && xmake
```
