### PR TITLE
fix some packages tests for clang on Windows with msvc runtime

### DIFF
--- a/packages/f/fast_float/xmake.lua
+++ b/packages/f/fast_float/xmake.lua
@@ -31,5 +31,5 @@ package("fast_float")
                 double result;
                 auto answer = fast_float::from_chars(input.data(), input.data()+input.size(), result);
             }
-        ]]}, {configs = {languages = "c++11"}, includes = {"fast_float/fast_float.h"}}))
+        ]]}, {configs = {languages = "c++14"}, includes = {"fast_float/fast_float.h"}}))
     end)

--- a/packages/n/nlohmann_json/xmake.lua
+++ b/packages/n/nlohmann_json/xmake.lua
@@ -48,5 +48,5 @@ package("nlohmann_json")
                 json data;
                 data["name"] = "world";
             }
-        ]]}, {configs = {languages = "c++11"}, includes = {"nlohmann/json.hpp"}}))
+        ]]}, {configs = {languages = "c++14"}, includes = {"nlohmann/json.hpp"}}))
     end)

--- a/packages/o/ordered_map/xmake.lua
+++ b/packages/o/ordered_map/xmake.lua
@@ -32,5 +32,5 @@ package("ordered_map")
                     std::cout << "{" << key_value.first << ", " << key_value.second << "}" << std::endl;
                 }
             }
-        ]]}, {configs = {languages = "c++11"}, includes = { "tsl/ordered_map.h"} }))
+        ]]}, {configs = {languages = "c++14"}, includes = { "tsl/ordered_map.h"} }))
     end)


### PR DESCRIPTION
msvc began to use C++14 features in their STL library so tests compiling with C++11 fails

