### PR TITLE
Update c++ standard

### DIFF
--- a/packages/b/benchmark/xmake.lua
+++ b/packages/b/benchmark/xmake.lua
@@ -55,5 +55,5 @@ package("benchmark")
             }
             BENCHMARK(BM_empty);
             BENCHMARK(BM_empty)->ThreadPerCpu();
-        ]]}, {configs = {languages = "c++11"}, includes = "benchmark/benchmark.h"}))
+        ]]}, {configs = {languages = "c++14"}, includes = "benchmark/benchmark.h"}))
     end)


### PR DESCRIPTION
We need c++14 to compile the test of 1.8.0.