### PR TITLE
wayland-protocols: Improve rule wayland.protocols

### DIFF
--- a/packages/w/wayland-protocols/rules/wayland_protocols.lua
+++ b/packages/w/wayland-protocols/rules/wayland_protocols.lua
@@ -61,15 +61,11 @@ rule("wayland.protocols")
                 -- For C++ module dependency discovery
                 if client then
                     local clientfile = path.join(outputdir, client:format(basename))
-                    if not os.exists(clientfile) then
-                        os.touch(clientfile)
-                    end
+                    os.touch(clientfile)
                 end
                 if server then
                     local serverfile = path.join(outputdir, server:format(basename))
-                    if not os.exists(serverfile) then
-                        os.touch(serverfile)
-                    end
+                    os.touch(serverfile)
                 end
 
                 -- Add code file to target

--- a/packages/w/wayland-protocols/rules/wayland_protocols.lua
+++ b/packages/w/wayland-protocols/rules/wayland_protocols.lua
@@ -95,9 +95,7 @@ rule("wayland.protocols")
         end
         if client then
             local clientfile = path.join(outputdir, client:format(basename))
-
             local client_args = {"client-header", sourcefile, clientfile}
-
             batchcmds:show_progress(opt.progress, "${color.build.object}generating.wayland.protocol.client %s", basename)
             batchcmds:vexecv(wayland_scanner.program, client_args)
         end
@@ -106,22 +104,18 @@ rule("wayland.protocols")
         local server = target:extraconf("rules", rule_name, "server")
         if server then
             local serverfile = path.join(outputdir, server:format(basename))
-
             local server_args = {"server-header", sourcefile, serverfile}
-
             batchcmds:show_progress(opt.progress, "${color.build.object}generating.wayland.protocol.server %s", basename)
             batchcmds:vexecv(wayland_scanner.program, server_args)
         end
 
         -- Generate code
-        local code = target:extraconf("rules", rule_name, "code") or "%s.c"
-        local codefile = path.join(outputdir, code:format(basename))
-
         local public = target:extraconf("rules", rule_name, "public")
         local visibility = public and "public" or "private"
 
+        local code = target:extraconf("rules", rule_name, "code") or "%s.c"
+        local codefile = path.join(outputdir, code:format(basename))
         local code_args = {visibility .. "-code", sourcefile, codefile}
-
         batchcmds:show_progress(opt.progress, "${color.build.object}generating.wayland.protocol.%s %s", visibility, basename)
         batchcmds:vexecv(wayland_scanner.program, code_args)
 

--- a/packages/w/wayland-protocols/rules/wayland_protocols.lua
+++ b/packages/w/wayland-protocols/rules/wayland_protocols.lua
@@ -122,7 +122,7 @@ rule("wayland.protocols")
         local codefile = path.join(outputdir, code:format(basename))
 
         local public = target:extraconf("rules", rule_name, "public")
-        visibility = public and "public" or "private"
+        local visibility = public and "public" or "private"
 
         local code_args = {visibility .. "-code", sourcefile, codefile}
 


### PR DESCRIPTION
It seems that The `wayland.protocols` rule in package `wayland-protocols` didn't seem to work at all before. This PR fixes the rule and adds more options to the rule to provide more flexibility.

```lua
add_rules("@wayland-protocols/wayland.protocols", {
    outputdir = "...",  -- Path for generated files, default is `path.join(target:autogendir(), "rules", "wayland.protocols")`
    client = "...",     -- Path format for client protocol header files, default is `"%s.h"`, set to `false` to disable its generation
    server = "...",     -- Path format for server protocol header files, default is `nil`
    code = "...",       -- Path format for code files, default is `"%s.c"`
    public = false,     -- Visibility for headers and symbols in generated code, can be `false` or `true`, default is `false`
})
```