### PR TITLE
Add emscripten

### DIFF
--- a/packages/e/emscripten/xmake.lua
+++ b/packages/e/emscripten/xmake.lua
@@ -11,6 +11,7 @@ package("emscripten")
     add_deps("python")
 
     on_install("windows", "macosx", "linux", function (package)
+        import("lib.detect.find_directory")
 		-- copy to installdir
         os.cp("*", package:installdir())
 	
@@ -18,28 +19,25 @@ package("emscripten")
         local version = package:version():rawstr()
         local installdir = package:installdir()
         local py = package:is_plat("windows") and "python" or "python3"
-
         os.vrunv(py, {path.join(installdir, "emsdk.py"), "install", version})
 
         -- activation
         os.vrunv(py, {path.join(installdir, "emsdk.py"), "activate", version})
 
         -- setup env
-        local node = os.dirs(path.join(installdir, "node/**"))[1]
+        local node = find_directory("bin", {path.join(installdir, "node", "**")})
         package:addenv("PATH", node)
-
         package:addenv("PATH", path.join(installdir, "upstream", "emscripten"))
         package:addenv("PATH", installdir)
         package:addenv("EMSDK", installdir)
-
+    
         local exe = package:is_plat("windows") and ".exe" or ""
 
-        package:addenv("EMSDK_NODE", path.join(node, "bin", "node"..exe))
+        package:addenv("EMSDK_NODE", path.join(node, "node" .. exe))
         if package:is_plat("windows") then
-            local python = os.dirs(path.join(installdir, "python/**"))[1]
-            package:addenv("EMSDK_PYTHON", path.join(python, "python"..exe))
-
-            local java = os.dirs(path.join(installdir, "java/**"))[1]
+            local python = find_directory("*", path.join(installdir, "python"))
+            package:addenv("EMSDK_PYTHON", path.join(python, "python" .. exe))
+            local java = find_directory("*", path.join(installdir, "java"))
             package:addenv("JAVA_HOME", java)
         end
     end)

--- a/packages/e/emscripten/xmake.lua
+++ b/packages/e/emscripten/xmake.lua
@@ -1,0 +1,50 @@
+package("emscripten")
+
+    set_kind("toolchain")
+    set_homepage("https://emscripten.org/")
+    set_description("Emscripten: An LLVM-to-WebAssembly Compiler.")
+    set_license("MIT")
+
+    set_urls("https://github.com/emscripten-core/emsdk.git")
+    add_versions("3.1.42", "c2260b4f28f53b411032de0955a6fe6b6bcf3edd")
+
+    add_deps("python")
+
+    on_install("windows", "macosx", "linux", function (package)
+		-- copy to installdir
+        os.cp("*", package:installdir())
+	
+        -- installation
+        local version = package:version():rawstr()
+        local installdir = package:installdir()
+        local py = package:is_plat("windows") and "python" or "python3"
+
+        os.vrunv(py, {path.join(installdir, "emsdk.py"), "install", version})
+
+        -- activation
+        os.vrunv(py, {path.join(installdir, "emsdk.py"), "activate", version})
+
+        -- setup env
+        local node = os.dirs(path.join(installdir, "node/**"))[1]
+        package:addenv("PATH", node)
+
+        package:addenv("PATH", path.join(installdir, "upstream", "emscripten"))
+        package:addenv("PATH", installdir)
+        package:addenv("EMSDK", installdir)
+
+        local exe = package:is_plat("windows") and ".exe" or ""
+
+        package:addenv("EMSDK_NODE", path.join(node, "bin", "node"..exe))
+        if package:is_plat("windows") then
+            local python = os.dirs(path.join(installdir, "python/**"))[1]
+            package:addenv("EMSDK_PYTHON", path.join(python, "python"..exe))
+
+            local java = os.dirs(path.join(installdir, "java/**"))[1]
+            package:addenv("JAVA_HOME", java)
+        end
+    end)
+
+    on_test(function (package)
+        local emcc = is_host("windows") and "emcc.bat" or "emcc"
+        os.vrunv(emcc, {"--version"})
+    end)

--- a/packages/e/emscripten/xmake.lua
+++ b/packages/e/emscripten/xmake.lua
@@ -11,6 +11,7 @@ package("emscripten")
     add_deps("python")
 
     on_install("windows", "macosx", "linux", function (package)
+
         import("lib.detect.find_directory")
 		-- copy to installdir
         os.cp("*", package:installdir())
@@ -25,20 +26,27 @@ package("emscripten")
         os.vrunv(py, {path.join(installdir, "emsdk.py"), "activate", version})
 
         -- setup env
-        local node = find_directory("bin", {path.join(installdir, "node", "**")})
         package:addenv("PATH", node)
         package:addenv("PATH", path.join(installdir, "upstream", "emscripten"))
         package:addenv("PATH", installdir)
         package:addenv("EMSDK", installdir)
     
         local exe = package:is_plat("windows") and ".exe" or ""
+        local node = find_directory("bin", {path.join(installdir, "node", "**")})
+        if node then
+            package:addenv("PATH", node)
+            package:addenv("EMSDK_NODE", path.join(node, "node" .. exe))
+        end
 
-        package:addenv("EMSDK_NODE", path.join(node, "node" .. exe))
         if package:is_plat("windows") then
             local python = find_directory("*", path.join(installdir, "python"))
-            package:addenv("EMSDK_PYTHON", path.join(python, "python" .. exe))
+            if python then
+                package:addenv("EMSDK_PYTHON", path.join(python, "python" .. exe))
+            end
             local java = find_directory("*", path.join(installdir, "java"))
-            package:addenv("JAVA_HOME", java)
+            if java then
+                package:addenv("JAVA_HOME", java)
+            end
         end
     end)
 


### PR DESCRIPTION
I got the env variables from executing `emsdk activate latest`. It displays this on Windows:
```
Resolving SDK alias 'latest' to '3.1.42'
Resolving SDK version '3.1.42' to 'sdk-releases-9d73bf4bd5b5c9ce6e51be0ed5ce6599fcb28e9e-64bit'
Setting the following tools as active:
   node-16.20.0-64bit
   python-3.9.2-nuget-64bit
   java-8.152-64bit
   releases-9d73bf4bd5b5c9ce6e51be0ed5ce6599fcb28e9e-64bit

Adding directories to PATH:
PATH += D:\compiler\emsdk
PATH += D:\compiler\emsdk\upstream\emscripten

Setting environment variables:
PATH = D:\compiler\emsdk;D:\compiler\emsdk\upstream\emscripten;...
EMSDK_NODE = D:\compiler\emsdk\node\16.20.0_64bit\bin\node.exe
EMSDK_PYTHON = D:\compiler\emsdk\python\3.9.2-nuget_64bit\python.exe
JAVA_HOME = D:\compiler\emsdk\java\8.152_64bit
```

And on Linux:
```
Setting up EMSDK environment (suppress these messages with EMSDK_QUIET=1)
Adding directories to PATH:
PATH += /home/a2va/emsdk
PATH += /home/a2va/emsdk/upstream/emscripten
PATH += /home/a2va/emsdk/node/16.20.0_64bit/bin

Setting environment variables:
PATH = /home/a2va/emsdk:/home/a2va/emsdk/upstream/emscripten:/home/a2va/emsdk/node/16.20.0_64bit/bin:
EMSDK = /home/a2va/emsdk
EMSDK_NODE = /home/a2va/emsdk/node/16.20.0_64bit/bin/node
```