### PR TITLE
alsa-lib: Add autoconf dependencies

### DIFF
--- a/packages/a/alsa-lib/xmake.lua
+++ b/packages/a/alsa-lib/xmake.lua
@@ -14,6 +14,10 @@ package("alsa-lib")
         add_extsources("pacman::alsa-lib", "apt::libasound2-dev")
     end
 
+    if not is_plat("windows") then
+        add_deps("autoconf", "automake", "libtool")
+    end
+
     on_install("linux", function (package)
         local configs = {}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))


### PR DESCRIPTION
Should fix
```
checkinfo: cannot runv(autoreconf --version), No such file or directory
checking for autoreconf ... no
error: @programdir/modules/package/tools/autoconf.lua:432: autoreconf not found!
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:923]: in function 'raiselevel'
    [@programdir/core/sandbox/modules/utils.lua:149]: in function 'assert'
    [@programdir/modules/package/tools/autoconf.lua:432]: in function 'configure'
    [@programdir/modules/package/tools/autoconf.lua:478]: in function 'build'
    [@programdir/modules/package/tools/autoconf.lua:507]: in function 'install'
    [...ke/repositories/xmake-repo/packages/a/alsa-lib/xmake.lua:27]: in function 'script'
    [...dir/modules/private/action/require/impl/utils/filter.lua:125]: in function 'call'
    [.../modules/private/action/require/impl/actions/install.lua:366]:

  => install alsa-lib 1.2.10 .. failed
```