### PR TITLE
add missing x11 dependecies for glew

### DIFF
--- a/packages/g/glew/port/xmake.lua
+++ b/packages/g/glew/port/xmake.lua
@@ -13,6 +13,7 @@ target("glew")
         add_frameworks("OpenGL")
     elseif is_plat("linux") then
         add_syslinks("GL")
+        add_packages("libx11", "xorgproto")
     end
     add_defines("GLEW_NO_GLU", {public = true})
     if is_plat("windows") then


### PR DESCRIPTION
I was getting this error when trying to install glew on a debian machine without x11 installed with apt.
```
error: In file included from src/glew.c:55:
include/GL/glxew.h:98:10: fatal error: X11/Xlib.h: Aucun fichier ou dossier de ce type
   98 | #include <X11/Xlib.h>
      |          ^~~~~~~~~~~~
compilation terminated.