### PR TITLE
Auto-update hypre to v2.30.0

### DIFF
--- a/packages/h/hypre/xmake.lua
+++ b/packages/h/hypre/xmake.lua
@@ -1,5 +1,4 @@
 package("hypre")
-
     set_homepage("https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods")
     set_description("Parallel solvers for sparse linear systems featuring multigrid methods.")
     set_license("Apache-2.0")
@@ -16,11 +15,12 @@ package("hypre")
     end
 
     add_deps("cmake")
+
     on_load("windows", "macosx", "linux", function (package)
         package:add("deps", package:config("blas"))
     end)
 
-    on_install("windows", "linux", "macosx", function (package)
+    on_install("windows|x86", "windows|x64", "linux", "macosx", function (package)
         os.cd("src")
         local configs = {"-DHYPRE_WITH_MPI=OFF", "-DHYPRE_BUILD_EXAMPLES=OFF", "-DHYPRE_BUILD_TESTS=OFF", "-DHYPRE_USING_HYPRE_BLAS=OFF", "-DHYPRE_USING_HYPRE_LAPACK=OFF"}
         table.insert(configs, "-DHYPRE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))

--- a/packages/h/hypre/xmake.lua
+++ b/packages/h/hypre/xmake.lua
@@ -29,5 +29,5 @@ package("hypre")
     end)
 
     on_test(function (package)
-        assert(package:has_cfuncs("HYPRE_Init", {includes = "HYPRE_utilities.h"}))
+        assert(package:has_cfuncs(package:version():ge("v2.29.0") and "HYPRE_Initialize" or "HYPRE_Init", {includes = "HYPRE_utilities.h"}))
     end)

--- a/packages/h/hypre/xmake.lua
+++ b/packages/h/hypre/xmake.lua
@@ -6,6 +6,7 @@ package("hypre")
 
     add_urls("https://github.com/hypre-space/hypre/archive/refs/tags/$(version).tar.gz",
              "https://github.com/hypre-space/hypre.git")
+    add_versions("v2.30.0", "8e2af97d9a25bf44801c6427779f823ebc6f306438066bba7fcbc2a5f9b78421")
     add_versions("v2.20.0", "5be77b28ddf945c92cde4b52a272d16fb5e9a7dc05e714fc5765948cba802c01")
     add_versions("v2.23.0", "8a9f9fb6f65531b77e4c319bf35bfc9d34bf529c36afe08837f56b635ac052e2")
 


### PR DESCRIPTION
New version of hypre detected (package version: v2.23.0, last github version: v2.30.0)