### PR TITLE
add corrade resource compile rule

### DIFF
--- a/packages/c/corrade/patches/2020.06/msvc.patch
+++ b/packages/c/corrade/patches/2020.06/msvc.patch
@@ -1,4 +1,51 @@
+diff --git a/src/Corrade/Containers/GrowableArray.h b/src/Corrade/Containers/GrowableArray.h
+index f866bea..4bb8b12 100644
+--- a/src/Corrade/Containers/GrowableArray.h
++++ b/src/Corrade/Containers/GrowableArray.h
+@@ -1166,13 +1166,13 @@ template<class T, class Allocator> void arrayResize(Array<T>& array, NoInitT, co
+ template<class T, class Allocator> void arrayResize(Array<T>& array, DefaultInitT, const std::size_t size) {
+     const std::size_t prevSize = array.size();
+     arrayResize<T, Allocator>(array, NoInit, size);
+-    Implementation::arrayConstruct(DefaultInit, array + prevSize, array.end());
++    Implementation::arrayConstruct(DefaultInit, array.data() + prevSize, array.end());
+ }
+ 
+ template<class T, class Allocator> void arrayResize(Array<T>& array, ValueInitT, const std::size_t size) {
+     const std::size_t prevSize = array.size();
+     arrayResize<T, Allocator>(array, NoInit, size);
+-    Implementation::arrayConstruct(ValueInit, array + prevSize, array.end());
++    Implementation::arrayConstruct(ValueInit, array.data() + prevSize, array.end());
+ }
+ 
+ template<class T, class Allocator, class... Args> void arrayResize(Array<T>& array, DirectInitT, const std::size_t size, Args&&... args) {
+diff --git a/src/Corrade/Utility/Format.cpp b/src/Corrade/Utility/Format.cpp
+index 1d4c23c..7fe825f 100644
+--- a/src/Corrade/Utility/Format.cpp
++++ b/src/Corrade/Utility/Format.cpp
+@@ -383,7 +383,7 @@ std::size_t formatInto(const Containers::ArrayView<char>& buffer, const char* co
+             CORRADE_ASSERT(data.size() <= buffer.size(),
+                 "Utility::formatInto(): buffer too small, expected at least" << bufferOffset + data.size() << "but got" << bufferOffset + buffer.size(), );
+             /* strncpy() would stop on \0 characters */
+-            std::memcpy(buffer + bufferOffset, data, data.size());
++            std::memcpy(buffer.data() + bufferOffset, data, data.size());
+         }
+         bufferOffset += data.size();
+     }, [&buffer, &bufferOffset](BufferFormatter& formatter, int precision, FormatType type) {
+diff --git a/src/Corrade/Utility/String.cpp b/src/Corrade/Utility/String.cpp
+index 1b05870..0cdd472 100644
+--- a/src/Corrade/Utility/String.cpp
++++ b/src/Corrade/Utility/String.cpp
+@@ -129,7 +129,7 @@ bool beginsWith(Containers::ArrayView<const char> string, const Containers::Arra
+ bool endsWith(Containers::ArrayView<const char> string, const Containers::ArrayView<const char> suffix) {
+     if(string.size() < suffix.size()) return false;
+ 
+-    return std::strncmp(string + string.size() - suffix.size(), suffix, suffix.size()) == 0;
++    return std::strncmp(string.data() + string.size() - suffix.size(), suffix, suffix.size()) == 0;
+ }
+ 
+ std::string stripPrefix(std::string string, const Containers::ArrayView<const char> prefix) {
 diff --git a/src/Corrade/Utility/TweakableParser.cpp b/src/Corrade/Utility/TweakableParser.cpp
+index 4991991..993d107 100644
 --- a/src/Corrade/Utility/TweakableParser.cpp
 +++ b/src/Corrade/Utility/TweakableParser.cpp
 @@ -37,12 +37,12 @@ namespace Corrade { namespace Utility {

--- a/packages/c/corrade/patches/2020.06/msvc.patch
+++ b/packages/c/corrade/patches/2020.06/msvc.patch
@@ -1,0 +1,20 @@
+diff --git a/src/Corrade/Utility/TweakableParser.cpp b/src/Corrade/Utility/TweakableParser.cpp
+--- a/src/Corrade/Utility/TweakableParser.cpp
++++ b/src/Corrade/Utility/TweakableParser.cpp
+@@ -37,12 +37,12 @@ namespace Corrade { namespace Utility {
+ namespace {
+     std::pair<const char*, int> integerBase(Containers::ArrayView<const char> value) {
+         if(String::viewBeginsWith(value, "0x") || String::viewBeginsWith(value, "0X"))
+-            return {value + 2, 16};
++            return {value.data() + 2, 16};
+         if(String::viewBeginsWith(value, "0b") || String::viewBeginsWith(value, "0B"))
+-            return {value + 2, 2};
++            return {value.data() + 2, 2};
+         if(String::viewBeginsWith(value, "0"))
+-            return {value + 1, 8};
+-        return {value, 10};
++            return {value.data() + 1, 8};
++        return {value.data(), 10};
+     }
+ }
+ 

--- a/packages/c/corrade/rules/resource.lua
+++ b/packages/c/corrade/rules/resource.lua
@@ -6,6 +6,7 @@
 -- add_files("resources.conf", {rule = "@corrade/resource", single = false})
 
 rule("resource")
+    set_extensions(".conf")
     on_buildcmd_file(function (target, batchcmds, sourcefile, opt)
         import("core.base.option")
         import("lib.detect.find_program")
@@ -13,7 +14,7 @@ rule("resource")
         batchcmds:show_progress(opt.progress, "${color.build.object}compiling.corrade %s", sourcefile)
 
         -- get corrade-rc program
-        local corrade = find_program("corrade-rc", {paths = {path.join(target:pkg("corrade"):installdir(), "bin"), "$(env PATH)"}, check = "-h"})
+        local corrade = find_program("corrade-rc", {check = "-h"})
         assert(corrade, "corrade-rc not found! please check your corrade installation.")
 
         -- generate source file

--- a/packages/c/corrade/rules/resource.lua
+++ b/packages/c/corrade/rules/resource.lua
@@ -1,0 +1,53 @@
+-- Compile corrade resource files. Substitution for cmake corrade_add_resource.
+--
+-- Usage:
+--
+-- add_rules("@corrade/resource")
+-- add_files("resources.conf", {rule = "@corrade/resource", single = false})
+
+rule("resource")
+    on_buildcmd_file(function (target, batchcmds, sourcefile, opt)
+        import("core.base.option")
+        import("lib.detect.find_program")
+
+        batchcmds:show_progress(opt.progress, "${color.build.object}compiling.corrade %s", sourcefile)
+
+        -- get corrade-rc program
+        local corrade = find_program("corrade-rc", {paths = {path.join(target:pkg("corrade"):installdir(), "bin"), "$(env PATH)"}, check = "-h"})
+        assert(corrade, "corrade-rc not found! please check your corrade installation.")
+
+        -- generate source file
+        local basename = path.basename(sourcefile)
+        local sourcefile_cx = path.join(target:autogendir(), "rules", "autogen", basename .. ".cpp")
+        local objectfile = target:objectfile(sourcefile_cx)
+        table.insert(target:objectfiles(), objectfile)
+
+        -- compile
+        batchcmds:mkdir(path.directory(sourcefile_cx))
+        local args = {}
+        local fileconf = target:fileconfig(sourcefile)
+        if fileconf and fileconf.single then
+            table.insert(args, "--single")
+        end
+        if fileconf and fileconf.name then
+            table.insert(args, fileconf.name)
+        else
+            table.insert(args, basename)
+        end
+        local workdir = path.directory(sourcefile)
+        table.insert(args, path.filename(sourcefile))
+        table.insert(args, path.relative(sourcefile_cx, workdir))
+        if option.get("verbose") then
+            batchcmds:show(corrade .. " " ..  os.args(args))
+        end
+        local currentdir = os.curdir()
+        batchcmds:cd(workdir)
+        batchcmds:vrunv(corrade, args)
+        batchcmds:cd(currentdir)
+        batchcmds:compile(sourcefile_cx, objectfile)
+
+        -- add dependency
+        batchcmds:add_depfiles(sourcefile)
+        batchcmds:set_depmtime(os.mtime(objectfile))
+        batchcmds:set_depcache(target:dependfile(objectfile))
+    end)

--- a/packages/c/corrade/xmake.lua
+++ b/packages/c/corrade/xmake.lua
@@ -27,9 +27,10 @@ package("corrade")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DCORRADE_BUILD_STATIC=" .. (package:config("shared") and "OFF" or "ON"))
         table.insert(configs, "-DBUILD_STATIC=" .. (package:config("shared") and "OFF" or "ON"))
-        table.insert(configs, "-DWITH_RC=" .. (package:is_cross() and "OFF" or "ON"))
         import("package.tools.cmake").install(package, configs)
-        if not package:is_cross() then
+        if package:is_cross() then
+            os.rm(path.join(package:installdir("bin"), "*"))
+        else
             package:addenv("PATH", "bin")
         end
     end)

--- a/packages/c/corrade/xmake.lua
+++ b/packages/c/corrade/xmake.lua
@@ -8,6 +8,8 @@ package("corrade")
              "https://github.com/mosra/corrade.git")
     add_versions("v2020.06", "d89a06128c334920d91fecf23cc1df48fd6be26543dc0ed81b2f819a92d70e72")
 
+    add_patches("2020.06", "patches/2020.06/msvc.patch", "2606eded31cb52456c9a9d73e32468605150f1ffc7ae57bf2d04a250328fe710")
+
     if is_plat("windows") then
         add_syslinks("shell32")
     elseif is_plat("linux") then

--- a/packages/c/corrade/xmake.lua
+++ b/packages/c/corrade/xmake.lua
@@ -8,7 +8,7 @@ package("corrade")
              "https://github.com/mosra/corrade.git")
     add_versions("v2020.06", "d89a06128c334920d91fecf23cc1df48fd6be26543dc0ed81b2f819a92d70e72")
 
-    add_patches("2020.06", "patches/2020.06/msvc.patch", "2606eded31cb52456c9a9d73e32468605150f1ffc7ae57bf2d04a250328fe710")
+    add_patches("2020.06", "patches/2020.06/msvc.patch", "af90c9bad846a2cbe834fe270860446f6329636f9b9b7ad23454cf479c1dc05f")
 
     if is_plat("windows") then
         add_syslinks("shell32")

--- a/packages/i/imgui/port/xmake.lua
+++ b/packages/i/imgui/port/xmake.lua
@@ -1,4 +1,5 @@
 add_rules("mode.debug", "mode.release")
+add_rules("utils.install.cmake_importfiles")
 set_languages("cxx11")
 
 option("dx9",              {showmenu = true,  default = false})

--- a/packages/i/imgui/xmake.lua
+++ b/packages/i/imgui/xmake.lua
@@ -3,7 +3,7 @@ package("imgui")
     set_description("Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies")
     set_license("MIT")
 
-    add_urls("https://github.com/ocornut/imgui/archive/$(version).tar.gz",
+    add_urls("https://github.com/ocornut/imgui/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ocornut/imgui.git")
     add_versions("v1.90-docking", "v1.90-docking")
     add_versions("v1.90", "170986e6a4b83d165bfc1d33c2c5a5bc2d67e5b97176287485c51a2299249296")
@@ -38,6 +38,9 @@ package("imgui")
     add_versions("v1.81", "f7c619e03a06c0f25e8f47262dbc32d61fd033d2c91796812bf0f8c94fca78fb")
     add_versions("v1.80", "d7e4e1c7233409018437a646680316040e6977b9a635c02da93d172baad94ce9")
     add_versions("v1.79", "f1908501f6dc6db8a4d572c29259847f6f882684b10488d3a8d2da31744cd0a4")
+    add_versions("v1.78", "f70bbb17581ee2bd42fda526d9c3dc1a5165f3847ff047483d4d7980e166f9a3")
+    add_versions("v1.77", "c0dae830025d4a1a169df97409709f40d9dfa19f8fc96b550052224cbb238fa8")
+    add_versions("v1.76", "e482dda81330d38c87bd81597cacaa89f05e20ed2c4c4a93a64322e97565f6dc")
     add_versions("v1.75", "1023227fae4cf9c8032f56afcaea8902e9bfaad6d9094d6e48fb8f3903c7b866")
 
     add_configs("dx9",              {description = "Enable the dx9 backend", default = false, type = "boolean"})

--- a/packages/m/magnum-integration/xmake.lua
+++ b/packages/m/magnum-integration/xmake.lua
@@ -26,7 +26,7 @@ package("magnum-integration")
         end
     end)
 
-    on_install("windows", "linux", "macosx", function (package)
+    on_install("windows", "linux", "macosx|x86_64", function (package)
         local configs = {"-DBUILD_TESTS=OFF", "-DLIB_SUFFIX="}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_STATIC=" .. (package:config("shared") and "OFF" or "ON"))

--- a/packages/m/magnum-integration/xmake.lua
+++ b/packages/m/magnum-integration/xmake.lua
@@ -16,7 +16,7 @@ package("magnum-integration")
     add_deps("cmake", "magnum")
     on_load("windows", "linux", "macosx", function (package)
         local configdeps = {bullet = "bullet3",
-                            eigen = "eigen3",
+                            eigen = "eigen",
                             glm = "glm",
                             imgui = "imgui"}
         for config, dep in pairs(configdeps) do

--- a/packages/m/magnum/patches/2020.06/msvc.patch
+++ b/packages/m/magnum/patches/2020.06/msvc.patch
@@ -1,0 +1,26 @@
+diff --git a/src/Magnum/GL/Buffer.cpp b/src/Magnum/GL/Buffer.cpp
+index 5fa02c2..038e001 100644
+--- a/src/Magnum/GL/Buffer.cpp
++++ b/src/Magnum/GL/Buffer.cpp
+@@ -419,7 +419,7 @@ void Buffer::bindImplementationMulti(const Target target, const GLuint firstInde
+         }
+     }
+ 
+-    glBindBuffersRange(GLenum(target), firstIndex, buffers.size(), ids, offsetsSizes, offsetsSizes + buffers.size());
++    glBindBuffersRange(GLenum(target), firstIndex, buffers.size(), ids, offsetsSizes, offsetsSizes.data() + buffers.size());
+ }
+ #endif
+ 
+diff --git a/src/Magnum/Implementation/ImageProperties.h b/src/Magnum/Implementation/ImageProperties.h
+index d6326cf..6eedae0 100644
+--- a/src/Magnum/Implementation/ImageProperties.h
++++ b/src/Magnum/Implementation/ImageProperties.h
+@@ -70,7 +70,7 @@ template<UnsignedInt dimensions, class T, class Image, class Data> Containers::S
+ 
+     static_assert(sizeof(decltype(image.data().front())) == 1,
+         "pointer arithmetic expects image data type to have 1 byte");
+-    return {data.suffix(properties.first[dimensions - 1]), data + properties.first.sum(), size, stride};
++    return {data.suffix(properties.first[dimensions - 1]), data.data() + properties.first.sum(), size, stride};
+ }
+ 
+ }}

--- a/packages/m/magnum/patches/2020.06/msvc.patch
+++ b/packages/m/magnum/patches/2020.06/msvc.patch
@@ -24,3 +24,47 @@ index d6326cf..6eedae0 100644
  }
  
  }}
+diff --git a/src/Magnum/MeshTools/Concatenate.cpp b/src/Magnum/MeshTools/Concatenate.cpp
+index 38a7bc1..c20eeb9 100644
+--- a/src/Magnum/MeshTools/Concatenate.cpp
++++ b/src/Magnum/MeshTools/Concatenate.cpp
+@@ -73,7 +73,7 @@ Trade::MeshData concatenate(Containers::Array<char>&& indexData, const UnsignedI
+         attribute = Trade::MeshAttributeData{
+             attribute.name(), attribute.format(),
+             Containers::StridedArrayView1D<void>{vertexData,
+-                vertexData + attribute.offset(vertexData),
++                vertexData.data() + attribute.offset(vertexData),
+                 vertexCount, attribute.stride()},
+             attribute.arraySize()};
+     }
+@@ -130,7 +130,7 @@ Trade::MeshData concatenate(Containers::Array<char>&& indexData, const UnsignedI
+         /* Otherwise, if we need an index buffer (meaning at least one of the
+            meshes is indexed), generate a trivial index buffer */
+         } else if(!indices.empty()) {
+-            std::iota(indices + indexOffset, indices + indexOffset + mesh.vertexCount(), UnsignedInt(vertexOffset));
++            std::iota(indices.data() + indexOffset, indices.data() + indexOffset + mesh.vertexCount(), UnsignedInt(vertexOffset));
+             indexOffset += mesh.vertexCount();
+         }
+ 
+diff --git a/src/Magnum/MeshTools/Interleave.cpp b/src/Magnum/MeshTools/Interleave.cpp
+index b98c589..c16fd74 100644
+--- a/src/Magnum/MeshTools/Interleave.cpp
++++ b/src/Magnum/MeshTools/Interleave.cpp
+@@ -224,7 +224,7 @@ Trade::MeshData interleavedLayout(Trade::MeshData&& data, const UnsignedInt vert
+         attribute = Trade::MeshAttributeData{
+             attribute.name(), attribute.format(),
+             Containers::StridedArrayView1D<void>{vertexData,
+-                vertexData + attribute.offset(vertexData),
++                vertexData.data() + attribute.offset(vertexData),
+                 vertexCount, attribute.stride()},
+             attribute.arraySize()};
+     }
+@@ -261,7 +261,7 @@ Trade::MeshData interleave(Trade::MeshData&& data, const Containers::ArrayView<c
+             indexData = Containers::Array<char>{data.indexData().size()};
+             Utility::copy(data.indexData(), indexData);
+             indices = Trade::MeshIndexData{data.indexType(),
+-                Containers::ArrayView<const void>{indexData + data.indexOffset(), data.indices().size()[0]*data.indices().size()[1]}};
++                Containers::ArrayView<const void>{indexData.data() + data.indexOffset(), data.indices().size()[0]*data.indices().size()[1]}};
+         }
+     }
+ 

--- a/packages/m/magnum/xmake.lua
+++ b/packages/m/magnum/xmake.lua
@@ -54,7 +54,7 @@ package("magnum")
             package:add("deps", "glfw")
         end
         if package:config("sdl2") then
-            package:add("deps", "libsdl")
+            package:add("deps", "libsdl", {configs = {sdlmain = false}})
         end
         if package:config("glx") then
             package:add("deps", "libx11")
@@ -62,6 +62,8 @@ package("magnum")
     end)
 
     on_install("windows", "linux", "macosx", function (package)
+        io.replace("modules/FindSDL2.cmake", "SDL2-2.0 SDL2", "SDL2-2.0 SDL2 SDL2-static", {plain = true})
+        io.replace("modules/FindSDL2.cmake", "${_SDL2_LIBRARY_PATH_SUFFIX}", "lib ${_SDL2_LIBRARY_PATH_SUFFIX}", {plain = true})
         local configs = {"-DBUILD_TESTS=OFF", "-DLIB_SUFFIX="}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_STATIC=" .. (package:config("shared") and "OFF" or "ON"))

--- a/packages/m/magnum/xmake.lua
+++ b/packages/m/magnum/xmake.lua
@@ -39,10 +39,6 @@ package("magnum")
     end
 
     add_deps("cmake", "corrade", "opengl")
-    add_links("MagnumAnyAudioImporter", "MagnumAnyImageConverter", "MagnumAnyImageImporter", "MagnumAnySceneConverter", "MagnumAnySceneImporter", "MagnumMagnumFont", "MagnumMagnumFontConverter", "MagnumObjImporter", "MagnumTgaImageConverter", "MagnumTgaImporter", "MagnumWavAudioImporter")
-    add_links("MagnumCglContext", "MagnumEglContext", "MagnumGlxContext", "MagnumWglContext", "MagnumOpenGLTester", "MagnumVulkanTester")
-    add_links("MagnumAndroidApplication", "MagnumEmscriptenApplication", "MagnumGlfwApplication", "MagnumGlxApplication", "MagnumSdl2Application", "MagnumXEglApplication", "MagnumWindowlessCglApplication", "MagnumWindowlessEglApplication", "MagnumWindowlessGlxApplication", "MagnumWindowlessIosApplication", "MagnumWindowlessWglApplication", "MagnumWindowlessWindowsEglApplication")
-    add_links("MagnumAudio", "MagnumDebugTools", "MagnumGL", "MagnumMeshTools", "MagnumPrimitives", "MagnumSceneGraph", "MagnumShaders", "MagnumText", "MagnumTextureTools", "MagnumTrade", "MagnumVk", "Magnum")
     on_load("windows", "linux", "macosx", function (package)
         if package:config("audio") then
             package:add("deps", "openal-soft", {configs = {shared = true}})
@@ -58,6 +54,14 @@ package("magnum")
         end
         if package:config("glx") then
             package:add("deps", "libx11")
+        end
+        local links = {"MagnumAnyAudioImporter", "MagnumAnyImageConverter", "MagnumAnyImageImporter", "MagnumAnySceneConverter", "MagnumAnySceneImporter", "MagnumMagnumFont", "MagnumMagnumFontConverter", "MagnumObjImporter", "MagnumTgaImageConverter", "MagnumTgaImporter", "MagnumWavAudioImporter"}
+        table.join2(links, {"MagnumCglContext", "MagnumEglContext", "MagnumGlxContext", "MagnumWglContext", "MagnumOpenGLTester", "MagnumVulkanTester"})
+        table.join2(links, {"MagnumAndroidApplication", "MagnumEmscriptenApplication", "MagnumGlfwApplication", "MagnumGlxApplication", "MagnumSdl2Application", "MagnumXEglApplication", "MagnumWindowlessCglApplication", "MagnumWindowlessEglApplication", "MagnumWindowlessGlxApplication", "MagnumWindowlessIosApplication", "MagnumWindowlessWglApplication", "MagnumWindowlessWindowsEglApplication"})
+        table.join2(links, {"MagnumAudio", "MagnumDebugTools", "MagnumGL", "MagnumMeshTools", "MagnumPrimitives", "MagnumSceneGraph", "MagnumShaders", "MagnumText", "MagnumTextureTools", "MagnumTrade", "MagnumVk", "Magnum"})
+        local postfix = package:debug() and "-d" or ""
+        for _, link in ipairs(links) do
+            package:add("links", link .. postfix)
         end
     end)
 

--- a/packages/m/magnum/xmake.lua
+++ b/packages/m/magnum/xmake.lua
@@ -8,6 +8,8 @@ package("magnum")
              "https://github.com/mosra/magnum.git")
     add_versions("v2020.06", "78c52bc403cec27b98d8d87186622ca57f8d70ffd64342fe4094c720b7d3b0e3")
 
+    add_patches("2020.06", "patches/2020.06/msvc.patch", "bee86e2eb637c44b6c5b2dbcbb273138dbc26e8df11af31716f4f0c884bf8cdc")
+
     add_configs("audio",         {description = "Build audio module.", default = false, type = "boolean"})
     add_configs("vulkan",        {description = "Build vulkan module.", default = false, type = "boolean"})
     add_configs("deprecated",    {description = "Include deprecated APIs in the build.", default = true, type = "boolean"})

--- a/packages/m/magnum/xmake.lua
+++ b/packages/m/magnum/xmake.lua
@@ -8,7 +8,7 @@ package("magnum")
              "https://github.com/mosra/magnum.git")
     add_versions("v2020.06", "78c52bc403cec27b98d8d87186622ca57f8d70ffd64342fe4094c720b7d3b0e3")
 
-    add_patches("2020.06", "patches/2020.06/msvc.patch", "bee86e2eb637c44b6c5b2dbcbb273138dbc26e8df11af31716f4f0c884bf8cdc")
+    add_patches("2020.06", "patches/2020.06/msvc.patch", "0739a29807c6aeb4681eaadb4c624c39f5d1ba746de3df7ab83801f41d1ad5bd")
 
     add_configs("audio",         {description = "Build audio module.", default = false, type = "boolean"})
     add_configs("vulkan",        {description = "Build vulkan module.", default = false, type = "boolean"})

--- a/packages/m/meshoptimizer/xmake.lua
+++ b/packages/m/meshoptimizer/xmake.lua
@@ -7,6 +7,7 @@ package("meshoptimizer")
     add_urls("https://github.com/zeux/meshoptimizer/archive/refs/tags/$(version).tar.gz",
              "https://github.com/zeux/meshoptimizer.git")
     add_versions("v0.18", "f5bc07d7322e6292fe0afce03462b5c394d111386236f926fdc44d2aff3b854b")
+    add_versions("v0.20", "cf1077a83958bed3d8da28a841ca53a6a42d871e49023edce64e37002a0f5a48")
 
     add_deps("cmake")
     on_load("windows", function (package)


### PR DESCRIPTION
这里加了 corrade resource compilation 的 rule

问题：
1. corrade-rc 是 corrade 这个包带的代码生成器，用 path.join(target:pkg("corrade"):installdir(), "bin") 找路径是否合理？有没有更好的方案？
2. xmake 源码里的 rule 有的是 target:autogendir() ，有的是 target:autogenfile() ，这两个有什么区别？用哪一个更好？
3. 从 xmake-repo 为文件指定 rule 也是用 rule = "@corrade/resource" 这样的写法吗？能识别吗？
4. batchcmds:set_depcache 应该给什么参数？源码中有的是 set_depcache(objectfile) ，有的是 set_depcache(sourcefile_cx) ，这两个在什么情况下有区别呢？