### PR TITLE
Auto-update littlefs to v2.8.2

### DIFF
--- a/packages/l/littlefs/xmake.lua
+++ b/packages/l/littlefs/xmake.lua
@@ -4,6 +4,7 @@ package("littlefs")
 
     add_urls("https://github.com/littlefs-project/littlefs/archive/refs/tags/$(version).tar.gz",
              "https://github.com/littlefs-project/littlefs.git")
+    add_versions("v2.8.2", "9f46d00d6d6ad0a0d72840455ba748efcad84b8a236bd8b9d3a08e3af7953386")
     add_versions("v2.5.0", "07de0d788c2a849a137715b48cce9daeb3fdc7570873ac6faae4566432e140c8")
 
     on_install(function (package)


### PR DESCRIPTION
New version of littlefs detected (package version: v2.5.0, last github version: v2.8.2)