### PR TITLE
some improvements on ncurses

### DIFF
--- a/packages/n/ncurses/xmake.lua
+++ b/packages/n/ncurses/xmake.lua
@@ -14,8 +14,12 @@ package("ncurses")
 
     add_configs("widec", {description = "Compile with wide-char/UTF-8 code.", default = true, type = "boolean"})
 
-    if is_plat("linux") then
-        add_extsources("apt::libncurses-dev")
+    if is_plat("mingw") and is_subhost("msys") then
+        add_extsources("pacman::ncurses")
+    elseif is_plat("linux") then
+        add_extsources("apt::libncurses-dev", "pacman::ncurses")
+    elseif is_plat("macosx") then
+        add_extsources("brew::ncurses")
     end
     on_load(function (package)
         if package:config("widec") then

--- a/packages/n/ncurses/xmake.lua
+++ b/packages/n/ncurses/xmake.lua
@@ -27,9 +27,15 @@ package("ncurses")
         end
     end)
 
-    on_install("linux", "macosx", "bsd", function (package)
-        local configs = {"--without-manpages", "--enable-sigwinch", "--with-gpm=no"}
-        table.insert(configs, "--with-debug=" .. (package:debug() and "yes" or "no"))
+    on_install(function (package)
+        local configs = {"--with-debug=" .. (package:debug() and "yes" or "no"),
+                         "--without-manpages",
+                         "--enable-sigwinch",
+                         "--with-gpm=no",
+                         "--without-ada",
+                         "--without-progs",
+                         "--without-tack",
+                         "--without-tests"}
         if package:config("widec") then
             table.insert(configs, "--enable-widec")
         end

--- a/scripts/test.lua
+++ b/scripts/test.lua
@@ -34,6 +34,7 @@ local options =
 ,   {nil, "target_minver",  "kv", nil, "The Target Minimal Version"                 }
 ,   {nil, "appledev",       "kv", nil, "The Apple Device Type"                      }
 ,   {nil, "mingw",          "kv", nil, "Set the MingW directory."                   }
+,   {nil, "cross",          "kv", nil, "Set cross toolchains prefix."               }
 ,   {nil, "toolchain",      "kv", nil, "Set the toolchain name."                    }
 ,   {nil, "packages",       "vs", nil, "The package list."                          }
 }
@@ -89,6 +90,9 @@ function _require_packages(argv, packages)
     end
     if argv.mingw then
         table.insert(config_argv, "--mingw=" .. argv.mingw)
+    end
+    if argv.cross then
+        table.insert(config_argv, "--cross=" .. argv.cross)
     end
     if argv.toolchain then
         table.insert(config_argv, "--toolchain=" .. argv.toolchain)


### PR DESCRIPTION
hi

i wanted to cross compile my project that uses this library for arm64 linux from an x86_64 linux host,

i used `xmake f -p cross --cross=aarch64-linux-gnu-` (i have the cross gcc and binutils installed on my host, sysroot is at `/usr/aarch64-linux-gnu` and gcc is prefixed by `aarch64-linux-gnu-` and its installed to `/usr/bin`),

but i had got a problem while configuring, a warning complains about ncurses is not supported for `cross/arm64`,
so i had a quick check of the source and found the supported platform list is hardcoded...

but luckily after removing it and tweaking some ac config options, it does seems to build and work with my original project.

also i thought adding these extsources might make it more friendly for some users?