### PR TITLE
Auto-update nowide_standalone to 11.3.0

### DIFF
--- a/packages/n/nowide_standalone/xmake.lua
+++ b/packages/n/nowide_standalone/xmake.lua
@@ -5,6 +5,7 @@ package("nowide_standalone")
 
     add_urls("https://github.com/boostorg/nowide/releases/download/v$(version)/nowide_standalone_v$(version).tar.gz",
              "https://github.com/boostorg/nowide/tree/standalone")
+    add_versions("11.3.0", "153ac93173c8de9c08e7701e471fa750f84c27e51fe329570c5aa06016591f8c")
     add_versions("11.2.0", "1869d176a8af389e4f7416f42bdd15d6a5db3c6e4ae77269ecb071a232304e1d")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of nowide_standalone detected (package version: 11.2.0, last github version: 11.3.0)