### PR TITLE
protobuf-cpp: fix debug mode link

### DIFF
--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -39,6 +39,7 @@ package("protobuf-cpp")
 
     on_install("windows", "linux", "macosx", function (package)
         os.cd("cmake")
+        io.replace("CMakeLists.txt", "set(protobuf_DEBUG_POSTFIX \"d\"", "set(protobuf_DEBUG_POSTFIX \"\"", {plain = true})
         local configs = {"-Dprotobuf_BUILD_TESTS=OFF", "-Dprotobuf_BUILD_PROTOC_BINARIES=ON"}
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         if package:is_plat("windows") then


### PR DESCRIPTION
debug模式下会有lib会有后缀d 导致links里没有lib