### PR TITLE
ixwebsocket: fix TLS

### DIFF
--- a/packages/i/ixwebsocket/xmake.lua
+++ b/packages/i/ixwebsocket/xmake.lua
@@ -89,7 +89,7 @@ package("ixwebsocket")
         assert(package:check_cxxsnippets({test = [[
             #include <ixwebsocket/IXNetSystem.h>
             #include <ixwebsocket/IXWebSocket.h>
-            void test () {
+            void test() {
                 ix::initNetSystem();
                 ix::WebSocket webSocket;
                 std::string url("wss://echo.websocket.org");


### PR DESCRIPTION
- The file 'ixwebsocket/IXSocketMbedTLS.cpp' had `errorMsg` commented out
- Fix windows TLS 
- Always add dep if TLS is enabled