### PR TITLE
Auto-update fast_float to v6.1.0

### DIFF
--- a/packages/f/fast_float/xmake.lua
+++ b/packages/f/fast_float/xmake.lua
@@ -12,6 +12,7 @@ package("fast_float")
     add_versions("v5.2.0", "72bbfd1914e414c920e39abdc81378adf910a622b62c45b4c61d344039425d18")
     add_versions("v5.3.0", "2f3bc50670455534dcaedc9dcd0517b71152f319d0cec8625f21c51d23eaf4b9")
     add_versions("v6.0.0", "7e98671ef4cc7ed7f44b3b13f80156c8d2d9244fac55deace28bd05b0a2c7c8e")
+    add_versions("v6.1.0", "a9c8ca8ca7d68c2dbb134434044f9c66cfd4c383d5e85c36b704d30f6be82506")
 
     if is_plat("wasm") then
         add_patches("v3.4.0", path.join(os.scriptdir(), "patches", "emscripten_fix.patch"), "482705431f67e6f0a375ed7bfe87d6856e7d13f071db6157e1d5659834b0eb50")


### PR DESCRIPTION
New version of fast_float detected (package version: v6.0.0, last github version: v6.1.0)