### PR TITLE
[refactor] : add cross-compilation of packages eudev, gnu-gsl, and li…

### DIFF
--- a/packages/e/eudev/xmake.lua
+++ b/packages/e/eudev/xmake.lua
@@ -6,6 +6,8 @@ package("eudev")
     add_urls("https://dev.gentoo.org/~blueness/eudev/eudev-$(version).tar.gz")
     add_versions("3.2.9", "89618619084a19e1451d373c43f141b469c9fd09767973d73dd268b92074d4fc")
 
+    add_configs("host", {description = "to cross compile add --host", default = "", type = "string"})
+
     if is_plat("linux") then
         add_deps("autoconf", "automake", "libtool", "pkg-config", "gperf")
     end
@@ -19,6 +21,9 @@ package("eudev")
         end
         if package:config("pic") ~= false then
             table.insert(configs, "--with-pic")
+        end
+        if package:config("host") ~= "" then
+            table.insert(configs, "--host=" .. package:config("host"))
         end
         import("package.tools.autoconf").install(package, configs)
     end)

--- a/packages/g/gnu-gsl/xmake.lua
+++ b/packages/g/gnu-gsl/xmake.lua
@@ -8,6 +8,8 @@ package("gnu-gsl")
              "https://ftpmirror.gnu.org/gsl/gsl-$(version).tar.gz")
     add_versions("2.7", "efbbf3785da0e53038be7907500628b466152dbc3c173a87de1b5eba2e23602b")
 
+    add_configs("host", {description = "to cross compile add --host", default = "", type = "string"})
+
     add_links("gsl", "gslcblas")
     on_install("macosx", "linux", function (package)
         local configs = {"--disable-dependency-tracking"}
@@ -15,6 +17,9 @@ package("gnu-gsl")
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
         if package:config("pic") ~= false then
             table.insert(configs, "--with-pic")
+        end
+        if package:config("host") ~= "" then
+            table.insert(configs, "--host=" .. package:config("host"))
         end
         import("package.tools.autoconf").install(package, configs, {cppflags = cppflags, ldflags = ldflags})
     end)

--- a/packages/l/libusb/xmake.lua
+++ b/packages/l/libusb/xmake.lua
@@ -23,6 +23,9 @@ package("libusb")
         end
     end
 
+
+    add_configs("host", {description = "to cross compile add --host", default = "", type = "string"})
+
     if is_plat("macosx") then
         add_frameworks("CoreFoundation", "IOKit")
     elseif is_plat("linux", "bsd") then
@@ -95,6 +98,9 @@ package("libusb")
         if package:is_plat("linux") then
             cflags = "-I" .. package:dep("eudev"):installdir("include")
             ldflags = "-L" .. package:dep("eudev"):installdir("lib")
+        end
+        if package:config("host") ~= "" then
+            table.insert(configs, "--host=" .. package:config("host"))
         end
         import("package.tools.autoconf").install(package, configs, {cflags = cflags, ldflags = ldflags})
     end)


### PR DESCRIPTION
The target platform needs to be specified when compiling the linux-arrch64 target cross-platform on windows platform using the muslcc tool chain