### PR TITLE
[rsm-binary-io] Add `2.0.6`

### DIFF
--- a/packages/r/rsm-binary-io/xmake.lua
+++ b/packages/r/rsm-binary-io/xmake.lua
@@ -6,6 +6,7 @@ package("rsm-binary-io")
     add_urls("https://github.com/Ryan-rsm-McKenzie/binary_io/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Ryan-rsm-McKenzie/binary_io.git")
     add_versions("2.0.5", "4cc904ef02f77e04756cbdf01372629b0f04d859f06ee088d854468abdd4b840")
+    add_versions("2.0.6", "88354a25064f3da58bdcb24049ca23d7d8f4fb3e12496f397937a65d1943f114")
 
     on_install(function (package)
         io.writefile("xmake.lua", [[

--- a/packages/r/rsm-binary-io/xmake.lua
+++ b/packages/r/rsm-binary-io/xmake.lua
@@ -21,14 +21,12 @@ package("rsm-binary-io")
                     add_rules("utils.symbols.export_all", {export_classes = true})
                 end
         ]])
-        local configs = {}
-        configs.kind = package:config("shared") and "shared" or "static"
-        import("package.tools.xmake").install(package, configs)
+        import("package.tools.xmake").install(package)
     end)
 
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
-            void test(int argc, char** argv) {
+            void test() {
                 binary_io::span_istream s;
                 assert(s.tell() == 0);
             }

--- a/packages/r/rsm-binary-io/xmake.lua
+++ b/packages/r/rsm-binary-io/xmake.lua
@@ -8,7 +8,7 @@ package("rsm-binary-io")
     add_versions("2.0.5", "4cc904ef02f77e04756cbdf01372629b0f04d859f06ee088d854468abdd4b840")
     add_versions("2.0.6", "88354a25064f3da58bdcb24049ca23d7d8f4fb3e12496f397937a65d1943f114")
 
-    on_install(function (package)
+    on_install("windows", "linux", "macosx", "iphoneos", "android", "bsd", "wasm", "cross", function (package)
         io.writefile("xmake.lua", [[
             add_rules("mode.debug", "mode.release")
             set_languages("c++20")


### PR DESCRIPTION
- Add version `2.0.6`
- Remove unnecessary `kind` config, this is already passed by xmake
- Remove args from test function

