### PR TITLE
Fix TOML++ compilation with Clang-Cl toolchain

### DIFF
--- a/packages/t/toml++/xmake.lua
+++ b/packages/t/toml++/xmake.lua
@@ -49,7 +49,7 @@ package("toml++")
                     cpp = 17
                 )"sv;
 
-                toml::table tbl = toml::parse(some_toml);
+                auto tbl = toml::parse(some_toml);
                 std::cout << tbl << "\n";
             }
         ]]}, {configs = {languages = "c++17"}, includes = "toml++/toml.h"}))


### PR DESCRIPTION
Compilation fails for Clang-Cl toolchain when it tries to test the package due to failure on implicit conversion to toml::table.

I simply replaced it with auto in the test snippet which seems to resolve this issue.

Log from error: (same happens for latest release version)
```
  => install toml++ master .. failed

C:\Users\andre\AppData\Local\Temp\.xmake\230715\_04EC0038C54040C282A93F45FB54B05B.cpp(18,29): error: conversion from 'toml::parse_result' to 'toml::table' is ambiguous
                toml::table tbl = toml::parse(some_toml);
                            ^     ~~~~~~~~~~~~~~~~~~~~~~
C:\Users\andre\AppData\Local\.xmake\packages\t\toml++\master\91dd63516d5447209d6768a849484ffd\include\toml++/impl/parse_result.h(203,18): note: candidate function
                /* implicit */ operator toml::table&() noexcept
                               ^
C:\Users\andre\AppData\Local\.xmake\packages\t\toml++\master\91dd63516d5447209d6768a849484ffd\include\toml++/impl/parse_result.h(210,18): note: candidate function
                /* implicit */ operator toml::table&&() noexcept
                               ^
1 error generated.
```