### PR TITLE
Auto-update ordered_map to v1.1.0

### DIFF
--- a/packages/o/ordered_map/xmake.lua
+++ b/packages/o/ordered_map/xmake.lua
@@ -8,6 +8,7 @@ package("ordered_map")
     set_urls("https://github.com/Tessil/ordered-map/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Tessil/ordered-map.git")
 
+    add_versions("v1.1.0", "d6070502351646d68f2bbe6078c0da361bc1db733ee8a392e33cfb8b31183e28")
     add_versions("v1.0.0", "49cd436b8bdacb01d5f4afd7aab0c0d6fa57433dfc29d65f08a5f1ed1e2af26b")
 
     on_install(function (package)


### PR DESCRIPTION
New version of ordered_map detected (package version: v1.0.0, last github version: v1.1.0)