### PR TITLE
Fix missing `numpy` when linking boost.python and linking wrong library name when turn debug on.

### DIFF
--- a/packages/b/boost/xmake.lua
+++ b/packages/b/boost/xmake.lua
@@ -84,7 +84,7 @@ package("boost")
             else
                 linkname = "boost_" .. libname
             end
-            if libname == "python" then
+            if libname == "python" or libname == "numpy" then
                 linkname = linkname .. package:config("pyver"):gsub("%p+", "")
             end
             if package:config("multi") then
@@ -103,11 +103,16 @@ package("boost")
                 elseif vs_runtime == "MDd" then
                     linkname = linkname .. "-gd"
                 end
+            else
+                if package:debug() then
+                    linkname = linkname .. "-d"
+                end
             end
             return linkname
         end
         -- we need the fixed link order
         local sublibs = {log = {"log_setup", "log"},
+                         python = {"python", "numpy"},
                          stacktrace = {"stacktrace_backtrace", "stacktrace_basic"}}
         for _, libname in ipairs(libnames) do
             local libs = sublibs[libname]


### PR DESCRIPTION
1. boost.python has 2 sub-library python and numpy, but the numpy is missing here.
2. the library name is added `-d` as suffix when turned on debug, so we need to append `-d` at the end of linkname if `package:debug()`