### PR TITLE
Auto-update minizip-ng to 4.0.4

### DIFF
--- a/packages/m/minizip-ng/xmake.lua
+++ b/packages/m/minizip-ng/xmake.lua
@@ -6,6 +6,7 @@ package("minizip-ng")
 
     add_urls("https://github.com/zlib-ng/minizip-ng/archive/refs/tags/$(version).tar.gz",
              "https://github.com/zlib-ng/minizip-ng.git")
+    add_versions("4.0.4", "955800fe39f9d830fcb84e60746952f6a48e41093ec7a233c63ad611b5fcfe9f")
     add_versions("3.0.3", "5f1dd0d38adbe9785cb9c4e6e47738c109d73a0afa86e58c4025ce3e2cc504ed")
     add_versions("3.0.5", "1a248c378fdf4ef6c517024bb65577603d5146cffaebe81900bec9c0a5035d4d")
 

--- a/packages/m/minizip-ng/xmake.lua
+++ b/packages/m/minizip-ng/xmake.lua
@@ -23,7 +23,7 @@ package("minizip-ng")
     elseif is_plat("linux", "android") then
         add_deps("openssl")
     elseif is_plat("windows", "mingw") then
-        add_syslinks("crypt32", "advapi32")
+        add_syslinks("crypt32", "advapi32", "Bcrypt")
     end
 
     on_load(function (package)

--- a/packages/m/minizip-ng/xmake.lua
+++ b/packages/m/minizip-ng/xmake.lua
@@ -16,6 +16,7 @@ package("minizip-ng")
     add_configs("zstd",  {description = "Enable zstd comppressression library.", default = false, type = "boolean"})
 
     add_deps("cmake")
+
     if is_plat("macosx") then
         add_frameworks("CoreFoundation", "Security")
         add_syslinks("iconv")
@@ -48,5 +49,9 @@ package("minizip-ng")
     end)
 
     on_test(function (package)
-        assert(package:has_cfuncs("zipOpen", {includes = {"mz.h", "mz_compat.h"}}))
+        if package:version():ge("4.0") then
+            assert(package:has_cfuncs("zipOpen", {includes = {"minizip/mz.h", "minizip/mz_compat.h"}}))
+        else
+            assert(package:has_cfuncs("zipOpen", {includes = {"mz.h", "mz_compat.h"}}))
+        end
     end)

--- a/packages/m/minizip-ng/xmake.lua
+++ b/packages/m/minizip-ng/xmake.lua
@@ -30,7 +30,7 @@ package("minizip-ng")
         if package:version():ge("4.0") then
             if package:is_plat("macosx") then
                 package:add("deps", "openssl")
-            elseif package:is_plat("windows") then
+            elseif package:is_plat("windows", "mingw") then
                 package:add("syslinks", "Bcrypt")
             end
         end

--- a/packages/m/minizip-ng/xmake.lua
+++ b/packages/m/minizip-ng/xmake.lua
@@ -23,10 +23,17 @@ package("minizip-ng")
     elseif is_plat("linux", "android") then
         add_deps("openssl")
     elseif is_plat("windows", "mingw") then
-        add_syslinks("crypt32", "advapi32", "Bcrypt")
+        add_syslinks("crypt32", "advapi32")
     end
 
     on_load(function (package)
+        if package:version():ge("4.0") then
+            if package:is_plat("macosx") then
+                package:add("deps", "openssl")
+            elseif package:is_plat("windows") then
+                package:add("syslinks", "Bcrypt")
+            end
+        end
         for name, enabled in pairs(package:configs()) do
             if not package:extraconf("configs", name, "builtin") then
                 if enabled then


### PR DESCRIPTION
New version of minizip-ng detected (package version: 3.0.5, last github version: 4.0.4)