### PR TITLE
Fix libwebp dll exports

### DIFF
--- a/packages/l/libwebp/patches/0001-fix-dll-export.patch
+++ b/packages/l/libwebp/patches/0001-fix-dll-export.patch
@@ -1,0 +1,26 @@
+diff --git a/src/webp/types.h b/src/webp/types.h
+index 0ce2622..69f7e89 100644
+--- a/src/webp/types.h
++++ b/src/webp/types.h
+@@ -39,7 +39,9 @@ typedef long long int int64_t;
+ #ifndef WEBP_EXTERN
+ // This explicitly marks library functions and allows for changing the
+ // signature for e.g., Windows DLL builds.
+-# if defined(__GNUC__) && __GNUC__ >= 4
++# if defined(_MSC_VER) && defined(WEBP_DLL)
++#  define WEBP_EXTERN __declspec(dllexport)
++# elif defined(__GNUC__) && __GNUC__ >= 4
+ #  define WEBP_EXTERN extern __attribute__ ((visibility ("default")))
+ # else
+ #  define WEBP_EXTERN extern
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2501012..2e090e6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,2 +16,6 @@ project(WebP C)
+ 
++if(MSVC AND BUILD_SHARED_LIBS)
++  add_definitions(-DWEBP_DLL)
++endif()
++
+ # Options for coder / decoder executables.

--- a/packages/l/libwebp/xmake.lua
+++ b/packages/l/libwebp/xmake.lua
@@ -14,6 +14,8 @@ package("libwebp")
     add_versions("v1.2.4", "dfe7bff3390cd4958da11e760b65318f0a48c32913e4d5bc5e8d55abaaa2d32e")
     add_versions("v1.3.0", "dc9860d3fe06013266c237959e1416b71c63b36f343aae1d65ea9c94832630e1")
 
+    add_patches(">=1.1.0 <1.3.0", path.join(os.scriptdir(), "patches", "0001-fix-dll-export.patch"), "81d92d800dd7b57704a0e4db3b7155184fe8bb6bc0a925a699a8a0868629f60c")
+
     add_configs("anim_utils", {description = "Build animation utilities.", default = false, type = "boolean"})
     add_configs("cwebp",      {description = "Build the cwebp command line tool.", default = false, type = "boolean"})
     add_configs("dwebp",      {description = "Build the dwebp command line tool.", default = false, type = "boolean"})
@@ -43,6 +45,9 @@ package("libwebp")
         if package:config("sharpyuv") or package:version():ge("1.2.3") then
             package:add("links", "sharpyuv")
         end
+        if package:config("libwebpmux") then
+            package:add("links", "webpmux")
+        end
 
         for name, enabled in pairs(package:configs()) do
             if name == "thread" then
@@ -61,4 +66,7 @@ package("libwebp")
 
     on_test(function (package)
         assert(package:has_cfuncs("WebPGetEncoderVersion", {includes = "webp/encode.h"}))
+        if package:config("libwebpmux") and package:version():ge("1.2.1") then
+            assert(package:has_cfuncs("WebPGetMuxVersion", {includes = "webp/mux.h"}))
+        end
     end)


### PR DESCRIPTION
Fixes linker error when libwebpmux is enabled

```
LINK : fatal error LNK1181: cannot open input file 'Release\webp.lib' [C:\Users\calebmagiya\AppData\Local\.xmake\cache\packages\2307\l\libw
       ebp\v1.2.4\source\build_62a8009b\webpdemux.vcxproj]
```

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

