### PR TITLE
dr_libs: Don't checkout submodules

### DIFF
--- a/packages/d/dr_flac/xmake.lua
+++ b/packages/d/dr_flac/xmake.lua
@@ -4,7 +4,7 @@ package("dr_flac")
     set_description("Single file audio decoding libraries for C/C++.")
     set_license("MIT")
 
-    set_urls("https://github.com/mackron/dr_libs.git")
+    set_urls("https://github.com/mackron/dr_libs.git", {submodules = false})
     add_versions("0.12.42", "39ce69188eab79a913aa23423eef9da5f3dcd142")
     add_versions("0.12.41", "056b6f5e1f7cc5046aac33e6331551b6b2813292")
     add_versions("0.12.39", "7d3638f215599e4b576fe5d4be4f6820b9988e48")

--- a/packages/d/dr_mp3/xmake.lua
+++ b/packages/d/dr_mp3/xmake.lua
@@ -4,7 +4,7 @@ package("dr_mp3")
     set_description("Single file audio decoding libraries for C/C++.")
     set_license("MIT")
 
-    set_urls("https://github.com/mackron/dr_libs.git")
+    set_urls("https://github.com/mackron/dr_libs.git", {submodules = false})
     add_versions("0.6.38", "01d23df76776faccee3bc456f685900dcc273b4c")
     add_versions("0.6.37", "1b0bc87c6b9b04052e6ef0117396dab8482c250e")
     add_versions("0.6.36", "b7f4c04e77b4c14347b74503e4ce93494e314283")

--- a/packages/d/dr_wav/xmake.lua
+++ b/packages/d/dr_wav/xmake.lua
@@ -4,7 +4,7 @@ package("dr_wav")
     set_description("Single file audio decoding libraries for C/C++.")
     set_license("MIT")
 
-    set_urls("https://github.com/mackron/dr_libs.git")
+    set_urls("https://github.com/mackron/dr_libs.git", {submodules = false})
     add_versions("0.13.13", "9eed1be421749ba68a87e5b4c3b10858f8580689")
     add_versions("0.13.12", "d35a3bc5efd02455d98cbe12b94647136f09b42d")
     add_versions("0.13.11", "e07e2b8264da5fa1331a0ca3d30a3606084c311f")


### PR DESCRIPTION
dr_libs has a miniaudio submodule which takes some time to clone for some reason, but it's used only for testing and is not required for the libs
