### PR TITLE
Auto-update entt to v3.12.1

### DIFF
--- a/packages/e/entt/xmake.lua
+++ b/packages/e/entt/xmake.lua
@@ -6,6 +6,7 @@ package("entt")
 
     set_urls("https://github.com/skypjack/entt/archive/$(version).tar.gz",
              "https://github.com/skypjack/entt.git")
+    add_versions("v3.12.1", "7dc4fc74cc32c1ec74b37419140d9334563bb22ab1b92ad9be580703da05b8ac")
     add_versions("v3.11.1", "0ac010f232d3089200c5e545bcbd6480cf68b705de6930d8ff7cdb0a29f5b47b")
     add_versions("v3.11.0", "7cca2bd4d4aeef6c5bdbe06b9e047e7f2519ebaff901207cc81ac71a2bbe185e")
     add_versions("v3.10.3", "315918fc678e89a326ce1c13b0e9d3e53882dd9c58a63fef413325917a5c753b")


### PR DESCRIPTION
New version of entt detected (package version: v3.11.1, last github version: v3.12.1)