### PR TITLE
Auto-update breakpad to v2023.06.01

### DIFF
--- a/packages/b/breakpad/xmake.lua
+++ b/packages/b/breakpad/xmake.lua
@@ -6,6 +6,7 @@ package("breakpad")
              "https://github.com/google/breakpad.git",
              "https://chromium.googlesource.com/breakpad/breakpad.git")
 
+    add_versions("v2023.06.01", "81555be3595e25e8be0fe6dd34e9490beba224296e0a8a858341e7bced67674d")
     add_versions("v2023.01.27", "f187e8c203bd506689ce4b32596ba821e1e2f034a83b8e07c2c635db4de3cc0b")
 
     if is_plat("windows") then


### PR DESCRIPTION
New version of breakpad detected (package version: v2023.01.27, last github version: v2023.06.01)