### PR TITLE
[fxdiv] Formatting

### DIFF
--- a/packages/f/fxdiv/xmake.lua
+++ b/packages/f/fxdiv/xmake.lua
@@ -1,5 +1,4 @@
 package("fxdiv")
-
     set_kind("library", {headeronly = true})
     set_homepage("https://github.com/Maratyszcza/FXdiv")
     set_description("C99/C++ header-only library for division via fixed-point multiplication by inverse")
@@ -8,12 +7,10 @@ package("fxdiv")
     add_urls("https://github.com/Maratyszcza/FXdiv.git")
     add_versions("2020.12.09", "63058eff77e11aa15bf531df5dd34395ec3017c8")
 
-    add_deps("cmake")
-    on_install("windows", "macosx", "linux", function (package)
-        local configs = {"-DFXDIV_BUILD_TESTS=OFF", "-DFXDIV_BUILD_BENCHMARKS=OFF"}
-        import("package.tools.cmake").install(package, configs)
+    on_install("windows", "macosx", "linux", function(package)
+        os.cp("include", package:installdir())
     end)
 
-    on_test(function (package)
+    on_test(function(package)
         assert(package:has_cfuncs("fxdiv_init_uint32_t", {includes = "fxdiv.h"}))
     end)

--- a/packages/f/fxdiv/xmake.lua
+++ b/packages/f/fxdiv/xmake.lua
@@ -7,8 +7,11 @@ package("fxdiv")
     add_urls("https://github.com/Maratyszcza/FXdiv.git")
     add_versions("2020.12.09", "63058eff77e11aa15bf531df5dd34395ec3017c8")
 
+    add_deps("cmake")
+
     on_install("windows", "macosx", "linux", function(package)
-        os.cp("include", package:installdir())
+        local configs = {"-DFXDIV_BUILD_TESTS=OFF", "-DFXDIV_BUILD_BENCHMARKS=OFF"}
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function(package)


### PR DESCRIPTION
Simplify the [`fxdiv`](https://github.com/Maratyszcza/FXdiv) package. The cmakelists is only really used for building the tests and benchmarks, the library itself is a single header.

