### PR TITLE
Fixing sfml package for mingw

### DIFF
--- a/packages/s/sfml/xmake.lua
+++ b/packages/s/sfml/xmake.lua
@@ -137,9 +137,9 @@ package("sfml")
                     package:add("deps", "libx11", "libxext", "libxrandr", "libxrender", "freetype", "eudev")
                     package:add("deps", "opengl", "glx", {optional = true})
                 end
-                if package:config("audio") then
-                    package:add("deps", "libogg", "libflac", "libvorbis", "openal-soft")
-                end
+            end
+            if package:config("audio") then
+                package:add("deps", "libogg", "libflac", "libvorbis", "openal-soft")
             end
             package:add("components", "system")
             for _, component in ipairs({"graphics", "window", "audio", "network"}) do


### PR DESCRIPTION
For some reason, the dependencies of the audio module of SFML were only taken into account when targetting Linux. 
I just moved the dependency code out of the if statement.
Just tested it in local and it works.