### PR TITLE
Auto-update g3log to 2.4

### DIFF
--- a/packages/g/g3log/xmake.lua
+++ b/packages/g/g3log/xmake.lua
@@ -6,6 +6,7 @@ package("g3log")
     add_urls("https://github.com/KjellKod/g3log/archive/refs/tags/$(version).tar.gz",
              "https://github.com/KjellKod/g3log.git")
 
+    add_versions("2.4", "a240673f6dda17a8d4d5768b6741534e6863e6c4d786c3678e4fe687eb115902")
     add_versions("2.3", "a27dc3ff0d962cc6e0b4e60890b4904e664b0df16393d27e14c878d7de09b505")
 
     add_configs("ios", {description = "iOS version of library.", default = false, type = "boolean", readonly = true})


### PR DESCRIPTION
New version of g3log detected (package version: 2.3, last github version: 2.4)