### PR TITLE
Auto-update utfcpp to v3.2.4

### DIFF
--- a/packages/u/utfcpp/xmake.lua
+++ b/packages/u/utfcpp/xmake.lua
@@ -7,6 +7,7 @@ package("utfcpp")
 
     add_urls("https://github.com/nemtrif/utfcpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nemtrif/utfcpp.git")
+    add_versions("v3.2.4", "fde21a4c519eed25f095a1cd8490167409cc70d7b5e9c38756142e588ccb7c7e")
     add_versions("v3.2.3", "3ba9b0dbbff08767bdffe8f03b10e596ca351228862722e4c9d4d126d2865250")
     add_versions("v3.2.1", "8d6aa7d77ad0abb35bb6139cb9a33597ac4c5b33da6a004ae42429b8598c9605")
 


### PR DESCRIPTION
New version of utfcpp detected (package version: v3.2.3, last github version: v3.2.4)