### PR TITLE
Add wgpu-native

### DIFF
--- a/packages/w/wgpu-native/xmake.lua
+++ b/packages/w/wgpu-native/xmake.lua
@@ -30,6 +30,13 @@ package("wgpu-native")
         end
     end)
 
+    on_load("macosx", function (package)
+        if not package:config("shared") then
+            package:add("syslinks", "objc")
+            package:add("frameworks", "Metal")
+        end
+    end)
+
     on_install("windows|x64", "windows|x86", "linux|x86_64", "macosx|x86_64", "macosx|arm64", function (package)
         os.cp("*.h", package:installdir("include"))
         if package:is_plat("windows") then

--- a/packages/w/wgpu-native/xmake.lua
+++ b/packages/w/wgpu-native/xmake.lua
@@ -1,0 +1,60 @@
+package("wgpu-native")
+    set_homepage("https://github.com/gfx-rs/wgpu-native")
+    set_description("Native WebGPU implementation based on wgpu-core")
+    set_license("Apache-2.0")
+
+    if is_plat("windows") and is_arch("x64") then
+        add_urls("https://github.com/gfx-rs/wgpu-native/releases/download/$(version)/wgpu-windows-x86_64-release.zip", {version = function(version) return version:gsub("%+", ".") end})
+        add_versions("v0.17.0+2", "1b8ae05bb7626e037ab7088f9f11fc8bb8341a32800d33857c09ff2fb1b3893f")
+    elseif is_plat("windows") and is_arch("x86") then
+        add_urls("https://github.com/gfx-rs/wgpu-native/releases/download/$(version)/wgpu-windows-i686-release.zip", {version = function(version) return version:gsub("%+", ".") end})
+        add_versions("v0.17.0+2", "098037ca18c1a3fbf25f061f822762d5eab1cd4ecf8e7d039f9ccbd357322a54")
+    elseif is_plat("linux") and is_arch("x86_64") then
+        add_urls("https://github.com/gfx-rs/wgpu-native/releases/download/$(version)/wgpu-linux-x86_64-release.zip", {version = function(version) return version:gsub("%+", ".") end})
+        add_versions("v0.17.0+2", "2bfebb48072cafee316fcec452d49d02aa46d7096325097e637c3c2e784eca5b")
+    elseif is_plat("macosx") and is_arch("x86_64") then
+        add_urls("https://github.com/gfx-rs/wgpu-native/releases/download/$(version)/wgpu-macos-x86_64-release.zip", {version = function(version) return version:gsub("%+", ".") end})
+        add_versions("v0.17.0+2", "749683e616659b5fa9a42151b7b71c2308e114c0322df78975d486aaf43650e9")
+    elseif is_plat("macosx") and is_arch("arm64") then
+        add_urls("https://github.com/gfx-rs/wgpu-native/releases/download/$(version)/wgpu-macos-arm64-release.zip", {version = function(version) return version:gsub("%+", ".") end})
+        add_versions("v0.17.0+2", "9af5dadcd05fa8d47d37cf171abae65c7d813123d0a60f0b50392da381279d04")
+    end
+
+    if is_plat("windows") then
+        add_configs("vs_runtime", {description = "Set vs compiler runtime.", default = "MD", readonly = true})
+    end
+
+    on_load("windows", function (package)
+        if not package:config("shared") then
+            package:add("syslinks", "Advapi32", "bcrypt", "d3dcompiler", "NtDll", "User32", "Userenv", "WS2_32")
+        end
+    end)
+
+    on_install("windows|x64", "windows|x86", "linux|x86_64", "macosx|x86_64", "macosx|arm64", function (package)
+        os.cp("*.h", package:installdir("include"))
+        if package:is_plat("windows") then
+            if package:config("shared") then
+                os.cp("wgpu_native.dll", package:installdir("bin"))
+                os.cp("wgpu_native.pdb", package:installdir("bin"))
+                os.cp("wgpu_native.dll.lib", package:installdir("lib"))
+            else
+                os.cp("wgpu_native.lib", package:installdir("lib"))
+            end
+        elseif package:is_plat("linux") then
+            if package:config("shared") then
+                os.cp("libwgpu_native.so", package:installdir("bin"))
+            else
+                os.cp("libwgpu_native.a", package:installdir("lib"))
+            end
+        elseif package:is_plat("macosx") then
+            if package:config("shared") then
+                os.cp("libwgpu_native.dylib", package:installdir("bin"))
+            else
+                os.cp("libwgpu_native.a", package:installdir("lib"))
+            end
+        end
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("wgpuCreateInstance", {includes = "wgpu.h"}))
+    end)

--- a/packages/w/wgpu-native/xmake.lua
+++ b/packages/w/wgpu-native/xmake.lua
@@ -33,7 +33,7 @@ package("wgpu-native")
     on_load("macosx", function (package)
         if not package:config("shared") then
             package:add("syslinks", "objc")
-            package:add("frameworks", "Metal")
+            package:add("frameworks", "Metal", "QuartzCore")
         end
     end)
 


### PR DESCRIPTION
I tried to support debug builds as well but I couldn't because artifacts are processed before the "load" script is.

```lua

    on_load("windows|x64", "windows|x86", "linux|x86_64", "macosx|x86_64", "macosx|arm64", function (package)
        local suffix = package:debug() and "debug" or "release"
        if package:is_plat("windows") and package:is_arch("x64") then
            package:add("url", "https://github.com/gfx-rs/wgpu-native/releases/download/$(version)/wgpu-windows-x86_64-" .. suffix .. ".zip", {version = function(version) return version:gsub("%+", ".") end})
            if package:debug() then
                package:add("version", "v0.17.0+2", "ddcaa0542149be17e47e3f85f8df637814318668d03c341cfddcd3ccd9269f28")
            else
                package:add("version", "v0.17.0+2", "1b8ae05bb7626e037ab7088f9f11fc8bb8341a32800d33857c09ff2fb1b3893f")
            end
        elseif package:is_plat("windows") and package:is_arch("x86") then
            package:add("url", "https://github.com/gfx-rs/wgpu-native/releases/download/$(version)/wgpu-windows-i686-" .. suffix .. ".zip", {version = function(version) return version:gsub("%+", ".") end})
            if package:debug() then
                package:add("version", "v0.17.0+2", "c9efb8e0ea1ba776e3dec968691d0f53ff50f199705f1c0fdb98d93182b7289a")
            else
                package:add("version", "v0.17.0+2", "098037ca18c1a3fbf25f061f822762d5eab1cd4ecf8e7d039f9ccbd357322a54")
            end
        elseif package:is_plat("linux") and package:is_arch("x86_64") then
            package:add("url", "https://github.com/gfx-rs/wgpu-native/releases/download/$(version)/wgpu-linux-x86_64-" .. suffix .. ".zip", {version = function(version) return version:gsub("%+", ".") end})
            if package:debug() then
                package:add("version", "v0.17.0+2", "7a05f7367b75ac2619e7da3a6a523a88207d7bc7c21ea00552f504ed0480610f")
            else
                package:add("version", "v0.17.0+2", "2bfebb48072cafee316fcec452d49d02aa46d7096325097e637c3c2e784eca5b")
            end
        elseif package:is_plat("macosx") and package:is_arch("x86_64") then
            package:add("url", "https://github.com/gfx-rs/wgpu-native/releases/download/$(version)/wgpu-macos-x86_64-" .. suffix .. ".zip", {version = function(version) return version:gsub("%+", ".") end})
            if package:debug() then
                package:add("version", "v0.17.0+2", "adbaa903a23984016a5dfc7ec3b7754cc355b6f604671986bd46a1d4c67d554b")
            else
                package:add("version", "v0.17.0+2", "749683e616659b5fa9a42151b7b71c2308e114c0322df78975d486aaf43650e9")
            end
        elseif package:is_plat("macosx") and package:is_arch("arm64") then
            package:add("url", "https://github.com/gfx-rs/wgpu-native/releases/download/$(version)/wgpu-macos-arm64-" .. suffix .. ".zip", {version = function(version) return version:gsub("%+", ".") end})
            if package:debug() then
                package:add("version", "v0.17.0+2", "77f27c870a44aaad1de413c0bca3d2a6227d2d4d6c3e80246241384f50bd3642")
            else
                package:add("version", "v0.17.0+2", "9af5dadcd05fa8d47d37cf171abae65c7d813123d0a60f0b50392da381279d04")
            end
        else
            os.raise("unsupported plat/arch")
        end
    end)
```