### PR TITLE
Auto-update ogre-next to v2.3.3

### DIFF
--- a/packages/o/ogre-next/xmake.lua
+++ b/packages/o/ogre-next/xmake.lua
@@ -6,6 +6,7 @@ package("ogre-next")
 
     add_urls("https://github.com/OGRECave/ogre-next/archive/refs/tags/$(version).tar.gz",
              "https://github.com/OGRECave/ogre-next.git")
+    add_versions("v2.3.3", "92ce7765d892d6424df3d8d4a56a8fc0b2f4f91c216b1b1d5b231caa9abaaa38")
     add_versions("v2.2.5", "b3b555386aa7ebf164a41451ad896bb3774521410944568ecec58f780d0725c4")
 
     add_patches("v2.2.5", path.join(os.scriptdir(), "patches", "2.2.5", "macosx.patch"), "a20f32d8847dd4c93fe2b824d2b793862b8e3126ae7fda4450ad22e76bb00c32")


### PR DESCRIPTION
New version of ogre-next detected (package version: v2.2.5, last github version: v2.3.3)