### PR TITLE
[imgui] Add `v1.89.6`, include misc cpp

### DIFF
--- a/packages/i/imgui/port/xmake.lua
+++ b/packages/i/imgui/port/xmake.lua
@@ -10,7 +10,7 @@ option("opengl2",          {showmenu = true,  default = false})
 option("opengl3",          {showmenu = true,  default = false})
 option("glad",             {showmenu = true,  default = false})
 option("sdl2",             {showmenu = true,  default = false})
-option("sdlrenderer",      {showmenu = true,  default = false})
+option("sdlrenderer2",     {showmenu = true,  default = false})
 option("vulkan",           {showmenu = true,  default = false})
 option("win32",            {showmenu = true,  default = false})
 option("freetype",         {showmenu = true,  default = false})
@@ -25,7 +25,7 @@ if has_config("glad") then
     add_requires("glad")
 end
 
-if has_config("sdlrenderer") then
+if has_config("sdlrenderer2") then
     add_requires("libsdl >=2.0.17")
 elseif has_config("sdl2") then
     add_requires("libsdl")
@@ -41,9 +41,9 @@ end
 
 target("imgui")
     set_kind("static")
-    add_files("*.cpp")
-    add_headerfiles("*.h")
-    add_includedirs(".")
+    add_files("*.cpp", "misc/cpp/*.cpp")
+    add_headerfiles("*.h", "(misc/cpp/*.h)")
+    add_includedirs(".", "misc/cpp")
 
     if has_config("dx9") then
         add_files("backends/imgui_impl_dx9.cpp")
@@ -98,9 +98,14 @@ target("imgui")
         add_packages("libsdl")
     end
 
-    if has_config("sdlrenderer") then
-        add_files("backends/imgui_impl_sdlrenderer.cpp")
-        add_headerfiles("(backends/imgui_impl_sdlrenderer.h)")
+    if has_config("sdlrenderer2") then
+        if os.exists("backends/imgui_impl_sdlrenderer2.cpp") then
+            add_files("backends/imgui_impl_sdlrenderer2.cpp")
+            add_headerfiles("(backends/imgui_impl_sdlrenderer2.h)")
+        else
+            add_files("backends/imgui_impl_sdlrenderer.cpp")
+            add_headerfiles("(backends/imgui_impl_sdlrenderer.h)")
+        end
         add_packages("libsdl")
     end
 

--- a/packages/i/imgui/port/xmake.lua
+++ b/packages/i/imgui/port/xmake.lua
@@ -10,7 +10,7 @@ option("opengl2",          {showmenu = true,  default = false})
 option("opengl3",          {showmenu = true,  default = false})
 option("glad",             {showmenu = true,  default = false})
 option("sdl2",             {showmenu = true,  default = false})
-option("sdlrenderer2",     {showmenu = true,  default = false})
+option("sdl2_renderer",    {showmenu = true,  default = false})
 option("vulkan",           {showmenu = true,  default = false})
 option("win32",            {showmenu = true,  default = false})
 option("freetype",         {showmenu = true,  default = false})
@@ -25,7 +25,7 @@ if has_config("glad") then
     add_requires("glad")
 end
 
-if has_config("sdlrenderer2") then
+if has_config("sdl2_renderer") then
     add_requires("libsdl >=2.0.17")
 elseif has_config("sdl2") then
     add_requires("libsdl")
@@ -98,7 +98,7 @@ target("imgui")
         add_packages("libsdl")
     end
 
-    if has_config("sdlrenderer2") then
+    if has_config("sdl2_renderer") then
         if os.exists("backends/imgui_impl_sdlrenderer2.cpp") then
             add_files("backends/imgui_impl_sdlrenderer2.cpp")
             add_headerfiles("(backends/imgui_impl_sdlrenderer2.h)")

--- a/packages/i/imgui/xmake.lua
+++ b/packages/i/imgui/xmake.lua
@@ -40,9 +40,9 @@ package("imgui")
     add_configs("glfw",             {description = "Enable the glfw backend", default = false, type = "boolean"})
     add_configs("opengl2",          {description = "Enable the opengl2 backend", default = false, type = "boolean"})
     add_configs("opengl3",          {description = "Enable the opengl3 backend", default = false, type = "boolean"})
-    add_configs("sdl2",             {description = "Enable the sdl2 backend with sdlrenderer", default = false, type = "boolean"})
-    add_configs("sdl2_no_renderer", {description = "Enable the sdl2 backend without sdlrenderer", default = false, type = "boolean"})
-    add_configs("sdlrenderer2",     {description = "Enable the sdlrenderer2 backend", default = false, type = "boolean"})
+    add_configs("sdl2",             {description = "Enable the sdl2 backend with sdl2_renderer", default = false, type = "boolean"})
+    add_configs("sdl2_no_renderer", {description = "Enable the sdl2 backend without sdl2_renderer", default = false, type = "boolean"})
+    add_configs("sdl2_renderer",    {description = "Enable the sdl2 renderer backend", default = false, type = "boolean"})
     add_configs("vulkan",           {description = "Enable the vulkan backend", default = false, type = "boolean"})
     add_configs("win32",            {description = "Enable the win32 backend", default = false, type = "boolean"})
     add_configs("freetype",         {description = "Use FreeType to build and rasterize the font atlas", default = false, type = "boolean"})
@@ -63,11 +63,8 @@ package("imgui")
 
     on_load("macosx", "linux", "windows", "mingw", "android", "iphoneos", function (package)
         -- begin: backwards compatibility
-        if package:config("sdl2") then
-            package:config_set("sdlrenderer2", true)
-        end
-        if package:config("sdlrenderer") then
-            package:config_set("sdlrenderer2", true)
+        if package:config("sdl2") or package:config("sdlrenderer") then
+            package:config_set("sdl2_renderer", true)
         end
         if package:config("glfw_opengl3") then
             package:config_set("glfw", true)
@@ -94,7 +91,7 @@ package("imgui")
         if package:config("sdl2_no_renderer") then
             package:add("deps", "libsdl")
         end
-        if package:config("sdlrenderer2") then
+        if package:config("sdl2_renderer") then
             package:add("deps", "libsdl >=2.0.17")
         end
         if package:config("vulkan") then
@@ -119,7 +116,7 @@ package("imgui")
             opengl3          = package:config("opengl3"),
             glad             = package:config("opengl3") and (not package:gitref() and package:version():lt("1.84")),
             sdl2             = package:config("sdl2") or package:config("sdl2_no_renderer"),
-            sdlrenderer2     = package:config("sdlrenderer2"),
+            sdl2_renderer    = package:config("sdl2_renderer"),
             vulkan           = package:config("vulkan"),
             win32            = package:config("win32"),
             freetype         = package:config("freetype"),

--- a/packages/i/imgui/xmake.lua
+++ b/packages/i/imgui/xmake.lua
@@ -6,6 +6,8 @@ package("imgui")
 
     add_urls("https://github.com/ocornut/imgui/archive/$(version).tar.gz",
              "https://github.com/ocornut/imgui.git")
+    add_versions("v1.89.6-docking", "823a1385a269d923d35b82b2f470f3ae1fa8b5a3")
+    add_versions("v1.89.6", "e95d1cba1481e66386acda3e7da19cd738da86c6c2a140a48fa55046e5f6e208")
     add_versions("v1.89.5-docking", "0ea3b87bd63ecbf359585b7c235839146e84dedb")
     add_versions("v1.89.5", "eab371005c86dd029523a0c4ba757840787163740d45c1f4e5a110eb21820546")
     add_versions("v1.89.4-docking", "9e30fb0ec1b44dc1b041db6bdd53b130b2a18509")
@@ -40,7 +42,7 @@ package("imgui")
     add_configs("opengl3",          {description = "Enable the opengl3 backend", default = false, type = "boolean"})
     add_configs("sdl2",             {description = "Enable the sdl2 backend with sdlrenderer", default = false, type = "boolean"})
     add_configs("sdl2_no_renderer", {description = "Enable the sdl2 backend without sdlrenderer", default = false, type = "boolean"})
-    add_configs("sdlrenderer",      {description = "Enable the sdlrenderer backend", default = false, type = "boolean"})
+    add_configs("sdlrenderer2",     {description = "Enable the sdlrenderer2 backend", default = false, type = "boolean"})
     add_configs("vulkan",           {description = "Enable the vulkan backend", default = false, type = "boolean"})
     add_configs("win32",            {description = "Enable the win32 backend", default = false, type = "boolean"})
     add_configs("freetype",         {description = "Use FreeType to build and rasterize the font atlas", default = false, type = "boolean"})
@@ -48,11 +50,12 @@ package("imgui")
     add_configs("wchar32",          {description = "Use 32-bit for ImWchar (default is 16-bit)", default = false, type = "boolean"})
 
     -- deprecated configs (kept for backwards compatibility)
+    add_configs("sdlrenderer",  {description = "(deprecated)", default = false, type = "boolean"})
     add_configs("glfw_opengl3", {description = "(deprecated)", default = false, type = "boolean"})
     add_configs("glfw_vulkan",  {description = "(deprecated)", default = false, type = "boolean"})
     add_configs("sdl2_opengl3", {description = "(deprecated)", default = false, type = "boolean"})
 
-    add_includedirs("include", "include/imgui", "include/backends")
+    add_includedirs("include", "include/imgui", "include/backends", "include/misc/cpp")
 
     if is_plat("windows", "mingw") then
         add_syslinks("imm32")
@@ -60,6 +63,12 @@ package("imgui")
 
     on_load("macosx", "linux", "windows", "mingw", "android", "iphoneos", function (package)
         -- begin: backwards compatibility
+        if package:config("sdl2") then
+            package:config_set("sdlrenderer2", true)
+        end
+        if package:config("sdlrenderer") then
+            package:config_set("sdlrenderer2", true)
+        end
         if package:config("glfw_opengl3") then
             package:config_set("glfw", true)
             package:config_set("opengl3", true)
@@ -82,13 +91,10 @@ package("imgui")
                 package:add("defines", "IMGUI_IMPL_OPENGL_LOADER_GLAD")
             end
         end
-        if package:config("sdl2") then
-            package:config_set("sdlrenderer", true) -- backwards compatibility
-        end
         if package:config("sdl2_no_renderer") then
             package:add("deps", "libsdl")
         end
-        if package:config("sdlrenderer") then
+        if package:config("sdlrenderer2") then
             package:add("deps", "libsdl >=2.0.17")
         end
         if package:config("vulkan") then
@@ -113,7 +119,7 @@ package("imgui")
             opengl3          = package:config("opengl3"),
             glad             = package:config("opengl3") and (not package:gitref() and package:version():lt("1.84")),
             sdl2             = package:config("sdl2") or package:config("sdl2_no_renderer"),
-            sdlrenderer      = package:config("sdlrenderer"),
+            sdlrenderer2     = package:config("sdlrenderer2"),
             vulkan           = package:config("vulkan"),
             win32            = package:config("win32"),
             freetype         = package:config("freetype"),


### PR DESCRIPTION
- Add version `v1.89.6` and `v1.89.6-docking`
- Include misc cpp helpers like `imgui_stdlib`
- Change `sdlrenderer` to `sdlrenderer2` to coincide with upcoming `sdl3` and `sdlrenderer3` support

