### PR TITLE
Auto-update fmt to 10.2.0

### DIFF
--- a/packages/f/fmt/xmake.lua
+++ b/packages/f/fmt/xmake.lua
@@ -5,6 +5,7 @@ package("fmt")
 
     set_urls("https://github.com/fmtlib/fmt/releases/download/$(version)/fmt-$(version).zip",
              "https://github.com/fmtlib/fmt.git")
+    add_versions("10.2.0", "8a942861a94f8461a280f823041cde8f620a6d8b0e0aacc98c15bb5a9dd92399")
     add_versions("10.1.1", "b84e58a310c9b50196cda48d5678d5fa0849bca19e5fdba6b684f0ee93ed9d1b")
     add_versions("10.1.0", "d725fa83a8b57a3cedf238828fa6b167f963041e8f9f7327649bddc68ae316f4")
     add_versions("10.0.0", "4943cb165f3f587f26da834d3056ee8733c397e024145ca7d2a8a96bb71ac281")


### PR DESCRIPTION
New version of fmt detected (package version: 10.1.1, last github version: 10.2.0)