### PR TITLE
[cimg] Add package

### DIFF
--- a/packages/c/cimg/xmake.lua
+++ b/packages/c/cimg/xmake.lua
@@ -10,7 +10,7 @@ package("cimg")
     add_urls("https://github.com/greyclab/cimg.git")
     add_versions("v3.2.6", "1fcca9a7a453aa278660c10d54c6db9b4c614b6a29250adeb231e95a0be209e7")
 
-    on_install(function (package)
+    on_install("windows", "linux", "macosx", "android", "mingw", "cygwin", "bsd", "cross", function (package)
         os.cp("CImg.h", package:installdir("include"))
     end)
 

--- a/packages/c/cimg/xmake.lua
+++ b/packages/c/cimg/xmake.lua
@@ -1,0 +1,19 @@
+package("cimg")
+    set_kind("library", {headeronly = true})
+    set_homepage("https://github.com/greyclab/cimg")
+    set_description("Small and open-source C++ toolkit for image processing")
+    set_license("CeCILL-C")
+
+    add_urls("https://github.com/greyclab/cimg/archive/refs/tags/$(version).tar.gz", {version = function(version)
+        return version:gsub("%v", "v.")
+    end})
+    add_urls("https://github.com/greyclab/cimg.git")
+    add_versions("v3.2.6", "1fcca9a7a453aa278660c10d54c6db9b4c614b6a29250adeb231e95a0be209e7")
+
+    on_install(function (package)
+        os.cp("CImg.h", package:installdir("include"))
+    end)
+
+    on_test(function (package)
+        assert(package:has_cxxtypes("cimg_library::CImg<>", {includes = "CImg.h"}))
+    end)

--- a/packages/c/cimg/xmake.lua
+++ b/packages/c/cimg/xmake.lua
@@ -15,7 +15,11 @@ package("cimg")
     end)
 
     on_test(function (package)
-        assert(package:has_cxxtypes("cimg_library::CImg<>", {
-            includes = "CImg.h", configs = {defines = "cimg_display=0"}
-        }))
+        assert(package:has_cxxsnippets({test = [[
+            int main() {
+                cimg_library::CImg<uint8_t> img{ 128, 128, 1, 3 };
+                img.fill(32);
+                img.noise(128);
+            }
+        ]]}, {configs = {languages = "c++11"}, includes = "CImg.h"}))
     end)

--- a/packages/c/cimg/xmake.lua
+++ b/packages/c/cimg/xmake.lua
@@ -15,5 +15,7 @@ package("cimg")
     end)
 
     on_test(function (package)
-        assert(package:has_cxxtypes("cimg_library::CImg<>", {includes = "CImg.h"}))
+        assert(package:has_cxxtypes("cimg_library::CImg<>", {
+            includes = "CImg.h", configs = {defines = "cimg_display=0"}
+        }))
     end)

--- a/packages/c/cimg/xmake.lua
+++ b/packages/c/cimg/xmake.lua
@@ -15,7 +15,7 @@ package("cimg")
     end)
 
     on_test(function (package)
-        assert(package:has_cxxsnippets({test = [[
+        assert(package:check_cxxsnippets({test = [[
             int main() {
                 cimg_library::CImg<uint8_t> img{ 128, 128, 1, 3 };
                 img.fill(32);

--- a/packages/c/cimg/xmake.lua
+++ b/packages/c/cimg/xmake.lua
@@ -10,6 +10,14 @@ package("cimg")
     add_urls("https://github.com/greyclab/cimg.git")
     add_versions("v3.2.6", "1fcca9a7a453aa278660c10d54c6db9b4c614b6a29250adeb231e95a0be209e7")
 
+    if is_plat("windows") then
+        add_syslinks("gdi32", "shell32", "user32")
+    elseif is_plat("linux") then
+        add_syslinks("pthread")
+    elseif is_plat("macosx") then
+        add_syslinks("m", "pthread")
+    end
+
     on_install("windows", "linux", "macosx", "android", "mingw", "cygwin", "bsd", "cross", function (package)
         os.cp("CImg.h", package:installdir("include"))
     end)
@@ -21,5 +29,5 @@ package("cimg")
                 img.fill(32);
                 img.noise(128);
             }
-        ]]}, {configs = {languages = "c++11"}, includes = "CImg.h"}))
+        ]]}, {configs = {languages = "c++11", defines = "cimg_display=0"}, includes = "CImg.h"}))
     end)

--- a/packages/c/cimg/xmake.lua
+++ b/packages/c/cimg/xmake.lua
@@ -25,7 +25,7 @@ package("cimg")
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
             int main() {
-                cimg_library::CImg<uint8_t> img{ 128, 128, 1, 3 };
+                cimg_library::CImg<unsigned char> img{ 128, 128, 1, 3 };
                 img.fill(32);
                 img.noise(128);
             }


### PR DESCRIPTION
Add [`cimg`](https://github.com/greyclab/cimg) header-only image processing package. This one has a strange versioning quirk.

