### PR TITLE
libgpiod: fix cxx bindings not having c links

### DIFF
--- a/packages/l/libgpiod/port/xmake.lua
+++ b/packages/l/libgpiod/port/xmake.lua
@@ -22,13 +22,23 @@ if has_config("enable_bindings_cxx") then
         set_kind("$(kind)")
         set_languages("cxx17")
 
+        add_headerfiles("include/(gpiod.h)")
+        add_headerfiles("lib/uapi/*.h")
+        add_files("lib/*.c")
+        
+        add_includedirs("include")
+
         add_headerfiles("bindings/cxx/(gpiod.hpp)")
         add_headerfiles("bindings/cxx/(gpiodcxx/**.hpp)")
         add_files("bindings/cxx/*.cpp")
 
         add_includedirs("bindings/cxx", {public = true})
 
-        add_deps("gpiod")
+        before_build(function (target)
+            local configure = io.readfile("configure.ac")
+            local version = configure:match("AC_INIT%(%[libgpiod%], %[?([0-9%.]+)%]?%)")
+            target:add("defines", "GPIOD_VERSION_STR=\"" .. version .. "\"")
+        end)
 end
 
 if has_config("enable_tools") then


### PR DESCRIPTION
add_deps("gpiod") does not work for target "gpiodcxx"
```
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::(anonymous namespace)::open_chip(std::filesystem::__cxx11::path const&)':
chip.cpp:(.text+0x3c): undefined reference to `gpiod_chip_open'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::chip::path[abi:cxx11]() const':
chip.cpp:(.text+0x398): undefined reference to `gpiod_chip_get_path'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::chip::get_info() const':
chip.cpp:(.text+0x3f0): undefined reference to `gpiod_chip_get_info'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::chip::get_line_info(gpiod::line::offset) const':
chip.cpp:(.text+0x528): undefined reference to `gpiod_chip_get_line_info'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::chip::watch_line_info(gpiod::line::offset) const':
chip.cpp:(.text+0x660): undefined reference to `gpiod_chip_watch_line_info'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::chip::unwatch_line_info(gpiod::line::offset) const':
chip.cpp:(.text+0x794): undefined reference to `gpiod_chip_unwatch_line_info'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::chip::fd() const':
chip.cpp:(.text+0x840): undefined reference to `gpiod_chip_get_fd'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::chip::wait_info_event(std::chrono::duration<long, std::ratio<1l, 1000000000l> > const&) const':
chip.cpp:(.text+0x88c): undefined reference to `gpiod_chip_wait_info_event'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::chip::read_info_event() const':
chip.cpp:(.text+0x94c): undefined reference to `gpiod_chip_read_info_event'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::chip::get_line_offset_from_name(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const':
chip.cpp:(.text+0xa80): undefined reference to `gpiod_chip_get_line_offset_from_name'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::deleter<gpiod_chip, &gpiod_chip_close>::operator()(gpiod_chip*)':
chip.cpp:(.text._ZN5gpiod7deleterI10gpiod_chipXadL_Z16gpiod_chip_closeEEEclEPS1_[_ZN5gpiod7deleterI10gpiod_chipXadL_Z16gpiod_chip_closeEEEclEPS1_]+0x14): undefined reference to `gpiod_chip_close'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::deleter<gpiod_chip_info, &gpiod_chip_info_free>::operator()(gpiod_chip_info*)':
chip.cpp:(.text._ZN5gpiod7deleterI15gpiod_chip_infoXadL_Z20gpiod_chip_info_freeEEEclEPS1_[_ZN5gpiod7deleterI15gpiod_chip_infoXadL_Z20gpiod_chip_info_freeEEEclEPS1_]+0x14): undefined reference to `gpiod_chip_info_free'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::deleter<gpiod_line_info, &gpiod_line_info_free>::operator()(gpiod_line_info*)':
chip.cpp:(.text._ZN5gpiod7deleterI15gpiod_line_infoXadL_Z20gpiod_line_info_freeEEEclEPS1_[_ZN5gpiod7deleterI15gpiod_line_infoXadL_Z20gpiod_line_info_freeEEEclEPS1_]+0x14): undefined reference to `gpiod_line_info_free'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip.cpp.o): in function `gpiod::deleter<gpiod_info_event, &gpiod_info_event_free>::operator()(gpiod_info_event*)':
chip.cpp:(.text._ZN5gpiod7deleterI16gpiod_info_eventXadL_Z21gpiod_info_event_freeEEEclEPS1_[_ZN5gpiod7deleterI16gpiod_info_eventXadL_Z21gpiod_info_event_freeEEEclEPS1_]+0x14): undefined reference to `gpiod_info_event_free'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(info-event.cpp.o): in function `gpiod::info_event::impl::set_info_event_ptr(std::unique_ptr<gpiod_info_event, gpiod::deleter<gpiod_info_event, &gpiod_info_event_free> >&)':
info-event.cpp:(.text+0x3c): undefined reference to `gpiod_info_event_get_line_info'
/usr/bin/ld: info-event.cpp:(.text+0x48): undefined reference to `gpiod_line_info_copy'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(info-event.cpp.o): in function `gpiod::info_event::type() const':
info-event.cpp:(.text+0x280): undefined reference to `gpiod_info_event_get_event_type'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(info-event.cpp.o): in function `gpiod::info_event::timestamp_ns() const':
info-event.cpp:(.text+0x2b8): undefined reference to `gpiod_info_event_get_timestamp_ns'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(request-builder.cpp.o): in function `gpiod::request_builder::do_request()':
request-builder.cpp:(.text+0x334): undefined reference to `gpiod_chip_request_lines'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(request-builder.cpp.o): in function `gpiod::deleter<gpiod_line_request, &gpiod_line_request_release>::operator()(gpiod_line_request*)':
request-builder.cpp:(.text._ZN5gpiod7deleterI18gpiod_line_requestXadL_Z26gpiod_line_request_releaseEEEclEPS1_[_ZN5gpiod7deleterI18gpiod_line_requestXadL_Z26gpiod_line_request_releaseEEEclEPS1_]+0x14): undefined reference to `gpiod_line_request_release'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-config.cpp.o): in function `gpiod::(anonymous namespace)::make_line_config()':
line-config.cpp:(.text+0x30): undefined reference to `gpiod_line_config_new'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-config.cpp.o): in function `gpiod::line_config::reset()':
line-config.cpp:(.text+0x228): undefined reference to `gpiod_line_config_reset'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-config.cpp.o): in function `gpiod::line_config::add_line_settings(std::vector<gpiod::line::offset, std::allocator<gpiod::line::offset> > const&, gpiod::line_settings const&)':
line-config.cpp:(.text+0x3d8): undefined reference to `gpiod_line_config_add_line_settings'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-config.cpp.o): in function `gpiod::line_config::set_output_values(std::vector<gpiod::line::value, std::allocator<gpiod::line::value> > const&)':
line-config.cpp:(.text+0x568): undefined reference to `gpiod_line_config_set_output_values'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-config.cpp.o): in function `gpiod::line_config::get_line_settings() const':
line-config.cpp:(.text+0x644): undefined reference to `gpiod_line_config_get_num_configured_offsets'
/usr/bin/ld: line-config.cpp:(.text+0x6a8): undefined reference to `gpiod_line_config_get_configured_offsets'
/usr/bin/ld: line-config.cpp:(.text+0x6fc): undefined reference to `gpiod_line_config_get_line_settings'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-config.cpp.o): in function `gpiod::deleter<gpiod_line_config, &gpiod_line_config_free>::operator()(gpiod_line_config*)':
line-config.cpp:(.text._ZN5gpiod7deleterI17gpiod_line_configXadL_Z22gpiod_line_config_freeEEEclEPS1_[_ZN5gpiod7deleterI17gpiod_line_configXadL_Z22gpiod_line_config_freeEEEclEPS1_]+0x14): undefined reference to `gpiod_line_config_free'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-config.cpp.o): in function `gpiod::deleter<gpiod_line_settings, &gpiod_line_settings_free>::operator()(gpiod_line_settings*)':
line-config.cpp:(.text._ZN5gpiod7deleterI19gpiod_line_settingsXadL_Z24gpiod_line_settings_freeEEEclEPS1_[_ZN5gpiod7deleterI19gpiod_line_settingsXadL_Z24gpiod_line_settings_freeEEEclEPS1_]+0x14): undefined reference to `gpiod_line_settings_free'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-request.cpp.o): in function `gpiod::line_request::impl::set_request_ptr(std::unique_ptr<gpiod_line_request, gpiod::deleter<gpiod_line_request, &gpiod_line_request_release> >&)':
line-request.cpp:(.text+0x108): undefined reference to `gpiod_line_request_get_num_requested_lines'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-request.cpp.o): in function `gpiod::line_request::num_lines() const':
line-request.cpp:(.text+0x300): undefined reference to `gpiod_line_request_get_num_requested_lines'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-request.cpp.o): in function `gpiod::line_request::offsets() const':
line-request.cpp:(.text+0x3b4): undefined reference to `gpiod_line_request_get_requested_offsets'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-request.cpp.o): in function `gpiod::line_request::get_values(std::vector<gpiod::line::offset, std::allocator<gpiod::line::offset> > const&, std::vector<gpiod::line::value, std::allocator<gpiod::line::value> >&)':
line-request.cpp:(.text+0x718): undefined reference to `gpiod_line_request_get_values_subset'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-request.cpp.o): in function `gpiod::line_request::set_values(std::vector<gpiod::line::offset, std::allocator<gpiod::line::offset> > const&, std::vector<gpiod::line::value, std::allocator<gpiod::line::value> > const&)':
line-request.cpp:(.text+0xb8c): undefined reference to `gpiod_line_request_set_values_subset'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-request.cpp.o): in function `gpiod::line_request::reconfigure_lines(gpiod::line_config const&)':
line-request.cpp:(.text+0xcdc): undefined reference to `gpiod_line_request_reconfigure_lines'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-request.cpp.o): in function `gpiod::line_request::fd() const':
line-request.cpp:(.text+0xd88): undefined reference to `gpiod_line_request_get_fd'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-request.cpp.o): in function `gpiod::line_request::wait_edge_events(std::chrono::duration<long, std::ratio<1l, 1000000000l> > const&) const':
line-request.cpp:(.text+0xdd4): undefined reference to `gpiod_line_request_wait_edge_events'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(request-config.cpp.o): in function `gpiod::(anonymous namespace)::make_request_config()':
request-config.cpp:(.text+0x30): undefined reference to `gpiod_request_config_new'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(request-config.cpp.o): in function `gpiod::request_config::set_consumer(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
request-config.cpp:(.text+0x244): undefined reference to `gpiod_request_config_set_consumer'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(request-config.cpp.o): in function `gpiod::request_config::consumer[abi:cxx11]() const':
request-config.cpp:(.text+0x278): undefined reference to `gpiod_request_config_get_consumer'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(request-config.cpp.o): in function `gpiod::request_config::set_event_buffer_size(unsigned long)':
request-config.cpp:(.text+0x2f4): undefined reference to `gpiod_request_config_set_event_buffer_size'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(request-config.cpp.o): in function `gpiod::request_config::event_buffer_size() const':
request-config.cpp:(.text+0x31c): undefined reference to `gpiod_request_config_get_event_buffer_size'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(request-config.cpp.o): in function `gpiod::deleter<gpiod_request_config, &gpiod_request_config_free>::operator()(gpiod_request_config*)':
request-config.cpp:(.text._ZN5gpiod7deleterI20gpiod_request_configXadL_Z25gpiod_request_config_freeEEEclEPS1_[_ZN5gpiod7deleterI20gpiod_request_configXadL_Z25gpiod_request_config_freeEEEclEPS1_]+0x14): undefined reference to `gpiod_request_config_free'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip-info.cpp.o): in function `gpiod::chip_info::name[abi:cxx11]() const':
chip-info.cpp:(.text+0x190): undefined reference to `gpiod_chip_info_get_name'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip-info.cpp.o): in function `gpiod::chip_info::label[abi:cxx11]() const':
chip-info.cpp:(.text+0x1f0): undefined reference to `gpiod_chip_info_get_label'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(chip-info.cpp.o): in function `gpiod::chip_info::num_lines() const':
chip-info.cpp:(.text+0x248): undefined reference to `gpiod_chip_info_get_num_lines'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-info.cpp.o): in function `gpiod::line_info::offset() const':
line-info.cpp:(.text+0x188): undefined reference to `gpiod_line_info_get_offset'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-info.cpp.o): in function `gpiod::line_info::name[abi:cxx11]() const':
line-info.cpp:(.text+0x1c4): undefined reference to `gpiod_line_info_get_name'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-info.cpp.o): in function `gpiod::line_info::used() const':
line-info.cpp:(.text+0x238): undefined reference to `gpiod_line_info_is_used'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-info.cpp.o): in function `gpiod::line_info::consumer[abi:cxx11]() const':
line-info.cpp:(.text+0x268): undefined reference to `gpiod_line_info_get_consumer'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-info.cpp.o): in function `gpiod::line_info::direction() const':
line-info.cpp:(.text+0x2dc): undefined reference to `gpiod_line_info_get_direction'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-info.cpp.o): in function `gpiod::line_info::active_low() const':
line-info.cpp:(.text+0x314): undefined reference to `gpiod_line_info_is_active_low'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-info.cpp.o): in function `gpiod::line_info::bias() const':
line-info.cpp:(.text+0x33c): undefined reference to `gpiod_line_info_get_bias'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-info.cpp.o): in function `gpiod::line_info::drive() const':
line-info.cpp:(.text+0x37c): undefined reference to `gpiod_line_info_get_drive'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-info.cpp.o): in function `gpiod::line_info::edge_detection() const':
line-info.cpp:(.text+0x3bc): undefined reference to `gpiod_line_info_get_edge_detection'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-info.cpp.o): in function `gpiod::line_info::event_clock() const':
line-info.cpp:(.text+0x3fc): undefined reference to `gpiod_line_info_get_event_clock'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-info.cpp.o): in function `gpiod::line_info::debounced() const':
line-info.cpp:(.text+0x43c): undefined reference to `gpiod_line_info_is_debounced'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-info.cpp.o): in function `gpiod::line_info::debounce_period() const':
line-info.cpp:(.text+0x464): undefined reference to `gpiod_line_info_get_debounce_period_us'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::(anonymous namespace)::make_line_settings()':
line-settings.cpp:(.text+0x10): undefined reference to `gpiod_line_settings_new'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::(anonymous namespace)::copy_line_settings(std::unique_ptr<gpiod_line_settings, gpiod::deleter<gpiod_line_settings, &gpiod_line_settings_free> > const&)':
line-settings.cpp:(.text+0xd8): undefined reference to `gpiod_line_settings_copy'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::line_settings::reset()':
line-settings.cpp:(.text+0x3ec): undefined reference to `gpiod_line_settings_reset'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::line_settings::set_active_low(bool)':
line-settings.cpp:(.text+0x5ec): undefined reference to `gpiod_line_settings_set_active_low'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::line_settings::active_low() const':
line-settings.cpp:(.text+0x614): undefined reference to `gpiod_line_settings_get_active_low'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::line_settings::set_debounce_period(std::chrono::duration<long, std::ratio<1l, 1000000l> > const&)':
line-settings.cpp:(.text+0x658): undefined reference to `gpiod_line_settings_set_debounce_period_us'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::line_settings::debounce_period() const':
line-settings.cpp:(.text+0x684): undefined reference to `gpiod_line_settings_get_debounce_period_us'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `void gpiod::(anonymous namespace)::set_mapped_prop<gpiod::line::direction, gpiod_line_direction, &gpiod_line_settings_set_direction>(gpiod_line_settings*, gpiod::line::direction, std::map<gpiod::line::direction, gpiod_line_direction, std::less<gpiod::line::direction>, std::allocator<std::pair<gpiod::line::direction const, gpiod_line_direction> > > const&)':
line-settings.cpp:(.text+0xe54): undefined reference to `gpiod_line_settings_set_direction'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::line::direction gpiod::(anonymous namespace)::get_mapped_prop<gpiod::line::direction, gpiod_line_direction, &gpiod_line_settings_get_direction>(gpiod_line_settings*, std::map<gpiod_line_direction, gpiod::line::direction, std::less<gpiod_line_direction>, std::allocator<std::pair<gpiod_line_direction const, gpiod::line::direction> > > const&)':
line-settings.cpp:(.text+0xef0): undefined reference to `gpiod_line_settings_get_direction'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `void gpiod::(anonymous namespace)::set_mapped_prop<gpiod::line::edge, gpiod_line_edge, &gpiod_line_settings_set_edge_detection>(gpiod_line_settings*, gpiod::line::edge, std::map<gpiod::line::edge, gpiod_line_edge, std::less<gpiod::line::edge>, std::allocator<std::pair<gpiod::line::edge const, gpiod_line_edge> > > const&)':
line-settings.cpp:(.text+0xf3c): undefined reference to `gpiod_line_settings_set_edge_detection'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::line::edge gpiod::(anonymous namespace)::get_mapped_prop<gpiod::line::edge, gpiod_line_edge, &gpiod_line_settings_get_edge_detection>(gpiod_line_settings*, std::map<gpiod_line_edge, gpiod::line::edge, std::less<gpiod_line_edge>, std::allocator<std::pair<gpiod_line_edge const, gpiod::line::edge> > > const&)':
line-settings.cpp:(.text+0xfd8): undefined reference to `gpiod_line_settings_get_edge_detection'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `void gpiod::(anonymous namespace)::set_mapped_prop<gpiod::line::bias, gpiod_line_bias, &gpiod_line_settings_set_bias>(gpiod_line_settings*, gpiod::line::bias, std::map<gpiod::line::bias, gpiod_line_bias, std::less<gpiod::line::bias>, std::allocator<std::pair<gpiod::line::bias const, gpiod_line_bias> > > const&)':
line-settings.cpp:(.text+0x1024): undefined reference to `gpiod_line_settings_set_bias'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::line::bias gpiod::(anonymous namespace)::get_mapped_prop<gpiod::line::bias, gpiod_line_bias, &gpiod_line_settings_get_bias>(gpiod_line_settings*, std::map<gpiod_line_bias, gpiod::line::bias, std::less<gpiod_line_bias>, std::allocator<std::pair<gpiod_line_bias const, gpiod::line::bias> > > const&)':
line-settings.cpp:(.text+0x10c0): undefined reference to `gpiod_line_settings_get_bias'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `void gpiod::(anonymous namespace)::set_mapped_prop<gpiod::line::drive, gpiod_line_drive, &gpiod_line_settings_set_drive>(gpiod_line_settings*, gpiod::line::drive, std::map<gpiod::line::drive, gpiod_line_drive, std::less<gpiod::line::drive>, std::allocator<std::pair<gpiod::line::drive const, gpiod_line_drive> > > const&)':
line-settings.cpp:(.text+0x110c): undefined reference to `gpiod_line_settings_set_drive'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::line::drive gpiod::(anonymous namespace)::get_mapped_prop<gpiod::line::drive, gpiod_line_drive, &gpiod_line_settings_get_drive>(gpiod_line_settings*, std::map<gpiod_line_drive, gpiod::line::drive, std::less<gpiod_line_drive>, std::allocator<std::pair<gpiod_line_drive const, gpiod::line::drive> > > const&)':
line-settings.cpp:(.text+0x11a8): undefined reference to `gpiod_line_settings_get_drive'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `void gpiod::(anonymous namespace)::set_mapped_prop<gpiod::line::clock, gpiod_line_clock, &gpiod_line_settings_set_event_clock>(gpiod_line_settings*, gpiod::line::clock, std::map<gpiod::line::clock, gpiod_line_clock, std::less<gpiod::line::clock>, std::allocator<std::pair<gpiod::line::clock const, gpiod_line_clock> > > const&)':
line-settings.cpp:(.text+0x11f4): undefined reference to `gpiod_line_settings_set_event_clock'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::line::clock gpiod::(anonymous namespace)::get_mapped_prop<gpiod::line::clock, gpiod_line_clock, &gpiod_line_settings_get_event_clock>(gpiod_line_settings*, std::map<gpiod_line_clock, gpiod::line::clock, std::less<gpiod_line_clock>, std::allocator<std::pair<gpiod_line_clock const, gpiod::line::clock> > > const&)':
line-settings.cpp:(.text+0x1290): undefined reference to `gpiod_line_settings_get_event_clock'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `void gpiod::(anonymous namespace)::set_mapped_prop<gpiod::line::value, gpiod_line_value, &gpiod_line_settings_set_output_value>(gpiod_line_settings*, gpiod::line::value, std::map<gpiod::line::value, gpiod_line_value, std::less<gpiod::line::value>, std::allocator<std::pair<gpiod::line::value const, gpiod_line_value> > > const&)':
line-settings.cpp:(.text+0x12dc): undefined reference to `gpiod_line_settings_set_output_value'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(line-settings.cpp.o): in function `gpiod::line::value gpiod::(anonymous namespace)::get_mapped_prop<gpiod::line::value, gpiod_line_value, &gpiod_line_settings_get_output_value>(gpiod_line_settings*, std::map<gpiod_line_value, gpiod::line::value, std::less<gpiod_line_value>, std::allocator<std::pair<gpiod_line_value const, gpiod::line::value> > > const&)':
line-settings.cpp:(.text+0x1378): undefined reference to `gpiod_line_settings_get_output_value'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(edge-event-buffer.cpp.o): in function `gpiod::(anonymous namespace)::make_edge_event_buffer(unsigned int)':
edge-event-buffer.cpp:(.text+0x18): undefined reference to `gpiod_edge_event_buffer_new'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(edge-event-buffer.cpp.o): in function `gpiod::edge_event_buffer::impl::read_events(std::unique_ptr<gpiod_line_request, gpiod::deleter<gpiod_line_request, &gpiod_line_request_release> > const&, unsigned int)':
edge-event-buffer.cpp:(.text+0x224): undefined reference to `gpiod_line_request_read_edge_events'
/usr/bin/ld: edge-event-buffer.cpp:(.text+0x2a0): undefined reference to `gpiod_edge_event_buffer_get_event'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(edge-event-buffer.cpp.o): in function `gpiod::edge_event_buffer::num_events() const':
edge-event-buffer.cpp:(.text+0x470): undefined reference to `gpiod_edge_event_buffer_get_num_events'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(edge-event-buffer.cpp.o): in function `gpiod::edge_event_buffer::capacity() const':
edge-event-buffer.cpp:(.text+0x494): undefined reference to `gpiod_edge_event_buffer_get_capacity'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(edge-event-buffer.cpp.o): in function `gpiod::deleter<gpiod_edge_event_buffer, &gpiod_edge_event_buffer_free>::operator()(gpiod_edge_event_buffer*)':
edge-event-buffer.cpp:(.text._ZN5gpiod7deleterI23gpiod_edge_event_bufferXadL_Z28gpiod_edge_event_buffer_freeEEEclEPS1_[_ZN5gpiod7deleterI23gpiod_edge_event_bufferXadL_Z28gpiod_edge_event_buffer_freeEEEclEPS1_]+0x14): undefined reference to `gpiod_edge_event_buffer_free'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(edge-event.cpp.o): in function `gpiod::edge_event::impl_external::copy(std::shared_ptr<gpiod::edge_event::impl> const&) const':
edge-event.cpp:(.text+0x148): undefined reference to `gpiod_edge_event_copy'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(edge-event.cpp.o): in function `gpiod::edge_event::type() const':
edge-event.cpp:(.text+0x364): undefined reference to `gpiod_edge_event_get_event_type'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(edge-event.cpp.o): in function `gpiod::edge_event::timestamp_ns() const':
edge-event.cpp:(.text+0x3a8): undefined reference to `gpiod_edge_event_get_timestamp_ns'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(edge-event.cpp.o): in function `gpiod::edge_event::line_offset() const':
edge-event.cpp:(.text+0x3e8): undefined reference to `gpiod_edge_event_get_line_offset'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(edge-event.cpp.o): in function `gpiod::edge_event::global_seqno() const':
edge-event.cpp:(.text+0x428): undefined reference to `gpiod_edge_event_get_global_seqno'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(edge-event.cpp.o): in function `gpiod::edge_event::line_seqno() const':
edge-event.cpp:(.text+0x458): undefined reference to `gpiod_edge_event_get_line_seqno'
/usr/bin/ld: /home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib/libgpiodcxx.a(edge-event.cpp.o): in function `gpiod::deleter<gpiod_edge_event, &gpiod_edge_event_free>::operator()(gpiod_edge_event*)':
edge-event.cpp:(.text._ZN5gpiod7deleterI16gpiod_edge_eventXadL_Z21gpiod_edge_event_freeEEEclEPS1_[_ZN5gpiod7deleterI16gpiod_edge_eventXadL_Z21gpiod_edge_event_freeEEEclEPS1_]+0x14): undefined reference to `gpiod_edge_event_free'
collect2: error: ld returned 1 exit status
> checking for c++ links(gpiod, gpiodcxx)
> checking for c++ snippet(test)
checkinfo: ...gramdir/core/sandbox/modules/import/core/tool/linker.lua:75: @programdir/core/sandbox/modules/os.lua:378: execv(/usr/bin/g++ -o /tmp/.xmake1000/231224/_7E8875FC27654E00870F703CF380CD40.b /tmp/.xmake1000/231224/_7E8875FC27654E00870F703CF380CD40.o -L/home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib -lgpiod -lgpiodcxx) failed(1)
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:923]:
    [@programdir/core/sandbox/modules/os.lua:378]: in function 'execv'
    [@programdir/modules/core/tools/gcc.lua:526]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:280]:
    [@programdir/core/tool/linker.lua:224]: in function 'link'
    [...gramdir/core/sandbox/modules/import/core/tool/linker.lua:73]: in function 'link'
    [@programdir/modules/lib/detect/check_cxsnippets.lua:247]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:280]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [@programdir/modules/lib/detect/check_cxsnippets.lua:236]:
    [/home/admin/xmake-repo/packages/l/libgpiod/xmake.lua:36]: in function 'script'
    [...dir/modules/private/action/require/impl/utils/filter.lua:125]: in function 'call'
    [...dir/modules/private/action/require/impl/actions/test.lua:41]:
    [.../modules/private/action/require/impl/actions/install.lua:409]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:280]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [.../modules/private/action/require/impl/actions/install.lua:330]:
    [...modules/private/action/require/impl/install_packages.lua:479]: in function 'jobfunc'
    [@programdir/modules/async/runjobs.lua:237]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:280]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [@programdir/modules/async/runjobs.lua:220]: in function 'cotask'
    [@programdir/core/base/scheduler.lua:404]:

error: /home/admin/xmake-repo/packages/l/libgpiod/xmake.lua:36: ...gramdir/core/sandbox/modules/import/core/tool/linker.lua:75: @programdir/core/sandbox/modules/os.lua:378: execv(/usr/bin/g++ -o /tmp/.xmake1000/231224/_7E8875FC27654E00870F703CF380CD40.b /tmp/.xmake1000/231224/_7E8875FC27654E00870F703CF380CD40.o -L/home/admin/.xmake/packages/l/libgpiod/v2.0.1/157e18a575a14285a70fae64f41d3a6d/lib -lgpiod -lgpiodcxx) failed(1)
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:923]:
    [@programdir/core/sandbox/modules/os.lua:378]: in function 'execv'
    [@programdir/modules/core/tools/gcc.lua:526]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:280]:
    [@programdir/core/tool/linker.lua:224]: in function 'link'
    [...gramdir/core/sandbox/modules/import/core/tool/linker.lua:73]: in function 'link'
    [@programdir/modules/lib/detect/check_cxsnippets.lua:247]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:280]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [@programdir/modules/lib/detect/check_cxsnippets.lua:236]:
    [/home/admin/xmake-repo/packages/l/libgpiod/xmake.lua:36]: in function 'script'
    [...dir/modules/private/action/require/impl/utils/filter.lua:125]: in function 'call'
    [...dir/modules/private/action/require/impl/actions/test.lua:41]:
    [.../modules/private/action/require/impl/actions/install.lua:409]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:280]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [.../modules/private/action/require/impl/actions/install.lua:330]:
    [...modules/private/action/require/impl/install_packages.lua:479]: in function 'jobfunc'
    [@programdir/modules/async/runjobs.lua:237]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:280]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [@programdir/modules/async/runjobs.lua:220]: in function 'cotask'
    [@programdir/core/base/scheduler.lua:404]:

  => install libgpiod v2.0.1 .. failed
error: @programdir/core/main.lua:309: @programdir/modules/async/runjobs.lua:320: .../modules/private/action/require/impl/actions/install.lua:471: install failed!
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:923]:
    [.../modules/private/action/require/impl/actions/install.lua:471]: in function 'catch'
    [@programdir/core/sandbox/modules/try.lua:123]: in function 'try'
    [.../modules/private/action/require/impl/actions/install.lua:330]:
    [...modules/private/action/require/impl/install_packages.lua:479]: in function 'jobfunc'
    [@programdir/modules/async/runjobs.lua:237]:

stack traceback:
        [C]: in function 'error'
        @programdir/core/base/os.lua:923: in function 'os.raiselevel'
        (...tail calls...)
        @programdir/core/main.lua:309: in upvalue 'cotask'
        @programdir/core/base/scheduler.lua:404: in function <@programdir/core/base/scheduler.lua:397>
error: execv(xmake require -f -y --build -v -D --shallow --extra={configs={shared=false}} libgpiod) failed(255)

```