### PR TITLE
Auto-update libsais to v2.7.3

### DIFF
--- a/packages/l/libsais/xmake.lua
+++ b/packages/l/libsais/xmake.lua
@@ -5,6 +5,7 @@ package("libsais")
 
     add_urls("https://github.com/IlyaGrebnov/libsais/archive/refs/tags/$(version).tar.gz",
              "https://github.com/IlyaGrebnov/libsais.git")
+    add_versions("v2.7.3", "45d37dc12975c4d40db786f322cd6dcfd9f56a8f23741205fcd0fca6ec0bf246")
     add_versions("v2.7.1", "5f459ad90cd007c30aaefb7d122bba2a4307ea02915c56381be4b331cca92545")
 
     on_install(function (package)

--- a/packages/l/libsais/xmake.lua
+++ b/packages/l/libsais/xmake.lua
@@ -15,6 +15,8 @@ package("libsais")
             target("libsais")
                set_kind("$(kind)")
                add_files("src/*.c")
+               add_includedirs("include")
+               add_headerfiles("include/(*.h)")
                add_headerfiles("src/(*.h)")
         ]])
         if package:config("shared") then


### PR DESCRIPTION
New version of libsais detected (package version: v2.7.1, last github version: v2.7.3)