### PR TITLE
Add PATH env when installing libtasn1

### DIFF
--- a/packages/l/libtasn1/xmake.lua
+++ b/packages/l/libtasn1/xmake.lua
@@ -10,6 +10,7 @@ package("libtasn1")
     add_versions("4.19.0", "1613f0ac1cf484d6ec0ce3b8c06d56263cc7242f1c23b30d82d23de345a63f7a")
 
     on_install("macosx", "linux", function (package)
+        package:addenv("PATH", "bin")
         local configs = {"--disable-doc", "--disable-dependency-tracking"}
         if package:config("shared") then
             table.insert(configs, "--enable-shared")


### PR DESCRIPTION
`libtasn1` library provide some binary executables. The might be useful when building (e.g. `asn1Parser` can generate `.c` file from `.asn` definition file.).

With this patch, we can define rules to build `.asn` (something like `batchcmds:vexecv("asn1Parser" ...`)