### PR TITLE
cppp-reiconv: New package.

### DIFF
--- a/packages/c/cppp-reiconv/xmake.lua
+++ b/packages/c/cppp-reiconv/xmake.lua
@@ -1,5 +1,5 @@
 package("cppp-reiconv")
-    add_deps("cmake", "python")
+
     set_homepage("https://github.com/cppp-project/cppp-reiconv")
     set_description("A character set conversion library based on GNU LIBICONV.")
 
@@ -7,7 +7,7 @@ package("cppp-reiconv")
 
     add_versions("v2.1.0", "3e539785a437843793c5ce2f8a72cb08f2b543cba11635b06db25cfc6d9cc3a4")
 
-    add_deps("cmake")
+    add_deps("cmake", "python")
 
     on_install(function (package)
         local configs = {}
@@ -25,10 +25,10 @@ package("cppp-reiconv")
         #include <cstdlib>
         using namespace cppp::base::reiconv;
 
-        static void test()
+        void test()
         {
             iconv_t cd = iconv_open("UTF-8", "UTF-8");
-            if(cd == (iconv_t)(-1))
+            if (cd == (iconv_t)(-1))
             {
                 abort();
             }

--- a/packages/c/cppp-reiconv/xmake.lua
+++ b/packages/c/cppp-reiconv/xmake.lua
@@ -8,39 +8,6 @@ package("cppp-reiconv")
     add_versions("v2.1.0", "3e539785a437843793c5ce2f8a72cb08f2b543cba11635b06db25cfc6d9cc3a4")
 
     add_deps("cmake")
-    
-    on_download(function (package, opt)
-        import("net.http")
-        import("utils.archive")
-
-        local url = opt.url
-        local sourcedir = opt.sourcedir
-        local packagefile = path.filename(url)
-        local sourcehash = package:sourcehash(opt.url_alias)
-
-        local cached = true
-        if not os.isfile(packagefile) or sourcehash ~= hash.sha256(packagefile) then
-            cached = false
-
-            os.tryrm(packagefile)
-            http.download(url, packagefile)
-
-            if sourcehash and sourcehash ~= hash.sha256(packagefile) then
-                raise("unmatched checksum, current hash(%s) != original hash(%s)", hash.sha256(packagefile):sub(1, 8), sourcehash:sub(1, 8))
-            end
-        end
-
-        local sourcedir_tmp = sourcedir .. ".tmp"
-        os.rm(sourcedir_tmp)
-        if archive.extract(packagefile, sourcedir_tmp) then
-            os.rm(sourcedir)
-            os.mv(sourcedir_tmp, sourcedir)
-        else
-            os.tryrm(sourcedir)
-            os.mkdir(sourcedir)
-        end
-        package:originfile_set(path.absolute(packagefile))
-    end)
 
     on_install(function (package)
         local configs = {}
@@ -69,3 +36,4 @@ package("cppp-reiconv")
         }
     ]]}, {configs = {languages = "c++14"}}))
     end)
+

--- a/packages/c/cppp-reiconv/xmake.lua
+++ b/packages/c/cppp-reiconv/xmake.lua
@@ -50,3 +50,22 @@ package("cppp-reiconv")
         table.insert(configs, "-DENABLE_TEST=OFF")
         import("package.tools.cmake").install(package, configs)
     end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+        #include <cppp/reiconv.hpp>
+        #include <iostream>
+        #include <cstdlib>
+        using namespace cppp::base::reiconv;
+
+        static void test()
+        {
+            iconv_t cd = iconv_open("UTF-8", "UTF-8");
+            if(cd == (iconv_t)(-1))
+            {
+                abort();
+            }
+            iconv_close(cd);
+        }
+    ]]}, {configs = {languages = "c++14"}}))
+    end)

--- a/packages/c/cppp-reiconv/xmake.lua
+++ b/packages/c/cppp-reiconv/xmake.lua
@@ -1,0 +1,52 @@
+package("cppp-reiconv")
+    add_deps("cmake", "python")
+    set_homepage("https://github.com/cppp-project/cppp-reiconv")
+    set_description("A character set conversion library based on GNU LIBICONV.")
+
+    add_urls("https://github.com/cppp-project/cppp-reiconv/releases/download/$(version)/cppp-reiconv-$(version).zip")
+
+    add_versions("v2.1.0", "3e539785a437843793c5ce2f8a72cb08f2b543cba11635b06db25cfc6d9cc3a4")
+
+    add_deps("cmake")
+    
+    on_download(function (package, opt)
+        import("net.http")
+        import("utils.archive")
+
+        local url = opt.url
+        local sourcedir = opt.sourcedir
+        local packagefile = path.filename(url)
+        local sourcehash = package:sourcehash(opt.url_alias)
+
+        local cached = true
+        if not os.isfile(packagefile) or sourcehash ~= hash.sha256(packagefile) then
+            cached = false
+
+            os.tryrm(packagefile)
+            http.download(url, packagefile)
+
+            if sourcehash and sourcehash ~= hash.sha256(packagefile) then
+                raise("unmatched checksum, current hash(%s) != original hash(%s)", hash.sha256(packagefile):sub(1, 8), sourcehash:sub(1, 8))
+            end
+        end
+
+        local sourcedir_tmp = sourcedir .. ".tmp"
+        os.rm(sourcedir_tmp)
+        if archive.extract(packagefile, sourcedir_tmp) then
+            os.rm(sourcedir)
+            os.mv(sourcedir_tmp, sourcedir)
+        else
+            os.tryrm(sourcedir)
+            os.mkdir(sourcedir)
+        end
+        package:originfile_set(path.absolute(packagefile))
+    end)
+
+    on_install(function (package)
+        local configs = {}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_EXTRA=ON")
+        table.insert(configs, "-DENABLE_TEST=OFF")
+        import("package.tools.cmake").install(package, configs)
+    end)


### PR DESCRIPTION
Name: cppp-reiconv
Version: v2.1.0
Homepage: https://github.com/cppp-project/cppp-reiconv
Description: A character set conversion library based on GNU LIBICONV.
License: LGPL-3
