### PR TITLE
Changed libpq's version and fix compile failure of krb5

### DIFF
--- a/packages/i/icu4c/xmake.lua
+++ b/packages/i/icu4c/xmake.lua
@@ -76,8 +76,13 @@ package("icu4c")
             table.insert(configs, "--enable-debug")
             table.insert(configs, "--disable-release")
         end
-        table.insert(configs, "--enable-static")
-        table.insert(configs, "--enable-shared")
+        if package:config("shared") then
+            table.insert(configs, "--enable-shared")
+            table.insert(configs, "--disable-static")
+        else
+            table.insert(configs, "--disable-shared")
+            table.insert(configs, "--enable-static")
+        end
         if package:is_plat("mingw") then
             table.insert(configs, "--with-data-packaging=dll")
         end

--- a/packages/i/icu4c/xmake.lua
+++ b/packages/i/icu4c/xmake.lua
@@ -76,13 +76,8 @@ package("icu4c")
             table.insert(configs, "--enable-debug")
             table.insert(configs, "--disable-release")
         end
-        if package:config("shared") then
-            table.insert(configs, "--enable-shared")
-            table.insert(configs, "--disable-static")
-        else
-            table.insert(configs, "--disable-shared")
-            table.insert(configs, "--enable-static")
-        end
+        table.insert(configs, "--enable-static")
+        table.insert(configs, "--enable-shared")
         if package:is_plat("mingw") then
             table.insert(configs, "--with-data-packaging=dll")
         end

--- a/packages/k/krb5/xmake.lua
+++ b/packages/k/krb5/xmake.lua
@@ -20,7 +20,7 @@ package("krb5")
         end
     end)
 
-    on_install("macosx", "linux", function (package)
+    on_install("macosx|x86_64", "linux", function (package)
         os.cd("src")
         local configs = {"--disable-dependency-tracking", "--with-system-verto"}
         table.insert(configs, "--with-tls-impl=" .. (package:config("tls") and "openssl" or "no"))

--- a/packages/k/krb5/xmake.lua
+++ b/packages/k/krb5/xmake.lua
@@ -6,6 +6,7 @@ package("krb5")
     add_urls("https://kerberos.org/dist/krb5/$(version).tar.gz", {version = function (version)
         return format("%d.%d/krb5-%s", version:major(), version:minor(), version)
     end})
+    add_versions("1.21.2", "9560941a9d843c0243a71b17a7ac6fe31c7cebb5bce3983db79e52ae7e850491")
     add_versions("1.19.2", "10453fee4e3a8f8ce6129059e5c050b8a65dab1c257df68b99b3112eaa0cdf6a")
 
     add_configs("tls", {description = "Enable TLS/OpenSSL support.", default = false, type = "boolean"})

--- a/packages/k/krb5/xmake.lua
+++ b/packages/k/krb5/xmake.lua
@@ -13,7 +13,7 @@ package("krb5")
     add_configs("shared", {description = "Build shared library.", default = true, type = "boolean", readonly = true})
 
     add_deps("bison", "libverto")
-    add_links("k5crypto", "kdb5", "krad", "gssapi_krb5", "krb5support", "krb5", "gssrpc", "verto", "com_err")
+    add_links("libverto", "k5crypto", "kdb5", "krad", "gssapi_krb5", "krb5support", "krb5", "gssrpc", "verto", "com_err")
     on_load("macosx", "linux", function (package)
         if package:config("tls") then
             package:add("deps", "openssl")
@@ -22,7 +22,7 @@ package("krb5")
 
     on_install("macosx|x86_64", "linux", function (package)
         os.cd("src")
-        local configs = {"--disable-dependency-tracking", "--with-system-verto"}
+        local configs = {"--disable-dependency-tracking"}
         table.insert(configs, "--with-tls-impl=" .. (package:config("tls") and "openssl" or "no"))
         local cppflags = {}
         local ldflags = {}

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -27,9 +27,9 @@ package("libpq")
                 if #includedirs > 0 then
                     table.insert(configs, "--with-includes=" .. table.concat(includedirs, ":"))
                 end
-                local libfiles = table.wrap(libinfo.libfiles)
-                if #libfiles > 0 then
-                    table.insert(configs, "--with-libraries=" .. table.concat(libfiles, ":"))
+                local linkdirs = table.wrap(libinfo.linkdirs)
+                if #linkdirs > 0 then
+                    table.insert(configs, "--with-libraries=" .. table.concat(linkdirs, ":"))
                 end
             end
         end

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -1,11 +1,12 @@
 package("libpq")
-    set_homepage("https://www.postgresql.org/docs/14/libpq.html")
+    set_homepage("https://www.postgresql.org/docs/16/libpq.html")
     set_description("Postgres C API library")
     set_license("PostgreSQL")
 
     add_urls("https://github.com/postgres/postgres/archive/refs/tags/REL_$(version).tar.gz", {alias = "github", version = function (version)
         return version:gsub("%.", "_")
     end})
+    add_versions("16.1", "58250fee449f5fd0b5de5c1b0205e8aa8c9a4e3a8cead64ef8a3ca3c9fc2c6e9")
     add_versions("14.1", "14809c9f669851ab89b344a50219e85b77f3e93d9df9e255b9781d8d60fcfbc9")
 
     add_deps("krb5", "openssl", "zlib")

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -12,6 +12,7 @@ package("libpq")
     add_deps("krb5", "openssl", "zlib")
     if is_plat("linux") then
         add_deps("flex", "bison")
+        add_deps("apt::libicu-dev")
     end
 
     on_install("macosx", "linux", function (package)

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -21,6 +21,8 @@ package("libpq")
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
         if package:is_plat("macosx") then
             table.insert(configs, "--with-gssapi")
+            table.insert(configs, "--with-includes=" .. package:dep("krb5"):installdir("include"))
+            table.insert(configs, "--with-libraries=" .. package:dep("krb5"):installdir("lib"))
         end
         if package:debug() then
             table.insert(configs, "--enable-debug")

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -9,7 +9,7 @@ package("libpq")
     add_versions("16.1", "58250fee449f5fd0b5de5c1b0205e8aa8c9a4e3a8cead64ef8a3ca3c9fc2c6e9")
     add_versions("14.1", "14809c9f669851ab89b344a50219e85b77f3e93d9df9e255b9781d8d60fcfbc9")
 
-    add_deps("icu4c", {configs={shared=true}})
+    add_deps("icu4c", {configs = {shared = true}})
     add_deps("krb5", "openssl", "zlib")
     if is_plat("linux") then
         add_deps("flex", "bison")

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -9,7 +9,7 @@ package("libpq")
     add_versions("16.1", "58250fee449f5fd0b5de5c1b0205e8aa8c9a4e3a8cead64ef8a3ca3c9fc2c6e9")
     add_versions("14.1", "14809c9f669851ab89b344a50219e85b77f3e93d9df9e255b9781d8d60fcfbc9")
 
-    add_deps("icu4c")
+    add_deps("icu4c", {configs={shared=true}})
     add_deps("krb5", "openssl", "zlib")
     if is_plat("linux") then
         add_deps("flex", "bison")

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -21,11 +21,13 @@ package("libpq")
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
         if package:is_plat("macosx") then
             table.insert(configs, "--with-gssapi")
-            local libinfo=package:dep("krb5"):fetch()
-            local include_dir=libinfo.sysincludedir or libinfo.includedir
-            local lib_dir=libinfo.syslibdir or libinfo.libdir
-            table.insert(configs, "--with-includes=" .. include_dir)
-            table.insert(configs, "--with-libraries=" .. lib_dir)
+            local libinfo = package:dep("krb5"):fetch()
+            if libinfo then
+              local include_dir = libinfo.sysincludedir or libinfo.includedir
+              local lib_dir = libinfo.syslibdir or libinfo.libdir
+              table.insert(configs, "--with-includes=" .. include_dir)
+              table.insert(configs, "--with-libraries=" .. lib_dir)
+            end
         end
         if package:debug() then
             table.insert(configs, "--enable-debug")

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -21,15 +21,24 @@ package("libpq")
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
         if package:is_plat("macosx") then
             table.insert(configs, "--with-gssapi")
-            local libinfo = package:dep("krb5"):fetch()
-            if libinfo then
-                local includedirs = table.wrap(libinfo.sysincludedirs or libinfo.includedirs)
+            local libinfo_krb5 = package:dep("krb5"):fetch()
+            local libinfo_icu4c = package:dep("icu4c"):fetch()
+            if libinfo_krb5 or libinfo_icu4c then
+                local includedirs_krb5 = table.wrap(libinfo_krb5.sysincludedirs or libinfo_krb5.includedirs)
+                local includedirs_icu4c = table.wrap(libinfo_icu4c.sysincludedirs or libinfo_icu4c.includedirs)
+                local includedirs = table.join(includedirs_krb5, includedirs_icu4c)
                 if #includedirs > 0 then
                     table.insert(configs, "--with-includes=" .. table.concat(includedirs, ":"))
                 end
-                local linkdirs = table.wrap(libinfo.linkdirs)
+                local linkdirs_krb5 = table.wrap(libinfo_krb5.linkdirs)
+                local linkdirs_icu4c = table.wrap(libinfo_icu4c.linkdirs)
+                local linkdirs = table.join(linkdirs_krb5, linkdirs_icu4c)
                 if #linkdirs > 0 then
                     table.insert(configs, "--with-libraries=" .. table.concat(linkdirs, ":"))
+                end
+                if libinfo_icu4c then
+                    os.setenv("ICU_CFLAGS", "-I" .. includedirs_icu4c[1])
+                    os.setenv("ICU_LIBS", "-L" .. linkdirs_icu4c[1])
                 end
             end
         end

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -23,14 +23,14 @@ package("libpq")
             table.insert(configs, "--with-gssapi")
             local libinfo = package:dep("krb5"):fetch()
             if libinfo then
-              local include_dir = libinfo.sysincludedir or libinfo.includedir
-              table.insert(configs, "--with-includes=" .. include_dir)
-              local libraries = ""
-              for _, linkdir in ipairs(libinfo.linkdirs) do
-                libraries = libraries .. linkdir .. ":"
-              end
-              libraries = libraries:sub(1, -2) -- Remove the last ":"
-              table.insert(configs, "--with-libraries=" .. libraries)
+                local includedirs = table.wrap(libinfo.sysincludedirs or libinfo.includedirs)
+                if #includedirs > 0 then
+                    table.insert(configs, "--with-includes=" .. table.concat(includedirs, ":"))
+                end
+                local libfiles = table.wrap(libinfo.libfiles)
+                if #libfiles > 0 then
+                    table.insert(configs, "--with-libraries=" .. table.concat(libfiles, ":"))
+                end
             end
         end
         if package:debug() then

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -21,8 +21,11 @@ package("libpq")
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
         if package:is_plat("macosx") then
             table.insert(configs, "--with-gssapi")
-            table.insert(configs, "--with-includes=" .. package:dep("krb5"):installdir("include"))
-            table.insert(configs, "--with-libraries=" .. package:dep("krb5"):installdir("lib"))
+            local libinfo=package:dep("krb5"):fetch()
+            local include_dir=libinfo.sysincludedir or libinfo.includedir
+            local lib_dir=libinfo.syslibdir or libinfo.libdir
+            table.insert(configs, "--with-includes=" .. include_dir)
+            table.insert(configs, "--with-libraries=" .. lib_dir)
         end
         if package:debug() then
             table.insert(configs, "--enable-debug")

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -24,9 +24,13 @@ package("libpq")
             local libinfo = package:dep("krb5"):fetch()
             if libinfo then
               local include_dir = libinfo.sysincludedir or libinfo.includedir
-              local lib_dir = libinfo.syslibdir or libinfo.libdir
               table.insert(configs, "--with-includes=" .. include_dir)
-              table.insert(configs, "--with-libraries=" .. lib_dir)
+              local libraries = ""
+              for _, linkdir in ipairs(libinfo.linkdirs) do
+                libraries = libraries .. linkdir .. ":"
+              end
+              libraries = libraries:sub(1, -2) -- Remove the last ":"
+              table.insert(configs, "--with-libraries=" .. libraries)
             end
         end
         if package:debug() then

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -15,7 +15,7 @@ package("libpq")
         add_deps("flex", "bison")
     end
 
-    on_install("macosx", "linux", function (package)
+    on_install("macosx|x86_64", "linux", function (package)
         local configs = {"--with-openssl", "--without-readline"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))

--- a/packages/l/libpq/xmake.lua
+++ b/packages/l/libpq/xmake.lua
@@ -9,10 +9,10 @@ package("libpq")
     add_versions("16.1", "58250fee449f5fd0b5de5c1b0205e8aa8c9a4e3a8cead64ef8a3ca3c9fc2c6e9")
     add_versions("14.1", "14809c9f669851ab89b344a50219e85b77f3e93d9df9e255b9781d8d60fcfbc9")
 
+    add_deps("icu4c")
     add_deps("krb5", "openssl", "zlib")
     if is_plat("linux") then
         add_deps("flex", "bison")
-        add_deps("apt::libicu-dev")
     end
 
     on_install("macosx", "linux", function (package)
@@ -28,7 +28,7 @@ package("libpq")
         if package:config("pic") ~= false then
             table.insert(configs, "--with-pic")
         end
-        import("package.tools.autoconf").install(package, configs, {packagedeps = {"openssl", "zlib"}})
+        import("package.tools.autoconf").install(package, configs, {packagedeps = {"icu4c", "openssl", "zlib"}})
     end)
 
     on_test(function (package)


### PR DESCRIPTION
添加了libpq最新版本（16.1）的支持，同时由于旧的krb5库与最新OpenSSL库不兼容（krb5开启了`-Werror=discarded-qualifiers`，最新版本OpenSSL库中有若干处是否有`const`发生了变化，不改会因为编译错误无法安装krb5以及libpq），添加了krb5库的最新版本（1.21.2）的支持