### PR TITLE
Auto-update spdlog to v1.12.0

### DIFF
--- a/packages/s/spdlog/xmake.lua
+++ b/packages/s/spdlog/xmake.lua
@@ -5,6 +5,7 @@ package("spdlog")
 
     set_urls("https://github.com/gabime/spdlog/archive/$(version).zip",
              "https://github.com/gabime/spdlog.git")
+    add_versions("v1.12.0", "6174bf8885287422a6c6a0312eb8a30e8d22bcfcee7c48a6d02d1835d7769232")
     add_versions("v1.11.0", "33f83c6b86ec0fbbd0eb0f4e980da6767494dc0ad063900bcfae8bc3e9c75f21")
     add_versions("v1.10.0", "7be28ff05d32a8a11cfba94381e820dd2842835f7f319f843993101bcab44b66")
     add_versions("v1.9.2", "130bd593c33e2e2abba095b551db6a05f5e4a5a19c03ab31256c38fa218aa0a6")


### PR DESCRIPTION
New version of spdlog detected (package version: v1.11.0, last github version: v1.12.0)