### PR TITLE
Auto-update b2 to 5.0.0

### DIFF
--- a/packages/b/b2/xmake.lua
+++ b/packages/b/b2/xmake.lua
@@ -6,6 +6,7 @@ package("b2")
     set_license("BSL-1.0")
 
     add_urls("https://github.com/bfgroup/b2/releases/download/$(version)/b2-$(version).zip")
+    add_versions("5.0.0", "d5f280f466b80b694ccb9696413375522d16e6f811918daeb44a917d5bd6c7b5")
     add_versions("4.9.6", "a049f7fdfae4b62353a3f76f34a72c8c87324d1c026cf87febe6c563311bf687")
 
     on_install("@windows", function (package)


### PR DESCRIPTION
New version of b2 detected (package version: 4.9.6, last github version: 5.0.0)