### PR TITLE
Auto-update libcpuid to v0.6.4

### DIFF
--- a/packages/l/libcpuid/xmake.lua
+++ b/packages/l/libcpuid/xmake.lua
@@ -4,6 +4,7 @@ package("libcpuid")
 
     add_urls("https://github.com/anrieff/libcpuid/archive/refs/tags/$(version).tar.gz",
              "https://github.com/anrieff/libcpuid.git")
+    add_versions("v0.6.4", "1cbb1a79bfe6c37884a538b56504fa0975e78e492aee7c265a42f654c6056cb3")
     add_versions("v0.6.3", "da570fdeb450634d84208f203487b2e00633eac505feda5845f6921e811644fc")
     add_versions("v0.5.1", "36d62842ef43c749c0ba82237b10ede05b298d79a0e39ef5fd1115ba1ff8e126")
 


### PR DESCRIPTION
New version of libcpuid detected (package version: v0.6.3, last github version: v0.6.4)