### PR TITLE
Auto-update utfcpp to v4.0.5

### DIFF
--- a/packages/u/utfcpp/xmake.lua
+++ b/packages/u/utfcpp/xmake.lua
@@ -6,6 +6,7 @@ package("utfcpp")
 
     add_urls("https://github.com/nemtrif/utfcpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nemtrif/utfcpp.git")
+    add_versions("v4.0.5", "ffc668a310e77607d393f3c18b32715f223da1eac4c4d6e0579a11df8e6b59cf")
     add_versions("v4.0.4", "7c8a403d0c575d52473c8644cd9eb46c6ba028d2549bc3e0cdc2d45f5cfd78a0")
     add_versions("v4.0.3", "05e7d023b2bf606777442efc49038e0efce317596582db15adf5c776e237a326")
     add_versions("v4.0.2", "d3c032650cd30823b7ebbebbe91f39d8c0e91221b2e3e92b93ca425478f986f2")


### PR DESCRIPTION
New version of utfcpp detected (package version: v4.0.4, last github version: v4.0.5)