### PR TITLE
Auto-update toml11 to v3.8.1

### DIFF
--- a/packages/t/toml11/xmake.lua
+++ b/packages/t/toml11/xmake.lua
@@ -6,6 +6,7 @@ package("toml11")
 
     add_urls("https://github.com/ToruNiina/toml11/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ToruNiina/toml11.git")
+    add_versions("v3.8.1", "6a3d20080ecca5ea42102c078d3415bef80920f6c4ea2258e87572876af77849")
     add_versions("v3.7.0", "a0b6bec77c0e418eea7d270a4437510884f2fe8f61e7ab121729624f04c4b58e")
 
     add_deps("cmake")

--- a/packages/t/toml11/xmake.lua
+++ b/packages/t/toml11/xmake.lua
@@ -6,13 +6,14 @@ package("toml11")
 
     add_urls("https://github.com/ToruNiina/toml11/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ToruNiina/toml11.git")
+
     add_versions("v3.8.1", "6a3d20080ecca5ea42102c078d3415bef80920f6c4ea2258e87572876af77849")
     add_versions("v3.7.0", "a0b6bec77c0e418eea7d270a4437510884f2fe8f61e7ab121729624f04c4b58e")
 
     add_deps("cmake")
 
     on_install(function (package)
-        local configs = {}
+        local configs = {"-DCMAKE_CXX_STANDARD=11"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)


### PR DESCRIPTION
New version of toml11 detected (package version: v3.7.0, last github version: v3.8.1)