### PR TITLE
Fix gmssl missing syslink

### DIFF
--- a/packages/g/gmssl/xmake.lua
+++ b/packages/g/gmssl/xmake.lua
@@ -13,7 +13,7 @@ package("gmssl")
     end
 
     if is_plat("windows", "mingw") then
-        add_syslinks("ws2_32")
+        add_syslinks("ws2_32", "advapi32")
     elseif is_plat("linux") then
         add_syslinks("dl")
     elseif is_plat("macosx") then


### PR DESCRIPTION
GMSSL is using Windows Crypto API such as `CryptAcquireContext` ([here](https://github.com/guanzhi/GmSSL/blob/v3.1.0/src/rand_win.c#L32C1-L32C1)), and this API needs to link to library `Advapi32` ([msdoc](https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptacquirecontexta#requirements)).

This patch fixes this missing `add_syslinks`.
