### PR TITLE
Auto-update gcem to v1.17.0

### DIFF
--- a/packages/g/gcem/xmake.lua
+++ b/packages/g/gcem/xmake.lua
@@ -7,6 +7,7 @@ package("gcem")
 
     add_urls("https://github.com/kthohr/gcem/archive/refs/tags/$(version).tar.gz",
              "https://github.com/kthohr/gcem.git")
+    add_versions("v1.17.0", "74cc499e2db247c32f1ce82fc22022d22e0f0a110ecd19281269289a9e78a6f8")
     add_versions("v1.13.1", "69a1973f146a4a5e584193af062359f50bd5b948c4175d58ea2622e1c066b99b")
     add_versions("v1.16.0", "119c742b9371c0adc7d9cd710c3cbc575459a98fb63f6be4c636215dcf8404ce")
 


### PR DESCRIPTION
New version of gcem detected (package version: v1.16.0, last github version: v1.17.0)