### PR TITLE
qtifw: use 7z on windows but not on sub_host msys

### DIFF
--- a/packages/q/qtifw/xmake.lua
+++ b/packages/q/qtifw/xmake.lua
@@ -31,7 +31,7 @@ package("qtifw")
         local version = package:version()
         local installdir = package:installdir()
         local qtifw_version = "qt.tools.ifw." .. version:major() .. version:minor()
-        if is_host("windows") and (not is_host("msys")) then
+        if is_host("windows") and (not is_plat("msys")) then
             os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version, "--external", "7z"})
         else
             os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version})

--- a/packages/q/qtifw/xmake.lua
+++ b/packages/q/qtifw/xmake.lua
@@ -31,7 +31,7 @@ package("qtifw")
         local version = package:version()
         local installdir = package:installdir()
         local qtifw_version = "qt.tools.ifw." .. version:major() .. version:minor()
-        if is_host("windows") and (not is_plat("msys")) then
+        if is_host("windows") and (not is_subhost("msys")) then
             os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version, "--external", "7z"})
         else
             os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version})

--- a/packages/q/qtifw/xmake.lua
+++ b/packages/q/qtifw/xmake.lua
@@ -30,8 +30,8 @@ package("qtifw")
         local target = "desktop"
         local version = package:version()
         local installdir = package:installdir()
-	local qtifw_version = "qt.tools.ifw." .. version:major() .. version:minor()
-	if is_host("windows") then
+        local qtifw_version = "qt.tools.ifw." .. version:major() .. version:minor()
+        if is_host("windows") then
             os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version, "--external", "7z"})
         else
             os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version})

--- a/packages/q/qtifw/xmake.lua
+++ b/packages/q/qtifw/xmake.lua
@@ -31,7 +31,7 @@ package("qtifw")
         local version = package:version()
         local installdir = package:installdir()
         local qtifw_version = "qt.tools.ifw." .. version:major() .. version:minor()
-        if is_host("windows") then
+        if is_host("windows") and (not is_host("msys")) then
             os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version, "--external", "7z"})
         else
             os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version})

--- a/packages/q/qtifw/xmake.lua
+++ b/packages/q/qtifw/xmake.lua
@@ -30,7 +30,7 @@ package("qtifw")
         local target = "desktop"
         local version = package:version()
         local installdir = package:installdir()
-        os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", "qt.tools.ifw." .. version:major() .. version:minor()})
+        os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", "qt.tools.ifw." .. version:major() .. version:minor(), "--external", "7z"})
         os.mv(path.join(installdir, "Tools", "*", version:major() .. "." .. version:minor(), "*"), installdir)
         os.rmdir(path.join(installdir, "Tools"))
     end)

--- a/packages/q/qtifw/xmake.lua
+++ b/packages/q/qtifw/xmake.lua
@@ -6,7 +6,7 @@ package("qtifw")
 
     add_versions("4.6.0", "dummy")
 
-    add_deps("aqt", "7z")
+    add_deps("aqt")
 
     on_fetch(function (package, opt)
         if opt.system then
@@ -31,7 +31,11 @@ package("qtifw")
         local version = package:version()
         local installdir = package:installdir()
         local qtifw_version = "qt.tools.ifw." .. version:major() .. version:minor()
-        os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version, "--external", "7z"})
+        if is_host("windows") and (not is_host("msys")) then
+            os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version, "--external", "7z"})
+        else
+            os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version})
+        end
         os.mv(path.join(installdir, "Tools", "*", version:major() .. "." .. version:minor(), "*"), installdir)
         os.rmdir(path.join(installdir, "Tools"))
     end)

--- a/packages/q/qtifw/xmake.lua
+++ b/packages/q/qtifw/xmake.lua
@@ -6,7 +6,7 @@ package("qtifw")
 
     add_versions("4.6.0", "dummy")
 
-    add_deps("aqt")
+    add_deps("aqt", "7z")
 
     on_fetch(function (package, opt)
         if opt.system then
@@ -31,11 +31,7 @@ package("qtifw")
         local version = package:version()
         local installdir = package:installdir()
         local qtifw_version = "qt.tools.ifw." .. version:major() .. version:minor()
-        if is_host("windows") and (not is_host("msys")) then
-            os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version, "--external", "7z"})
-        else
-            os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version})
-        end
+        os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version, "--external", "7z"})
         os.mv(path.join(installdir, "Tools", "*", version:major() .. "." .. version:minor(), "*"), installdir)
         os.rmdir(path.join(installdir, "Tools"))
     end)

--- a/packages/q/qtifw/xmake.lua
+++ b/packages/q/qtifw/xmake.lua
@@ -30,7 +30,12 @@ package("qtifw")
         local target = "desktop"
         local version = package:version()
         local installdir = package:installdir()
-        os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", "qt.tools.ifw." .. version:major() .. version:minor(), "--external", "7z"})
+	local qtifw_version = "qt.tools.ifw." .. version:major() .. version:minor()
+	if is_host("windows") then
+            os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version, "--external", "7z"})
+        else
+            os.vrunv("aqt", {"install-tool", "-O", installdir, host, target, "tools_ifw", qtifw_version})
+        end
         os.mv(path.join(installdir, "Tools", "*", version:major() .. "." .. version:minor(), "*"), installdir)
         os.rmdir(path.join(installdir, "Tools"))
     end)


### PR DESCRIPTION
aqt may failed on Windows because py7zr failed to decompress.
a follow-up pr of https://github.com/xmake-io/xmake-repo/pull/2342