### PR TITLE
fix missing gspell dep on linux

### DIFF
--- a/packages/w/wxwidgets/xmake.lua
+++ b/packages/w/wxwidgets/xmake.lua
@@ -67,7 +67,7 @@ package("wxwidgets")
         add_deps("cmake")
         add_deps("libjpeg", "libpng", "nanosvg", "expat", "zlib")
         if is_plat("linux") then
-            add_deps("gtk+3", "opengl")
+            add_deps("gtk+3", "gspell", "opengl")
         end
     end
 


### PR DESCRIPTION
This fixes wxwidgets build here on Linux Manjaro (depends on gspell package: #3174
