### PR TITLE
Auto-update onednn to v3.3.4

### DIFF
--- a/packages/o/onednn/xmake.lua
+++ b/packages/o/onednn/xmake.lua
@@ -14,7 +14,7 @@ package("onednn")
     add_configs("gpu_runtime", {description = "Defines the offload runtime for GPU engines.", default = "none", type = "string", values = {"none", "ocl", "dpcpp"}})
 
     add_deps("cmake")
-    on_load("windows|x64", "macosx", "linux|x86_64", function (package)
+    on_load("windows|x64", "macosx|x86_64", "linux|x86_64", function (package)
         local cpu_runtime = package:config("cpu_runtime")
         if cpu_runtime == "omp" then
             package:add("deps", "openmp")

--- a/packages/o/onednn/xmake.lua
+++ b/packages/o/onednn/xmake.lua
@@ -6,6 +6,7 @@ package("onednn")
 
     add_urls("https://github.com/oneapi-src/oneDNN/archive/refs/tags/$(version).tar.gz",
              "https://github.com/oneapi-src/oneDNN.git")
+    add_versions("v3.3.4", "e291fa4702f4bcfa6c8c23cb5b6599f0fefa8f23bc08edb9e15ddc5254ab7843")
     add_versions("v2.5.4", "a463ab05129e3e307333ff49d637568fa6ae1fb81742f40918b618e8ef714987")
 
     add_configs("shared",      {description = "Build shared library.", default = true, type = "boolean"})

--- a/packages/o/onednn/xmake.lua
+++ b/packages/o/onednn/xmake.lua
@@ -27,7 +27,7 @@ package("onednn")
         end
     end)
 
-    on_install("windows|x64", "macosx", "linux|x86_64", function (package)
+    on_install("windows|x64", "macosx|x86_64", "linux|x86_64", function (package)
         local configs = {"-DDNNL_BUILD_TESTS=OFF", "-DDNNL_BUILD_EXAMPLES=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DDNNL_LIBRARY_TYPE=" .. (package:config("shared") and "SHARED" or "STATIC"))


### PR DESCRIPTION
New version of onednn detected (package version: v2.5.4, last github version: v3.3.4)