### PR TITLE
Auto-update libpng to v1.6.40

### DIFF
--- a/packages/l/libpng/xmake.lua
+++ b/packages/l/libpng/xmake.lua
@@ -6,7 +6,7 @@ package("libpng")
 
     set_urls("https://github.com/glennrp/libpng/archive/$(version).zip",
              "https://github.com/glennrp/libpng.git")
-    add_versions("v1.7.0beta89", "328e8a168ba5ea532fbf5cb1f5fabc2adaec6a58164016688f162392a37caec3")
+    add_versions("v1.6.40", "62d25af25e636454b005c93cae51ddcd5383c40fa14aa3dae8f6576feb5692c2")
     add_versions("v1.6.37", "c2c50c13a727af73ecd3fc0167d78592cf5e0bca9611058ca414b6493339c784")
     add_versions("v1.6.36", "6274d3f761cc80f7f6e2cde6c07bed10c00bc4ddd24c4f86e25eb51affa1664d")
     add_versions("v1.6.35", "3d22d46c566b1761a0e15ea397589b3a5f36ac09b7c785382e6470156c04247f")

--- a/packages/l/libpng/xmake.lua
+++ b/packages/l/libpng/xmake.lua
@@ -6,6 +6,7 @@ package("libpng")
 
     set_urls("https://github.com/glennrp/libpng/archive/$(version).zip",
              "https://github.com/glennrp/libpng.git")
+    add_versions("v1.7.0beta89", "328e8a168ba5ea532fbf5cb1f5fabc2adaec6a58164016688f162392a37caec3")
     add_versions("v1.6.37", "c2c50c13a727af73ecd3fc0167d78592cf5e0bca9611058ca414b6493339c784")
     add_versions("v1.6.36", "6274d3f761cc80f7f6e2cde6c07bed10c00bc4ddd24c4f86e25eb51affa1664d")
     add_versions("v1.6.35", "3d22d46c566b1761a0e15ea397589b3a5f36ac09b7c785382e6470156c04247f")


### PR DESCRIPTION
New version of libpng detected (package version: v1.6.37, last github version: v1.7.0beta89)