### PR TITLE
Auto-update open3d to v0.18.0

### DIFF
--- a/packages/o/open3d/xmake.lua
+++ b/packages/o/open3d/xmake.lua
@@ -6,6 +6,7 @@ package("open3d")
 
     add_urls("https://github.com/isl-org/Open3D/archive/refs/tags/$(version).tar.gz",
              "https://github.com/isl-org/Open3D.git")
+    add_versions("v0.18.0", "524ddeb7dc8aaed6dc5b272415df0c8ffcf7eff0816a84cfbdee56cdd6d3587a")
     add_versions("v0.15.1", "4bcfbaa6fcbcc14fba46a4d719b9256fffac09b23f8344a7d561b26394159660")
     add_versions("v0.17.0", "a7526efaf54434c4d54276fa0ddc63a1555401c30fb10fec9efa3241326bdd27")
 


### PR DESCRIPTION
New version of open3d detected (package version: v0.17.0, last github version: v0.18.0)