### PR TITLE
Auto-update zlib to v1.3

### DIFF
--- a/packages/z/zlib/xmake.lua
+++ b/packages/z/zlib/xmake.lua
@@ -9,6 +9,7 @@ package("zlib")
     add_versions("v1.2.11", "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff")
     add_versions("v1.2.12", "d8688496ea40fb61787500e863cc63c9afcbc524468cedeb478068924eb54932")
     add_versions("v1.2.13", "1525952a0a567581792613a9723333d7f8cc20b87a81f920fb8bc7e3f2251428")
+    add_versions("v1.3", "b5b06d60ce49c8ba700e0ba517fa07de80b5d4628a037f4be8ad16955be7a7c0")
 
     add_configs("zutil", {description = "Export zutil.h api", default = false, type = "boolean"})
 


### PR DESCRIPTION
New version of zlib detected (package version: v1.2.13, last github version: v1.3)