### PR TITLE
Auto-update blake3 to 1.5.0

### DIFF
--- a/packages/b/blake3/xmake.lua
+++ b/packages/b/blake3/xmake.lua
@@ -9,7 +9,7 @@ package("blake3")
     add_versions("1.3.3", "27d2bc4ee5945ba75434859521042c949463ee7514ff17aaef328e23ef83fec0")
     add_versions("1.3.1", "112becf0983b5c83efff07f20b458f2dbcdbd768fd46502e7ddd831b83550109")
 
-    on_install("windows", "linux", "macosx", "bsd", "mingw|x86_64", "android", "iphoneos", "cross", function (package)
+    on_install("windows|x64", "windows|x86", "linux", "macosx", "bsd", "mingw|x86_64", "android", "iphoneos", "cross", function (package)
         local configs = {}
 
         io.writefile("xmake.lua", [[

--- a/packages/b/blake3/xmake.lua
+++ b/packages/b/blake3/xmake.lua
@@ -5,6 +5,7 @@ package("blake3")
 
     add_urls("https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/$(version).tar.gz",
              "https://github.com/BLAKE3-team/BLAKE3.git")
+    add_versions("1.5.0", "f506140bc3af41d3432a4ce18b3b83b08eaa240e94ef161eb72b2e57cdc94c69")
     add_versions("1.3.3", "27d2bc4ee5945ba75434859521042c949463ee7514ff17aaef328e23ef83fec0")
     add_versions("1.3.1", "112becf0983b5c83efff07f20b458f2dbcdbd768fd46502e7ddd831b83550109")
 


### PR DESCRIPTION
New version of blake3 detected (package version: 1.3.3, last github version: 1.5.0)