### PR TITLE
S7: fix link on_test

### DIFF
--- a/packages/s/s7/xmake.lua
+++ b/packages/s/s7/xmake.lua
@@ -34,11 +34,6 @@ package("s7")
             ]])
             os.vrunv("s7", {file})
         end
-        if is_plat("linux") then
-            local configs = {syslinks = {"dl"}}
-        else
-            local configs = {}
-        end
         assert(package:check_csnippets([[
             static s7_pointer old_add;           /* the original "+" function for non-string cases */
             static s7_pointer old_string_append; /* same, for "string-append" */
@@ -53,5 +48,5 @@ package("s7")
                     return(s7_apply_function(sc, old_string_append, args));
                 return(s7_apply_function(sc, old_add, args));
             }
-        ]], {configs = configs, includes = "s7.h"}))
+        ]], {configs = {links = {"dl", "s7"}}, includes = "s7.h"}))
     end)

--- a/packages/s/s7/xmake.lua
+++ b/packages/s/s7/xmake.lua
@@ -48,5 +48,5 @@ package("s7")
                     return(s7_apply_function(sc, old_string_append, args));
                 return(s7_apply_function(sc, old_add, args));
             }
-        ]], {configs = {links = {"dl", "s7"}}, includes = "s7.h"}))
+        ]], {includes = "s7.h"}))
     end)

--- a/packages/s/s7/xmake.lua
+++ b/packages/s/s7/xmake.lua
@@ -48,5 +48,5 @@ package("s7")
                     return(s7_apply_function(sc, old_string_append, args));
                 return(s7_apply_function(sc, old_add, args));
             }
-        ]], {includes = "s7.h"}))
+        ]], {configs = {links = {"dl", "s7"}}, includes = "s7.h"}))
     end)

--- a/packages/s/s7/xmake.lua
+++ b/packages/s/s7/xmake.lua
@@ -34,6 +34,11 @@ package("s7")
             ]])
             os.vrunv("s7", {file})
         end
+        if is_plat("linux") then
+            local configs = {syslinks = {"dl"}}
+        else
+            local configs = {}
+        end
         assert(package:check_csnippets([[
             static s7_pointer old_add;           /* the original "+" function for non-string cases */
             static s7_pointer old_string_append; /* same, for "string-append" */
@@ -48,5 +53,5 @@ package("s7")
                     return(s7_apply_function(sc, old_string_append, args));
                 return(s7_apply_function(sc, old_add, args));
             }
-        ]], {configs = {links = {"dl", "s7"}}, includes = "s7.h"}))
+        ]], {configs = configs, includes = "s7.h"}))
     end)

--- a/packages/s/s7/xmake.lua
+++ b/packages/s/s7/xmake.lua
@@ -17,6 +17,10 @@ package("s7")
         end
     end)
 
+    if is_plat("linux") then
+        add_syslinks("pthread", "dl")
+    end
+
     on_install("bsd", "cross", "cygwin", "linux", "macosx", "mingw", "msys", "wasm", "windows", function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         local configs = {}


### PR DESCRIPTION
Here is the error message: https://github.com/XmacsLabs/mogan/actions/runs/5098606818/jobs/9165841420
```
 /usr/bin/ld: /home/runner/.xmake/packages/s/s7/2023.04.13/2a08221166c344c1b133bf3ba8e5b21c/lib/libs7.a(s7.c.o): in function `load_shared_object':
s7.c:(.text+0xab780): undefined reference to `dlopen'
/usr/bin/ld: s7.c:(.text+0xab805): undefined reference to `dlsym'
/usr/bin/ld: s7.c:(.text+0xab8e1): undefined reference to `dlerror'
/usr/bin/ld: s7.c:(.text+0xabacf): undefined reference to `dlerror'
/usr/bin/ld: s7.c:(.text+0xabafe): undefined reference to `dlclose'
```

Tested via:
```
xmake l scripts/test.lua  -vD  s7
```

And the above command line does not on loongarch, we need:
https://github.com/xmake-io/xmake/pull/3783
