### PR TITLE
doxygen: fix the build on windows.

### DIFF
--- a/packages/d/doxygen/xmake.lua
+++ b/packages/d/doxygen/xmake.lua
@@ -32,8 +32,18 @@ package("doxygen")
     end)
 
     on_install("@windows", "@macosx", "@linux", function (package)
+        local configs = {}
+        local cxflags = {}
+        if package:is_plat("windows") then
+            -- these 2 flags are required to make doxygen compile on windows
+            table.insert(cxflags, "/utf-8")
+            table.insert(cxflags, "/DGHC_WITH_EXCEPTIONS")
+
+            table.insert(cxflags, "/EHsc")  -- to reduce warnings
+        end
+
         os.rm("templates/*/PaxHeader")
-        import("package.tools.cmake").install(package)
+        import("package.tools.cmake").install(package, configs, {cxflags = cxflags})
     end)
 
     on_test(function (package)


### PR DESCRIPTION
See https://github.com/xmake-io/xmake-repo/issues/2727 for more info.

Passed local test with `xmake l scripts/test.lua --shallow -vD doxygen`

```
已成功生成。

“C:\Users\syp\AppData\Local\.xmake\cache\packages\2310\d\doxygen\1.9.6\source\build_bbc14a6e\INSTALL.vcxproj”(默认目标) (1) ->
“C:\Users\syp\AppData\Local\.xmake\cache\packages\2310\d\doxygen\1.9.6\source\build_bbc14a6e\ALL_BUILD.vcxproj”(默认目标) (3) ->
“C:\Users\syp\AppData\Local\.xmake\cache\packages\2310\d\doxygen\1.9.6\source\build_bbc14a6e\src\doxygen.vcxproj”(默认目标) (7) ->
“C:\Users\syp\AppData\Local\.xmake\cache\packages\2310\d\doxygen\1.9.6\source\build_bbc14a6e\src\doxymain.vcxproj”(默认目标) (9) ->
(CustomBuild 目标) ->
  C:/Users/syp/AppData/Local/.xmake/cache/packages/2310/d/doxygen/1.9.6/source/src/constexp.y : warning : fix-its can be applied.  Rerun with option '--update'. [-Wother] [C:\Users\syp\AppData\Local\.xmake\cache\
packages\2310\d\doxygen\1.9.6\source\build_bbc14a6e\src\doxymain.vcxproj]
  C:/Users/syp/AppData/Local/.xmake/cache/packages/2310/d/doxygen/1.9.6/source/src/constexp.y : warning : fix-its can be applied.  Rerun with option '--update'. [-Wother] [C:\Users\syp\AppData\Local\.xmake\cache\
packages\2310\d\doxygen\1.9.6\source\build_bbc14a6e\src\doxymain.vcxproj]

    2 个警告
    0 个错误

已用时间 00:01:44.99
checking for doxygen ... no
checking for doxygen ... no
{
  configs = {
    vs_runtime = "MT",
    shared = false,
    pic = true,
    debug = false
  },
  arch = "x64",
  envs = {
    PATH = {
      "bin"
    }
  },
  version = "1.9.6",
  librarydeps = { },
  deps = {
    winflexbison = {
      buildhash = "9b988b04c8f248f6a060c4bcdb78d415",
      version = "v2.5.25"
    },
    bison = {
      buildhash = "10253c39aca14760ae4382272800b680",
      version = "3.8.2"
    },
    flex = {
      buildhash = "10253c39aca14760ae4382272800b680",
      version = "2.6.4"
    },
    cmake = {
      buildhash = "4d23fc87455a4a1c819e093bd8456f0f",
      version = "3.27.7"
    },
    python = {
      buildhash = "951a357c924d404f906b8a49a06f1297",
      version = "3.11.3"
    }
  },
  mode = "release",
  plat = "windows",
  name = "doxygen",
  kind = "binary",
  license = "GPL-2.0",
  repo = {
    url = "D:\Documents\src\xmake-repo",
    commit = "532db347d18f06412200506d3e1fb55e11e25930",
    name = "local-repo"
  },
  artifacts = {
    installdir = "C:\Users\syp\AppData\Local\.xmake\packages\d\doxygen\1.9.6\bbc14a6e0f2e4e98a574ea699596f97a"
  }
}
```

