### PR TITLE
update miniaudio

### DIFF
--- a/packages/m/miniaudio/xmake.lua
+++ b/packages/m/miniaudio/xmake.lua
@@ -3,7 +3,8 @@ package("miniaudio")
     set_homepage("https://miniaud.io")
     set_description("Single file audio playback and capture library written in C.")
 
-    add_urls("https://github.com/mackron/miniaudio.git")
+    set_urls("https://github.com/mackron/miniaudio/archive/refs/tags/${version}.tar.gz",
+             "https://github.com/mackron/miniaudio.git")
     add_versions("0.11.15", "26b0a9ffc0b2e9d0528106f2f5e4dfc90b0a0d6b")
     add_versions("0.11.16", "ea205fb7b0b63613f7586a4082ec9c42a0381920")
     add_versions("0.11.17", "d76b9a1ac424b5b259c2faeea0dc83d215df522a")

--- a/packages/m/miniaudio/xmake.lua
+++ b/packages/m/miniaudio/xmake.lua
@@ -5,9 +5,9 @@ package("miniaudio")
 
     set_urls("https://github.com/mackron/miniaudio/archive/refs/tags/${version}.tar.gz",
              "https://github.com/mackron/miniaudio.git")
-    add_versions("0.11.15", "26b0a9ffc0b2e9d0528106f2f5e4dfc90b0a0d6b")
-    add_versions("0.11.16", "ea205fb7b0b63613f7586a4082ec9c42a0381920")
-    add_versions("0.11.17", "d76b9a1ac424b5b259c2faeea0dc83d215df522a")
+    add_versions("0.11.15", "24a6d38fe69cd42d91f6c1ad211bb559f6c89768c4671fa05b8027f5601d5457")
+    add_versions("0.11.16", "13320464820491c61bd178b95818fecb7cd0e68f9677d61e1345df6be8d4d77e")
+    add_versions("0.11.17", "4b139065f7068588b73d507d24e865060e942eb731f988ee5a8f1828155b9480")
 
 
     on_install(function (package)

--- a/packages/m/miniaudio/xmake.lua
+++ b/packages/m/miniaudio/xmake.lua
@@ -4,7 +4,10 @@ package("miniaudio")
     set_description("Single file audio playback and capture library written in C.")
 
     add_urls("https://github.com/mackron/miniaudio.git")
-    add_versions("2021.12.31", "42abbbea4602af80d1ccb4a22cdc35813aceee7a")
+    add_versions("0.11.15", "26b0a9ffc0b2e9d0528106f2f5e4dfc90b0a0d6b")
+    add_versions("0.11.16", "ea205fb7b0b63613f7586a4082ec9c42a0381920")
+    add_versions("0.11.17", "d76b9a1ac424b5b259c2faeea0dc83d215df522a")
+
 
     on_install(function (package)
         os.cp("miniaudio.h", package:installdir("include"))

--- a/packages/m/miniaudio/xmake.lua
+++ b/packages/m/miniaudio/xmake.lua
@@ -3,7 +3,7 @@ package("miniaudio")
     set_homepage("https://miniaud.io")
     set_description("Single file audio playback and capture library written in C.")
 
-    set_urls("https://github.com/mackron/miniaudio/archive/refs/tags/${version}.tar.gz",
+    set_urls("https://github.com/mackron/miniaudio/archive/refs/tags/$(version).tar.gz",
              "https://github.com/mackron/miniaudio.git")
     add_versions("0.11.15", "24a6d38fe69cd42d91f6c1ad211bb559f6c89768c4671fa05b8027f5601d5457")
     add_versions("0.11.16", "13320464820491c61bd178b95818fecb7cd0e68f9677d61e1345df6be8d4d77e")


### PR DESCRIPTION
miniaudio now uses git tags for its versions. This patch adds the currently available versions of miniaudio and removes the old fake version.
