### PR TITLE
Auto-update hopscotch-map to v2.3.1

### DIFF
--- a/packages/h/hopscotch-map/xmake.lua
+++ b/packages/h/hopscotch-map/xmake.lua
@@ -7,6 +7,7 @@ package("hopscotch-map")
     set_urls("https://github.com/Tessil/hopscotch-map/archive/$(version).zip",
              "https://github.com/Tessil/hopscotch-map.git")
 
+    add_versions("v2.3.1", "0a77f4835379e74bb7a1c043f3b3c498272acca1c70b03dd5a0444fddf28b316")
     add_versions("v2.3.0", "56ce4ff67215656065ee1a08948533baf9447c4440196ea5133c024856006938")
 
     on_install(function (package)


### PR DESCRIPTION
New version of hopscotch-map detected (package version: v2.3.0, last github version: v2.3.1)