### PR TITLE
Add egl-headers and opengl-headers packages

### DIFF
--- a/packages/e/egl-headers/xmake.lua
+++ b/packages/e/egl-headers/xmake.lua
@@ -1,0 +1,22 @@
+package("egl-headers")
+    set_kind("library", {headeronly = true})
+    set_homepage("https://github.com/KhronosGroup/EGL-Registry")
+    set_description("EGL API and Extension Registry")
+    set_license("MIT")
+ 
+    add_urls("https://github.com/KhronosGroup/EGL-Registry.git")
+
+    add_versions("2023.12.16", "a03692eea13514d9aef01822b2bc6575fcabfac2")
+
+    on_install(function (package)
+        os.vcp("api/EGL", package:installdir("include"))
+        os.vcp("api/KHR", package:installdir("include"))
+    end)
+
+    on_test(function (package)
+        assert(package:check_csnippets({test = [[
+            void test() {
+                int version = EGL_VERSION;
+            }
+        ]]}, {includes = "EGL/egl.h"}))
+    end)

--- a/packages/o/opengl-headers/xmake.lua
+++ b/packages/o/opengl-headers/xmake.lua
@@ -1,0 +1,23 @@
+package("opengl-headers")
+    set_kind("library", {headeronly = true})
+    set_homepage("https://github.com/KhronosGroup/OpenGL-Registry/")
+    set_description("OpenGL, OpenGL ES, and OpenGL ES-SC API and Extension Registry")
+    set_license("MIT")
+                    
+    add_urls("https://github.com/KhronosGroup/OpenGL-Registry.git")
+
+    add_versions("2024.01.04", "ca491a0576d5c026f06ebe29bfac7cbbcf1e8332")
+
+    add_deps("egl-headers")
+
+    on_install(function (package)
+        os.vcp("api/*", package:installdir("include"))
+    end)
+
+    on_test(function (package)
+        assert(package:check_csnippets({test = [[
+            void test() {
+                int version = GL_VERSION;
+            }
+        ]]}, {includes = "GLES3/gl3.h"}))
+    end)


### PR DESCRIPTION
Note that I didn't try to match system packages because it seems complicated.

for example, Debian has libgl-dev which has:
- GL/gl.h
- GL/glcorearb.h
- GL/glext.h
- KHR/khrplatform.h

but GL/* and KHR headers are on two different repositories.

Maybe we could improve xmake extsources to be able to specify multiple required dependencies:
```lua
add_extsources({ "apt::libgl-dev", "apt::libegl-dev" })
```
meaning "both are required"