### PR TITLE
concurrentqueue: Restore concurrentqueue/concurrentqueue.h include

### DIFF
--- a/packages/c/concurrentqueue/xmake.lua
+++ b/packages/c/concurrentqueue/xmake.lua
@@ -26,6 +26,13 @@ package("concurrentqueue")
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)
 
+        io.writefile(path.join(package:installdir("include"), "concurrentqueue", "concurrentqueue.h"), [[
+#pragma once
+
+#pragma message please update include <concurrentqueue/concurrentqueue.h> to <concurrentqueue.h>
+#include "moodycamel/concurrentqueue.h"
+        ]])
+
         if package:config("c_api") then
             io.writefile("xmake.lua", [[
                 add_rules("mode.debug", "mode.release")


### PR DESCRIPTION
https://github.com/xmake-io/xmake-repo/commit/095e769f1f6db3aa501300ecbe8ad5fb4bb4c5d4 reworked concurrentqueue which no longer has `concurrentqueue/concurrentqueue.h` includes, this breaks compilation for existing project using it.
