### PR TITLE
Auto-update nghttp2 to 1.58.0

### DIFF
--- a/packages/n/nghttp2/xmake.lua
+++ b/packages/n/nghttp2/xmake.lua
@@ -5,6 +5,7 @@ package("nghttp2")
     set_license("MIT")
 
     add_urls("https://github.com/nghttp2/nghttp2/releases/download/v$(version)/nghttp2-$(version).tar.gz")
+    add_versions("1.58.0", "9ebdfbfbca164ef72bdf5fd2a94a4e6dfb54ec39d2ef249aeb750a91ae361dfb")
     add_versions("1.46.0", "4b6d11c85f2638531d1327fe1ed28c1e386144e8841176c04153ed32a4878208")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of nghttp2 detected (package version: 1.46.0, last github version: 1.58.0)