### PR TITLE
fix libffi with correct flag

### DIFF
--- a/packages/l/libffi/xmake.lua
+++ b/packages/l/libffi/xmake.lua
@@ -34,18 +34,14 @@ package("libffi")
     end)
 
     on_install("macosx", "linux", "bsd", "mingw", function (package)
-        local configs = {"--disable-silent-rules", "--disable-dependency-tracking"}
-        table.insert(configs, "--libdir=" .. package:installdir("lib"):gsub("\\", "/"))
+        -- https://github.com/libffi/libffi/issues/127
+        local configs = {"--disable-silent-rules", "--disable-dependency-tracking", "--disable-multi-os-directory"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
         if package:debug() then
             table.insert(configs, "--enable-debug")
         end
         import("package.tools.autoconf").install(package, configs)
-        -- @see https://github.com/xmake-io/xmake-repo/pull/2085#issuecomment-1567654930
-        if os.isdir(path.join(package:installdir(), "lib64")) then
-            package:add("linkdirs", "lib", "lib64")
-        end
     end)
 
     on_test(function (package)

--- a/packages/n/ncurses/xmake.lua
+++ b/packages/n/ncurses/xmake.lua
@@ -14,6 +14,9 @@ package("ncurses")
 
     add_configs("widec", {description = "Compile with wide-char/UTF-8 code.", default = true, type = "boolean"})
 
+    if is_plat("linux") then
+        add_extsources("apt::libncurses-dev")
+    end
     on_load(function (package)
         if package:config("widec") then
             package:add("links", "ncursesw", "formw", "panelw", "menuw")


### PR DESCRIPTION
https://github.com/xmake-io/xmake-repo/pull/2129

https://github.com/libffi/libffi/issues/127 这里应该是加--disable-multi-os-directory让libffi装到lib 文件夹更好，而不是xmake中加入lib64兼容