### PR TITLE
Auto-update simpleini to v4.22

### DIFF
--- a/packages/s/simpleini/xmake.lua
+++ b/packages/s/simpleini/xmake.lua
@@ -6,6 +6,7 @@ package("simpleini")
 
     set_urls("https://github.com/brofield/simpleini/archive/refs/tags/$(version).tar.gz",
              "https://github.com/brofield/simpleini.git")
+    add_versions("v4.22", "b3a4b8f9e03aabd491aa55fd57457115857b9b9c7ecf4abf7ff035ca9d026eb8")
     add_versions("v4.19", "dc10df3fa363be2c57627d52cbb1b5ddd0689d474bf13908e822c1522df8377e")
 
     add_configs("convert", {description = "Unicode converter to use.", type = "string", values = {"none", "generic", "icu", "win32"}})


### PR DESCRIPTION
New version of simpleini detected (package version: v4.19, last github version: v4.22)