### PR TITLE
Auto-update kokkos to 4.2.00

### DIFF
--- a/packages/k/kokkos/xmake.lua
+++ b/packages/k/kokkos/xmake.lua
@@ -6,6 +6,7 @@ package("kokkos")
 
     add_urls("https://github.com/kokkos/kokkos/archive/refs/tags/$(version).tar.gz",
              "https://github.com/kokkos/kokkos.git")
+    add_versions("4.2.00", "ac08765848a0a6ac584a0a46cd12803f66dd2a2c2db99bb17c06ffc589bf5be8")
     add_versions("4.0.01", "bb942de8afdd519fd6d5d3974706bfc22b6585a62dd565c12e53bdb82cd154f0")
 
     if is_plat("windows") then

--- a/packages/k/kokkos/xmake.lua
+++ b/packages/k/kokkos/xmake.lua
@@ -24,7 +24,7 @@ package("kokkos")
         end
     end)
 
-    on_install("windows|x64", "macosx", "linux", function (package)
+    on_install("windows|x64", "macosx|x86_64", "linux", function (package)
         local configs = {"-DKokkos_ENABLE_SERIAL=ON"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))


### PR DESCRIPTION
New version of kokkos detected (package version: 4.0.01, last github version: 4.2.00)