### PR TITLE
Auto-update brotli to v1.1.0

### DIFF
--- a/packages/b/brotli/xmake.lua
+++ b/packages/b/brotli/xmake.lua
@@ -1,6 +1,7 @@
 package("brotli")
     set_homepage("https://github.com/google/brotli")
     set_description("Brotli compression format.")
+    set_license("MIT")
 
     set_urls("https://github.com/google/brotli/archive/$(version).tar.gz",
              "https://github.com/google/brotli.git")

--- a/packages/b/brotli/xmake.lua
+++ b/packages/b/brotli/xmake.lua
@@ -1,19 +1,19 @@
 package("brotli")
-
     set_homepage("https://github.com/google/brotli")
     set_description("Brotli compression format.")
 
-    set_urls("https://github.com/google/brotli/archive/v$(version).tar.gz",
+    set_urls("https://github.com/google/brotli/archive/$(version).tar.gz",
              "https://github.com/google/brotli.git")
 
-    add_versions("1.0.9", "f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46")
+    add_versions("v1.1.0", "e720a6ca29428b803f4ad165371771f5398faba397edf6778837a18599ea13ff")
+    add_versions("v1.0.9", "f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46")
 
     -- Fix VC C++ 12.0 BROTLI_MSVC_VERSION_CHECK calls
     -- VC <= 2012 build failed
     if is_plat("windows") then
-        add_patches("1.0.9", path.join(os.scriptdir(), "patches", "1.0.9", "common_platform.patch"),
+        add_patches("v1.0.9", path.join(os.scriptdir(), "patches", "1.0.9", "common_platform.patch"),
                     "5d7363a6ed1f9a504dc7af08920cd184f0d04d1ad12d25d657364cf0a2dae6bb")
-        add_patches("1.0.9", path.join(os.scriptdir(), "patches", "1.0.9", "tool_brotli.patch"),
+        add_patches("v1.0.9", path.join(os.scriptdir(), "patches", "1.0.9", "tool_brotli.patch"),
                     "333e2a0306cf33f2fac381aa6b81afd3d1237e7511e5cc8fe7fb760d16d01ca1")
     end
 


### PR DESCRIPTION
New version of brotli detected (package version: v1.0.9, last github version: v1.1.0)