### PR TITLE
libusb: Fix include dirs

### DIFF
--- a/packages/l/libusb/xmake.lua
+++ b/packages/l/libusb/xmake.lua
@@ -25,6 +25,8 @@ package("libusb")
 
     add_deps("cmake")
 
+    add_includedirs("include", "include/libusb-1.0")
+
     on_install("windows", "linux", "macosx", "bsd", "msys", "android", function (package)
         local dir = package:resourcefile("libusb-cmake")
         os.cp(path.join(dir, "CMakeLists.txt"), os.curdir())


### PR DESCRIPTION
#2926 broke `#include "libusb.h"` which is used in samples by libusb and other libs depending on it
