### PR TITLE
[rsm-binary-io] Update package

### DIFF
--- a/packages/r/rsm-binary-io/xmake.lua
+++ b/packages/r/rsm-binary-io/xmake.lua
@@ -25,7 +25,7 @@ package("rsm-binary-io")
 
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
-            int main() {
+            void test() {
                 binary_io::span_istream s;
                 assert(s.tell() == 0);
             }

--- a/packages/r/rsm-binary-io/xmake.lua
+++ b/packages/r/rsm-binary-io/xmake.lua
@@ -5,6 +5,7 @@ package("rsm-binary-io")
 
     add_urls("https://github.com/Ryan-rsm-McKenzie/binary_io/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Ryan-rsm-McKenzie/binary_io.git")
+    add_versions("2.0.6", "88354a25064f3da58bdcb24049ca23d7d8f4fb3e12496f397937a65d1943f114")
     add_versions("2.0.5", "4cc904ef02f77e04756cbdf01372629b0f04d859f06ee088d854468abdd4b840")
 
     on_install(function (package)
@@ -27,7 +28,7 @@ package("rsm-binary-io")
 
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
-            void test(int argc, char** argv) {
+            int main() {
                 binary_io::span_istream s;
                 assert(s.tell() == 0);
             }

--- a/packages/r/rsm-binary-io/xmake.lua
+++ b/packages/r/rsm-binary-io/xmake.lua
@@ -15,14 +15,12 @@ package("rsm-binary-io")
             add_rules("mode.debug", "mode.release")
             set_languages("c++20")
             target("rsm-binary-io")
-                set_kind("$(kind)")
+                set_kind("static")
                 add_files("src/**.cpp")
                 add_includedirs("include/")
                 add_headerfiles("include/(**.hpp)")
         ]])
-        local configs = {}
-        configs.kind = package:config("shared") and "shared" or "static"
-        import("package.tools.xmake").install(package, configs)
+        import("package.tools.xmake").install(package)
     end)
 
     on_test(function (package)

--- a/packages/r/rsm-binary-io/xmake.lua
+++ b/packages/r/rsm-binary-io/xmake.lua
@@ -8,6 +8,8 @@ package("rsm-binary-io")
     add_versions("2.0.6", "88354a25064f3da58bdcb24049ca23d7d8f4fb3e12496f397937a65d1943f114")
     add_versions("2.0.5", "4cc904ef02f77e04756cbdf01372629b0f04d859f06ee088d854468abdd4b840")
 
+    add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+
     on_install(function (package)
         io.writefile("xmake.lua", [[
             add_rules("mode.debug", "mode.release")
@@ -17,9 +19,6 @@ package("rsm-binary-io")
                 add_files("src/**.cpp")
                 add_includedirs("include/")
                 add_headerfiles("include/(**.hpp)")
-                if is_plat("windows") and is_kind("shared") then
-                    add_rules("utils.symbols.export_all", {export_classes = true})
-                end
         ]])
         local configs = {}
         configs.kind = package:config("shared") and "shared" or "static"


### PR DESCRIPTION
- Add `rsm-binary-io` version `2.0.6`
- Author has specified that it does not support building as a shared library