### PR TITLE
Auto-update plog to 1.1.10

### DIFF
--- a/packages/p/plog/xmake.lua
+++ b/packages/p/plog/xmake.lua
@@ -6,6 +6,7 @@ package("plog")
 
     add_urls("https://github.com/SergiusTheBest/plog/archive/refs/tags/$(version).tar.gz",
              "https://github.com/SergiusTheBest/plog.git")
+    add_versions("1.1.10", "55a090fc2b46ab44d0dde562a91fe5fc15445a3caedfaedda89fe3925da4705a")
     add_versions("1.1.9", "058315b9ec9611b659337d4333519ab4783fad3f2f23b1cc7bb84d977ea38055")
 
     on_install(function (package)


### PR DESCRIPTION
New version of plog detected (package version: 1.1.9, last github version: 1.1.10)