### PR TITLE
update trantor patch for win(off_t)

### DIFF
--- a/packages/t/trantor/patches/1.5.8/fix-win-off_t.patch
+++ b/packages/t/trantor/patches/1.5.8/fix-win-off_t.patch
@@ -1,0 +1,34 @@
+From 1ffb6c77389111de72985a92bf1519352d86ada4 Mon Sep 17 00:00:00 2001
+From: fenlog <bakurise@qq.com>
+Date: Tue, 20 Jun 2023 11:34:06 +0800
+Subject: [PATCH] fix off_t(windows is long, not longlong)
+
+---
+ trantor/net/inner/TcpConnectionImpl.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/trantor/net/inner/TcpConnectionImpl.cc b/trantor/net/inner/TcpConnectionImpl.cc
+index 22f90c9..633050e 100644
+--- a/trantor/net/inner/TcpConnectionImpl.cc
++++ b/trantor/net/inner/TcpConnectionImpl.cc
+@@ -1477,7 +1477,7 @@ void TcpConnectionImpl::sendFile(FILE *fp, size_t offset, size_t length)
+     BufferNodePtr node = std::make_shared<BufferNode>();
+     node->sendFp_ = fp;
+ #endif
+-    node->offset_ = static_cast<off_t>(offset);
++    node->offset_ = offset;
+     node->fileBytesToSend_ = length;
+     if (loop_->isInLoopThread())
+     {
+@@ -1758,7 +1758,7 @@ void TcpConnectionImpl::sendFileInLoop(const BufferNodePtr &filePtr)
+             if (nSend >= 0)
+             {
+                 filePtr->fileBytesToSend_ -= nSend;
+-                filePtr->offset_ += static_cast<off_t>(nSend);
++                filePtr->offset_ += nSend;
+                 if (static_cast<size_t>(nSend) < static_cast<size_t>(n))
+                 {
+                     if (!ioChannelPtr_->isWriting())
+-- 
+2.37.1.windows.1
+

--- a/packages/t/trantor/xmake.lua
+++ b/packages/t/trantor/xmake.lua
@@ -20,6 +20,7 @@ package("trantor")
     add_deps("cmake")
     add_deps("openssl", "c-ares", {optional = true})
     if is_plat("windows") or is_plat("mingw") then
+	    add_patches("v1.5.8", path.join(os.scriptdir(), "patches", "1.5.8", "fix-win-off_t.patch" ),"f0d7fbfc98085ed8b5f6c7504be29b18ddcd6fe4e14e3551396a643fc4574dc0")
         add_syslinks("ws2_32")
     elseif is_plat("linux") then
         add_syslinks("pthread")


### PR DESCRIPTION
in lib trantor, on windows off_t is defined with long, not longlong, it will be error when off_t is more than 4GB .

patch it.