### PR TITLE
Fix link error when building boost with a different toolset

### DIFF
--- a/packages/b/boost/xmake.lua
+++ b/packages/b/boost/xmake.lua
@@ -220,8 +220,8 @@ package("boost")
             "threading=" .. (package:config("multi") and "multi" or "single"),
             "debug-symbols=" .. (package:debug() and "on" or "off"),
             "link=" .. (package:config("shared") and "shared" or "static"),
-            "variant="..(package:is_debug() and "debug" or "release"),
-            "runtime-debugging="..(package:is_debug() and "on" or "off")
+            "variant=" .. (package:is_debug() and "debug" or "release"),
+            "runtime-debugging=" .. (package:is_debug() and "on" or "off")
         }
 
         if package:config("lto") then
@@ -245,7 +245,7 @@ package("boost")
                 table.insert(argv, "runtime-link=shared")
             end
             table.insert(argv, "cxxflags=-std:c++14")
-            table.insert(argv, "toolset="..(is_clang_cl and "clang-win" or "msvc"))
+            table.insert(argv, "toolset=" .. (is_clang_cl and "clang-win" or "msvc"))
         elseif package:is_plat("mingw") then
             table.insert(argv, "toolset=gcc")
         else

--- a/packages/b/boost/xmake.lua
+++ b/packages/b/boost/xmake.lua
@@ -157,8 +157,8 @@ package("boost")
                 local vs_toolset = msvc:config("vs_toolset")
                 local msvc_ver = ""
                 if vs_toolset then
-                    local i1, i2 = vs_toolset:find("%.")
-                    msvc_ver = string.sub(vs_toolset, 1, i2 + 1)
+                    local i = vs_toolset:find("%.")
+                    msvc_ver = i and vs_toolset:sub(1, i + 1)
                 end
 
                 -- Specifying a version will disable b2 from forcing tools

--- a/packages/b/boost/xmake.lua
+++ b/packages/b/boost/xmake.lua
@@ -154,11 +154,9 @@ package("boost")
                     msvc_ver = string.sub(vs_toolset, 1, i2 + 1)
                 end
 
-                -- Specifying a version will disable b2 from using tools
+                -- Specifying a version will disable b2 from forcing tools
                 -- from the latest installed msvc version.
-                -- Useful when VS version doesn't match msvc version.
-                -- e.g vs_toolset 14.1 on Visual Studio 2022
-                file:print("using msvc : %s : ;", msvc_ver)
+                file:print("using msvc : %s : \"%s\" ;", msvc_ver, (package:build_getenv("cxx"):gsub("\\", "\\\\")))
             else
                 file:print("using gcc : : %s ;", package:build_getenv("cxx"):gsub("\\", "/"))
             end

--- a/packages/b/boost/xmake.lua
+++ b/packages/b/boost/xmake.lua
@@ -134,7 +134,14 @@ package("boost")
 
     on_install("macosx", "linux", "windows", "bsd", "mingw", "cross", function (package)
         import("core.base.option")
+        import("core.tool.toolchain")
 
+        -- get msvc
+        local msvc
+        if package:is_plat("windows") then
+            msvc = toolchain.load("msvc", {plat = package:plat(), arch = package:arch()})
+        end
+        
         -- force boost to compile with the desired compiler
         local file = io.open("user-config.jam", "a")
         if file then
@@ -147,7 +154,7 @@ package("boost")
                 end
                 file:print("using darwin : : %s ;", cc)
             elseif package:is_plat("windows") then
-                local vs_toolset = import("core.tool.toolchain").load("msvc"):config("vs_toolset")
+                local vs_toolset = msvc:config("vs_toolset")
                 local msvc_ver = ""
                 if vs_toolset then
                     local i1, i2 = vs_toolset:find("%.")
@@ -170,10 +177,9 @@ package("boost")
             "--without-icu"
         }
 
-        local runenvs = nil
+        local runenvs
         if package:is_plat("windows") then
-            import("core.tool.toolchain")
-            runenvs = toolchain.load("msvc"):runenvs()
+            runenvs = msvc:runenvs()
             -- for bootstrap.bat, all other arguments are useless
             bootstrap_argv = { "msvc" }
             os.vrunv("bootstrap.bat", bootstrap_argv, {envs = runenvs})


### PR DESCRIPTION
When building boost statically without specifying an msvc version in the config file, b2 will call the environment setup for msvc and activate the latest toolset. This works for the default case, but when you have multiple toolsets installed and aren't using the latest one, the libraries will fail because link.exe will not match the user's environment.

An example error when compiling program_options with msvc 14.1 from Visual Studio 2022 build tools:

```
error LNK2019: unresolved external symbol "__std_count_trivial_1" referenced in function...
```