### PR TITLE
Auto-update yy-thunks to 1.0.9

### DIFF
--- a/packages/y/yy-thunks/xmake.lua
+++ b/packages/y/yy-thunks/xmake.lua
@@ -4,6 +4,7 @@ package("yy-thunks")
     set_license("MIT")
 
     add_urls("https://github.com/Chuyu-Team/YY-Thunks/releases/download/v$(version)/YY-Thunks-$(version)-Binary.zip")
+    add_versions("1.0.9", "216b88757f28075d3d8c0363139e870d49ba84458fc10a0f094f264ebf0a302c")
     add_versions("1.0.7", "3607a79ac37f141cbcbf00aaea8d82a4c2628d81d8dad9e2a4dce4c8c17a025b")
 
     on_install("windows|x64", "windows|x86", function (package)


### PR DESCRIPTION
New version of yy-thunks detected (package version: 1.0.7, last github version: 1.0.9)