### PR TITLE
alsa-lib: Add m4 dependency

### DIFF
--- a/packages/a/alsa-lib/xmake.lua
+++ b/packages/a/alsa-lib/xmake.lua
@@ -15,7 +15,7 @@ package("alsa-lib")
     end
 
     if not is_plat("windows") then
-        add_deps("autoconf", "automake", "libtool")
+        add_deps("autoconf", "automake", "libtool", "m4")
     end
 
     on_install("linux", function (package)


### PR DESCRIPTION
This fixes the compilation of alsa-lib and libsndio on Linux when autoconf and m4 are not installed
