### PR TITLE
Fixed miniaudio on macos

### DIFF
--- a/packages/m/miniaudio/xmake.lua
+++ b/packages/m/miniaudio/xmake.lua
@@ -10,6 +10,10 @@ package("miniaudio")
     add_versions("0.11.17", "4b139065f7068588b73d507d24e865060e942eb731f988ee5a8f1828155b9480")
     add_versions("0.11.18", "85ca916266d809b39902e180a6d16f82caea9c2ea1cea6d374413641b7ba48c3")
 
+    if is_plat("iphoneos", "macosx") then
+        add_defines("MA_NO_RUNTIME_LINKING")
+        add_frameworks("AudioToolbox", "CoreAudio", "AudioUnit", "AVFoundation", "CoreFoundation", "Foundation")
+    end
 
     on_install(function (package)
         os.cp("miniaudio.h", package:installdir("include"))

--- a/packages/m/miniaudio/xmake.lua
+++ b/packages/m/miniaudio/xmake.lua
@@ -10,7 +10,9 @@ package("miniaudio")
     add_versions("0.11.17", "4b139065f7068588b73d507d24e865060e942eb731f988ee5a8f1828155b9480")
     add_versions("0.11.18", "85ca916266d809b39902e180a6d16f82caea9c2ea1cea6d374413641b7ba48c3")
 
-    if is_plat("iphoneos", "macosx") then
+    if is_plat("iphoneos") then
+        add_frameworks("AudioToolbox", "AVFoundation", "CoreFoundation", "Foundation")
+    elseif is_plat("macosx") then
         add_defines("MA_NO_RUNTIME_LINKING")
         add_frameworks("AudioToolbox", "CoreAudio", "AudioUnit", "AVFoundation", "CoreFoundation", "Foundation")
     end

--- a/packages/s/soloud/xmake.lua
+++ b/packages/s/soloud/xmake.lua
@@ -12,8 +12,6 @@ package("soloud")
 
     if is_plat("linux") then
         add_syslinks("pthread", "dl")
-    elseif is_plat("macosx", "iphoneos") then
-        add_frameworks("AudioToolbox", "AVFoundation", "CoreFoundation", "Foundation")
     end
 
     on_install(function (package)
@@ -40,7 +38,6 @@ package("soloud")
                 add_files("src/**.c|tools/**.c|backend/**.c")
 
                 if is_plat("iphoneos", "macosx") then
-                    add_frameworks("AudioToolbox", "AVFoundation", "CoreFoundation", "Foundation")
                     add_files("src/backend/miniaudio/*.mm")
                 else
                     add_files("src/backend/miniaudio/*.cpp")


### PR DESCRIPTION
It's an entitlements issue that is solved with a #define for miniaudio: <https://github.com/mackron/miniaudio/issues/203>

This also lets us simplify the soloud xmake.lua file somewhat, since it inherits the linker flags.