### PR TITLE
Auto-update snmalloc to 0.6.2

### DIFF
--- a/packages/s/snmalloc/xmake.lua
+++ b/packages/s/snmalloc/xmake.lua
@@ -5,6 +5,7 @@ package("snmalloc")
 
     add_urls("https://github.com/microsoft/snmalloc/archive/refs/tags/$(version).tar.gz",
              "https://github.com/microsoft/snmalloc.git")
+    add_versions("0.6.2", "e0486ccf03eac5dd8acbb66ea8ad33bec289572a51614acdf7117397e4f1af8c")
     add_versions("0.6.0", "de1bfb86407d5aac9fdad88319efdd5593ca2f6c61fc13371c4f34aee0b6664f")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of snmalloc detected (package version: 0.6.0, last github version: 0.6.2)