### PR TITLE
added a package for soloud

### DIFF
--- a/packages/s/soloud/patches/miniaudio_v11.patch
+++ b/packages/s/soloud/patches/miniaudio_v11.patch
@@ -1,0 +1,22 @@
+diff --git a/src/backend/miniaudio/soloud_miniaudio.cpp b/src/backend/miniaudio/soloud_miniaudio.cpp
+index 7dba676..e34b910 100644
+--- a/src/backend/miniaudio/soloud_miniaudio.cpp
++++ b/src/backend/miniaudio/soloud_miniaudio.cpp
+@@ -61,7 +61,7 @@ namespace SoLoud
+     result miniaudio_init(SoLoud::Soloud *aSoloud, unsigned int aFlags, unsigned int aSamplerate, unsigned int aBuffer, unsigned int aChannels)
+     {
+         ma_device_config config = ma_device_config_init(ma_device_type_playback);
+-        config.bufferSizeInFrames = 128;
++        config.periodSizeInFrames = 128;
+         config.playback.format    = ma_format_f32;
+         config.playback.channels  = aChannels;
+         config.sampleRate         = aSamplerate;
+@@ -73,7 +73,7 @@ namespace SoLoud
+             return UNKNOWN_ERROR;
+         }
+ 
+-        aSoloud->postinit_internal(gDevice.sampleRate, gDevice.playback.internalBufferSizeInFrames, aFlags, gDevice.playback.channels);
++        aSoloud->postinit_internal(gDevice.sampleRate, gDevice.playback.internalPeriodSizeInFrames, aFlags, gDevice.playback.channels);
+ 
+         aSoloud->mBackendCleanupFunc = soloud_miniaudio_deinit;
+ 

--- a/packages/s/soloud/xmake.lua
+++ b/packages/s/soloud/xmake.lua
@@ -1,11 +1,11 @@
 package("soloud")
     set_description("SoLoud is an easy to use, free, portable c/c++ audio engine for games.")
-    
-    set_homepage("https://sol.gfxile.net/soloud/")
+    set_homepage("https://github.com/jarikomppa/soloud")
     set_license("zlib")
     
-    add_urls("https://github.com/jarikomppa/soloud/archive/refs/tags/RELEASE_20200207.zip")
-    add_versions("20200207", "ad3a6ee2020150e33e72911ce46bbfe26f9c84ec08ff8d7f22680ce4970f7fd3")
+    add_urls("https://github.com/jarikomppa/soloud/archive/refs/tags/RELEASE_$(version).zip",
+         {version = function (version) return version:gsub("%.", "") end})
+    add_versions("2020.02.07", "ad3a6ee2020150e33e72911ce46bbfe26f9c84ec08ff8d7f22680ce4970f7fd3")
     
     -- linux needs to link with libpthread and libdl
     if is_plat("linux") then

--- a/packages/s/soloud/xmake.lua
+++ b/packages/s/soloud/xmake.lua
@@ -1,16 +1,11 @@
--- Examples:
--- https://github.com/xmake-io/xmake-repo/tree/master/packages/n/newtondynamics
--- https://github.com/xmake-io/xmake-repo/blob/dev/packages/z/zlib/xmake.lua
--- https://github.com/tboox/benchbox
-
 package("soloud")
     set_description("SoLoud is an easy to use, free, portable c/c++ audio engine for games.")
     
-    add_urls("https://sol.gfxile.net/soloud/soloud_20200207_lite.zip")
-    add_versions("20200207", "a6fa8e5b7d26b03e21947307d45869e33f0d233639258bd5bf4bea73f88e709d")
-    
     set_homepage("https://sol.gfxile.net/soloud/")
     set_license("zlib")
+    
+    add_urls("https://github.com/jarikomppa/soloud/archive/refs/tags/RELEASE_20200207.zip")
+    add_versions("20200207", "ad3a6ee2020150e33e72911ce46bbfe26f9c84ec08ff8d7f22680ce4970f7fd3")
     
     -- linux needs to link with libpthread and libdl
     if is_plat("linux") then
@@ -36,21 +31,16 @@ package("soloud")
                 -- compile the miniaudio backend
                 -- hide the symbols from the included miniaudio
                 -- to avoid conflicts with xrepo miniaudio.
-                -- we can't use xrepo's miniaudio. it's too new.
+                -- we can't use xrepo's miniaudio. it's too new (0.11.x versus 0.10.x).
                 add_files("src/backend/miniaudio/*.c*", {symbols="hidden"})
                 
-                before_install(function (package)
-                    os.cp("include", package:installdir())
-                end)
+                add_headerfiles("include/(**.h)")
         ]])
         
         import("package.tools.xmake").install(package)
-        -- Copy headers
-        -- os.cp("include", package:installdir())
     end)
     
     on_test(function (package)
-        -- check includes and interfaces
         assert(package:has_cxxincludes("soloud.h"))
         assert(package:has_cxxtypes("SoLoud::Soloud", {includes = "soloud.h"}))
         assert(package:check_cxxsnippets({test = [[

--- a/packages/s/soloud/xmake.lua
+++ b/packages/s/soloud/xmake.lua
@@ -2,51 +2,54 @@ package("soloud")
     set_description("SoLoud is an easy to use, free, portable c/c++ audio engine for games.")
     set_homepage("https://github.com/jarikomppa/soloud")
     set_license("zlib")
-    
+
     add_urls("https://github.com/jarikomppa/soloud/archive/refs/tags/RELEASE_$(version).zip",
          {version = function (version) return version:gsub("%.", "") end})
     add_versions("2020.02.07", "ad3a6ee2020150e33e72911ce46bbfe26f9c84ec08ff8d7f22680ce4970f7fd3")
-    
-    -- for now we only support the miniaudio backend
+
     add_deps("miniaudio")
     add_patches("2020.02.07", path.join(os.scriptdir(), "patches", "miniaudio_v11.patch"), "d98b6727a159c3dccd45de872b321a1c180bc353af08d4bdce4e298f4de14f21")
-    
-    -- linux needs to link with libpthread and libdl
+
     if is_plat("linux") then
         add_syslinks("pthread", "dl")
+    elseif is_plat("macosx", "iphoneos") then
+        add_frameworks("AudioToolbox", "AVFoundation", "CoreFoundation", "Foundation")
     end
-    
+
     on_install(function (package)
-        -- remove the miniaudio.h that comes with soloud. we have it as an xrepo dependency.
         os.rm("src/backend/miniaudio/miniaudio.h")
-        
+        if package:is_plat("macosx", "iphoneos") then
+            os.mv("src/backend/miniaudio/soloud_miniaudio.cpp", "src/backend/miniaudio/soloud_miniaudio.mm")
+        end
         io.writefile("xmake.lua", [[
             add_rules("mode.debug", "mode.release")
-            
+
             add_requires("miniaudio")
-            
+
             target("soloud")
                 set_kind("$(kind)")
                 set_languages("cxx11")
-                
+                add_headerfiles("include/(**.h)")
+                add_includedirs("include", {public = true})
+
                 -- for now we'll only support the miniaudio backend
                 add_defines("WITH_MINIAUDIO")
                 add_packages("miniaudio")
-                
-                add_includedirs("include", {public = true})
-                
-                -- skip `tools` and `backend`
-                add_files("src/**.cpp|tools/**.cpp|backend/**.cpp")
+
+                add_files("src/**.cpp|tools/**.cpp|backend/**.cpp|backend/**.mm")
                 add_files("src/**.c|tools/**.c|backend/**.c")
-                -- compile the miniaudio backend
-                add_files("src/backend/miniaudio/*.c*")
-                
-                add_headerfiles("include/(**.h)")
+
+                if is_plat("iphoneos", "macosx") then
+                    add_frameworks("AudioToolbox", "AVFoundation", "CoreFoundation", "Foundation")
+                    add_files("src/backend/miniaudio/*.mm")
+                else
+                    add_files("src/backend/miniaudio/*.cpp")
+                end
         ]])
-        
+
         import("package.tools.xmake").install(package)
     end)
-    
+
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
             void test(int args, char** argv) {
@@ -54,4 +57,3 @@ package("soloud")
             }
         ]]}, {includes = "soloud.h"}))
     end)
-package_end()

--- a/packages/s/soloud/xmake.lua
+++ b/packages/s/soloud/xmake.lua
@@ -1,0 +1,62 @@
+-- Examples:
+-- https://github.com/xmake-io/xmake-repo/tree/master/packages/n/newtondynamics
+-- https://github.com/xmake-io/xmake-repo/blob/dev/packages/z/zlib/xmake.lua
+-- https://github.com/tboox/benchbox
+
+package("soloud")
+    set_description("SoLoud is an easy to use, free, portable c/c++ audio engine for games.")
+    
+    add_urls("https://sol.gfxile.net/soloud/soloud_20200207_lite.zip")
+    add_versions("20200207", "a6fa8e5b7d26b03e21947307d45869e33f0d233639258bd5bf4bea73f88e709d")
+    
+    set_homepage("https://sol.gfxile.net/soloud/")
+    set_license("zlib")
+    
+    -- linux needs to link with libpthread and libdl
+    if is_plat("linux") then
+        add_syslinks("pthread", "dl")
+    end
+    
+    on_install(function (package)
+        io.writefile("xmake.lua", [[
+            add_rules("mode.debug", "mode.release")
+            
+            target("soloud")
+                set_kind("$(kind)")
+                set_languages("cxx11")
+                
+                -- for now we'll only support the miniaudio backend
+                add_defines("WITH_MINIAUDIO")
+                
+                add_includedirs("include", {public = true})
+                
+                -- skip `tools` and `backend`
+                add_files("src/**.cpp|tools/**.cpp|backend/**.cpp")
+                add_files("src/**.c|tools/**.c|backend/**.c")
+                -- compile the miniaudio backend
+                -- hide the symbols from the included miniaudio
+                -- to avoid conflicts with xrepo miniaudio.
+                -- we can't use xrepo's miniaudio. it's too new.
+                add_files("src/backend/miniaudio/*.c*", {symbols="hidden"})
+                
+                before_install(function (package)
+                    os.cp("include", package:installdir())
+                end)
+        ]])
+        
+        import("package.tools.xmake").install(package)
+        -- Copy headers
+        -- os.cp("include", package:installdir())
+    end)
+    
+    on_test(function (package)
+        -- check includes and interfaces
+        assert(package:has_cxxincludes("soloud.h"))
+        assert(package:has_cxxtypes("SoLoud::Soloud", {includes = "soloud.h"}))
+        assert(package:check_cxxsnippets({test = [[
+            void test(int args, char** argv) {
+                SoLoud::Soloud soloud;
+            }
+        ]]}, {includes = "soloud.h"}))
+    end)
+package_end()


### PR DESCRIPTION
Added a package for the soloud sound library. This works on macos, windows, and linux.

It uses a miniaudio backend. It requires an older miniaudio version than the one in xrepo. The internal miniaudio symbols should be properly hidden. In the future, other backends could be supported.