### PR TITLE
Auto-update s2n-tls to v1.4.3

### DIFF
--- a/packages/s/s2n-tls/xmake.lua
+++ b/packages/s/s2n-tls/xmake.lua
@@ -6,6 +6,7 @@ package("s2n-tls")
     add_urls("https://github.com/aws/s2n-tls/archive/refs/tags/$(version).tar.gz",
              "https://github.com/aws/s2n-tls.git")
 
+    add_versions("v1.4.3", "e42551bdf6595f718e232eb98c4f0e37c7a284f29bfcbc09fa9c0a2145754ab9")
     add_versions("v1.3.51", "75c650493c42dddafd5dec6a42f2258ab52e501719ee5a337ec580cc958ea67a")
 
     add_configs("pq", {description = [[Enables all Post Quantum Crypto code. You likely want this


### PR DESCRIPTION
New version of s2n-tls detected (package version: v1.3.51, last github version: v1.4.3)