### PR TITLE
Improve OpenBLAS

### DIFF
--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -48,12 +48,15 @@ package("openblas")
     add_configs("lapack", {description = "Build LAPACK", default = true, type = "boolean", readonly = is_plat("windows")})
     add_configs("dynamic-arch", {description = "Enable dynamic arch dispatch", default = true, type = "boolean", readonly = is_plat("windows")})
     add_configs("openmp",  {description = "Compile with OpenMP enabled.", default = not is_plat("macosx"), type = "boolean", readonly = is_plat("windows")})
-
+    
+    if not is_plat("windows") then
+        add_deps("cmake")
+    end
     if is_plat("linux") then
         add_extsources("apt::libopenblas-dev", "pacman::libopenblas") -- remove ?
         add_syslinks("pthread")
     elseif is_plat("macosx") then
-        add_frameworks("Accelerate")
+        add_frameworks("Accelerate") -- remove ?
     end
 
     on_load("macosx", "linux", function (package)

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -45,7 +45,7 @@ package("openblas")
 
     add_configs("shared", {description = "Build shared library.", default = true, type = "boolean", readonly = is_plat("windows")})
     add_configs("lapack", {description = "Build LAPACK", default = not is_plat("android"), type = "boolean", readonly = (is_plat("windows") or is_plat("android"))})
-    add_configs("dynamic_arch", {description = "Enable dynamic arch dispatch", default = (is_plat("linux") or is_plat("windows")), type = "boolean", readonly = not is_plat("linux")})
+    add_configs("dynamic_arch", {description = "Enable dynamic arch dispatch", default = (is_plat("linux") or is_plat("windows") or is_plat("mingw")), type = "boolean", readonly = not is_plat("linux")})
     add_configs("openmp", {description = "Compile with OpenMP enabled.", default = (is_plat("windows") or is_plat("linux")), type = "boolean", readonly = not is_plat("linux")})
     add_configs("fortran", {description = "Compile with Fortran enabled.", default = false, type = "boolean", readonly = (is_plat("windows") or is_plat("android"))})
     

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -55,10 +55,8 @@ package("openblas")
     if is_plat("linux") then
         add_extsources("apt::libopenblas-dev", "pacman::libopenblas") -- remove ?
         add_syslinks("pthread")
-    elseif is_plat("macosx") then
-        add_frameworks("Accelerate") -- remove ?
     end
-
+  
     on_load("macosx", "linux", function (package)
         if package:config("openmp") then
             package:add("deps", "openmp")
@@ -83,6 +81,7 @@ package("openblas")
         table.insert(configs, "-DUSE_OPENMP=" .. (package:config("openmp") and "ON" or "OFF"))
         if package:is_plat("macosx") and package:is_arch("arm64") then
             table.insert(configs, "-DTARGET=VORTEX") -- manual target for apple arm64
+            table.insert(configs, "-DBINARY=64") -- manual binary for apple arm64
         end
         if (package:config("lapack")) then
             table.join2(configs, {"-DC_LAPACK=ON", "-DBUILD_LAPACK_DEPRECATED=OFF"})

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -46,7 +46,7 @@ package("openblas")
 
     add_configs("shared", {description = "Build shared library.", default = true, type = "boolean", readonly = is_plat("windows")})
     add_configs("lapack", {description = "Build LAPACK", default = true, type = "boolean", readonly = is_plat("windows")})
-    add_configs("dynamic-arch", {description = "Enable dynamic arch dispatch", default = true, type = "boolean", readonly = is_plat("windows")})
+    add_configs("dynamic-arch", {description = "Enable dynamic arch dispatch", default = not is_plat("macosx"), type = "boolean", readonly = is_plat("windows")})
     add_configs("openmp",  {description = "Compile with OpenMP enabled.", default = not is_plat("macosx"), type = "boolean", readonly = is_plat("windows")})
     
     if not is_plat("windows") then

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -81,7 +81,7 @@ package("openblas")
         table.insert(configs, "-DNOFORTRAN=" .. (package:config("fortran") and "OFF" or "ON"))
         if package:is_plat("mingw") then
             table.insert(configs, "-DTARGET=GENERIC")
-            if package:is_arch("i386", "x86") then table.insert(configs, "BINARY=32") end
+            if package:is_arch("i386", "x86") then table.insert(configs, "-DBINARY=32") end
         end
         if package:is_plat("macosx") and package:is_arch("arm64") then
             table.insert(configs, "-DTARGET=VORTEX") 

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -44,10 +44,10 @@ package("openblas")
         add_versions("0.3.26", "4e6e4f5cb14c209262e33e6816d70221a2fe49eb69eaf0a06f065598ac602c68")
     end
 
-    add_configs("shared", {description = "Build shared library.", default = true, type = "boolean"}) -- windows locked to true
-    add_configs("lapack", {description = "Build LAPACK", default = true, type = "boolean"}) -- windows locked to true
-    add_configs("dynamic-arch", {description = "Enable dynamic arch dispatch", default = true, type = "boolean"}) -- windows locked to true
-    add_configs("openmp",  {description = "Compile with OpenMP enabled.", default = not is_plat("macosx"), type = "boolean"})
+    add_configs("shared", {description = "Build shared library.", default = true, type = "boolean", readonly = is_plat("windows")})
+    add_configs("lapack", {description = "Build LAPACK", default = true, type = "boolean", readonly = is_plat("windows")})
+    add_configs("dynamic-arch", {description = "Enable dynamic arch dispatch", default = true, type = "boolean", readonly = is_plat("windows")})
+    add_configs("openmp",  {description = "Compile with OpenMP enabled.", default = not is_plat("macosx"), type = "boolean", readonly = is_plat("windows")})
 
     if is_plat("linux") then
         add_extsources("apt::libopenblas-dev", "pacman::libopenblas") -- remove ?

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -46,7 +46,12 @@ package("openblas")
 
     -- Configs
     add_configs("shared", {description = "Build shared library.", default = true, type = "boolean", readonly = is_plat("windows")})
-    add_configs("lapack", {description = "Build LAPACK", default = true, type = "boolean", readonly = is_plat("windows")})
+    add_configs("lapack", {
+        description = "Build LAPACK",
+        default = not is_plat("android"),
+        type = "boolean",
+        readonly = (is_plat("windows") or is_plat("android"))
+    })
     add_configs("dynamic-arch", {
         description = "Enable dynamic arch dispatch",
         default = not is_plat("macosx"),
@@ -103,6 +108,7 @@ package("openblas")
         if (package:config("lapack")) then
             table.join2(configs, {"-DC_LAPACK=ON", "-DBUILD_LAPACK_DEPRECATED=OFF"})
         else
+            table.insert(configs, "-DONLY_CBLAS=ON")
             table.insert(configs, "-DBUILD_WITHOUT_LAPACK=ON")
         end
         import("package.tools.cmake").build(package, configs, {buildir = "build"})

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -45,7 +45,7 @@ package("openblas")
     end
 
     add_configs("shared", {description = "Build shared library.", default = true, type = "boolean", readonly = is_plat("windows")})
-    add_configs("lapack", {description = "Build LAPACK", default = true, type = "boolean", readonly = is_plat("windows")})
+    add_configs("lapack", {description = "Build LAPACK", default = false, type = "boolean", readonly = is_plat("windows")})
     add_configs("dynamic-arch", {description = "Enable dynamic arch dispatch", default = true, type = "boolean", readonly = is_plat("windows")})
     add_configs("openmp",  {description = "Compile with OpenMP enabled.", default = not is_plat("macosx"), type = "boolean", readonly = is_plat("windows")})
 
@@ -56,7 +56,7 @@ package("openblas")
         add_frameworks("Accelerate")
     end
 
-    on_load("macosx", "linux", "mingw@windows,msys", function (package)
+    on_load("macosx", "linux", function (package)
         if package:config("openmp") then
             package:add("deps", "openmp")
         end
@@ -73,12 +73,13 @@ package("openblas")
         package:addenv("PATH", "bin")
     end)
 
-    on_install("macosx", "linux", "mingw@windows,msys", function (package)
-        local configs = {}
+    on_install("macosx", "linux", function (package)
+        local configs = {"-DCMAKE_BUILD_TYPE=Release", "-DBUILD_TESTING=OFF", "-DNOFORTRAN=ON"} -- necessary 
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DDYNAMIC_ARCH=" .. (package:config("dynamic-arch") and "ON" or "OFF"))
+        table.insert(configs, "-DUSE_OPENMP=" .. (package:config("openmp") and "ON" or "OFF"))
         if (package:config("lapack")) then
-            table.join2(configs, {"-DC_LAPACK=ON", "-DBUILD_LAPACK_DEPRECATED=OFF", "-DBUILD_TESTING=OFF"})
+            table.join2(configs, {"-DC_LAPACK=ON", "-DBUILD_LAPACK_DEPRECATED=OFF"})
         else
             table.insert(configs, "-DBUILD_WITHOUT_LAPACK=ON")
         end

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -78,6 +78,9 @@ package("openblas")
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DDYNAMIC_ARCH=" .. (package:config("dynamic-arch") and "ON" or "OFF"))
         table.insert(configs, "-DUSE_OPENMP=" .. (package:config("openmp") and "ON" or "OFF"))
+        if package:is_plat("macosx") and package:is_arch("arm64") then
+            table.insert(configs, "-DTARGET=VORTEX") -- manual target for apple arm64
+        end
         if (package:config("lapack")) then
             table.join2(configs, {"-DC_LAPACK=ON", "-DBUILD_LAPACK_DEPRECATED=OFF"})
         else

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -101,6 +101,10 @@ package("openblas")
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DDYNAMIC_ARCH=" .. (package:config("dynamic-arch") and "ON" or "OFF"))
         table.insert(configs, "-DUSE_OPENMP=" .. (package:config("openmp") and "ON" or "OFF"))
+        if package:is_plat("macosx") and package:is_arch("arm64") then -- manual target for apple arm64
+            table.insert(configs, "-DTARGET=VORTEX") 
+            table.insert(configs, "-DBINARY=64")
+        end
         if (package:config("lapack")) then
             table.join2(configs, {"-DC_LAPACK=ON", "-DBUILD_LAPACK_DEPRECATED=OFF"})
         else

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -47,7 +47,7 @@ package("openblas")
     add_configs("lapack", {description = "Build LAPACK", default = not is_plat("android"), type = "boolean", readonly = (is_plat("windows") or is_plat("android"))})
     add_configs("dynamic_arch", {description = "Enable dynamic arch dispatch", default = (is_plat("linux") or is_plat("windows") or is_plat("mingw")), type = "boolean", readonly = not is_plat("linux")})
     add_configs("openmp", {description = "Compile with OpenMP enabled.", default = (is_plat("windows") or is_plat("linux") or is_plat("mingw")), type = "boolean", readonly = not is_plat("linux")})
-    add_configs("fortran", {description = "Compile with Fortran enabled.", default = is_plat("mingw"), type = "boolean", readonly = (is_plat("windows") or is_plat("android"))})
+    add_configs("fortran", {description = "Compile with Fortran enabled.", default = false, type = "boolean", readonly = (is_plat("windows") or is_plat("android"))})
     
     if not is_plat("windows") then
         add_deps("cmake")

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -80,6 +80,9 @@ package("openblas")
         table.insert(configs, "-DDYNAMIC_ARCH=" .. (package:config("dynamic_arch") and "ON" or "OFF"))
         table.insert(configs, "-DUSE_OPENMP=" .. (package:config("openmp") and "ON" or "OFF"))
         table.insert(configs, "-DNOFORTRAN=" .. (package:config("fortran") and "OFF" or "ON"))
+        if package:is_plat("mingw") then
+            table.insert(configs, "-DTARGET=GENERIC")
+        end
         if package:is_plat("macosx") and package:is_arch("arm64") then
             table.insert(configs, "-DTARGET=VORTEX") 
             table.insert(configs, "-DBINARY=64")
@@ -91,8 +94,7 @@ package("openblas")
             table.insert(configs, "-DONLY_CBLAS=ON")
             table.insert(configs, "-DBUILD_WITHOUT_LAPACK=ON")
         end
-        import("package.tools.cmake").build(package, configs, {buildir = "build"})
-        import("package.tools.cmake").install(package, configs, {buildir = "build"})
+        import("package.tools.cmake").install(package, configs)
 
         os.mv(package:installdir() .. "/include/openblas/*" , package:installdir("include"))
         os.rm(package:installdir("include/openblas"))

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -45,9 +45,9 @@ package("openblas")
 
     add_configs("shared", {description = "Build shared library.", default = true, type = "boolean", readonly = is_plat("windows")})
     add_configs("lapack", {description = "Build LAPACK", default = not is_plat("android"), type = "boolean", readonly = (is_plat("windows") or is_plat("android"))})
-    add_configs("dynamic_arch", {description = "Enable dynamic arch dispatch", default = (is_plat("linux") or is_plat("windows")), type = "boolean", readonly = not is_plat("linux")})
-    add_configs("openmp", {description = "Compile with OpenMP enabled.", default = (is_plat("windows") or is_plat("linux")), type = "boolean", readonly = not is_plat("linux")})
-    add_configs("fortran", {description = "Compile with Fortran enabled.", default = false, type = "boolean", readonly = (is_plat("windows") or is_plat("android"))})
+    add_configs("dynamic_arch", {description = "Enable dynamic arch dispatch", default = (is_plat("linux") or is_plat("windows") or is_plat("mingw")), type = "boolean", readonly = not is_plat("linux")})
+    add_configs("openmp", {description = "Compile with OpenMP enabled.", default = (is_plat("windows") or is_plat("linux") or is_plat("mingw")), type = "boolean", readonly = not is_plat("linux")})
+    add_configs("fortran", {description = "Compile with Fortran enabled.", default = is_plat("mingw"), type = "boolean", readonly = (is_plat("windows") or is_plat("android"))})
     
     if not is_plat("windows") then
         add_deps("cmake")

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -45,7 +45,7 @@ package("openblas")
     end
 
     add_configs("shared", {description = "Build shared library.", default = true, type = "boolean", readonly = is_plat("windows")})
-    add_configs("lapack", {description = "Build LAPACK", default = false, type = "boolean", readonly = is_plat("windows")})
+    add_configs("lapack", {description = "Build LAPACK", default = true, type = "boolean", readonly = is_plat("windows")})
     add_configs("dynamic-arch", {description = "Enable dynamic arch dispatch", default = true, type = "boolean", readonly = is_plat("windows")})
     add_configs("openmp",  {description = "Compile with OpenMP enabled.", default = not is_plat("macosx"), type = "boolean", readonly = is_plat("windows")})
 

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -57,7 +57,7 @@ package("openblas")
         add_syslinks("pthread")
     end
   
-    on_load("linux", "macosx", "mingw", function (package)
+    on_load("linux", "macosx", "mingw@msys", function (package)
         if package:config("openmp") then package:add("deps", "openmp") end
         if package:config("fortran") then package:add("deps", "gfortran", {system = true}) end
     end)
@@ -73,7 +73,7 @@ package("openblas")
         package:addenv("PATH", "bin")
     end)
 
-    on_install("macosx", "linux", "android", "mingw", function (package)
+    on_install("macosx", "linux", "android", "mingw@msys", function (package)
         local configs = {"-DCMAKE_BUILD_TYPE=Release", "-DBUILD_TESTING=OFF"}
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DDYNAMIC_ARCH=" .. (package:config("dynamic_arch") and "ON" or "OFF"))

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -101,10 +101,6 @@ package("openblas")
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DDYNAMIC_ARCH=" .. (package:config("dynamic-arch") and "ON" or "OFF"))
         table.insert(configs, "-DUSE_OPENMP=" .. (package:config("openmp") and "ON" or "OFF"))
-        if package:is_plat("macosx") and package:is_arch("arm64") then
-            table.insert(configs, "-DTARGET=VORTEX") -- manual target for apple arm64
-            table.insert(configs, "-DBINARY=64") -- manual binary for apple arm64
-        end
         if (package:config("lapack")) then
             table.join2(configs, {"-DC_LAPACK=ON", "-DBUILD_LAPACK_DEPRECATED=OFF"})
         else

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -54,9 +54,9 @@ package("openblas")
     })
     add_configs("dynamic-arch", {
         description = "Enable dynamic arch dispatch",
-        default = not is_plat("macosx"),
+        default = (is_plat("linux") or is_plat("windows")),
         type = "boolean",
-        readonly = (is_plat("windows") or is_plat("macosx"))
+        readonly = not is_plat("linux")
     })
     add_configs("openmp",  {
         description = "Compile with OpenMP enabled.",

--- a/packages/o/openblas/xmake.lua
+++ b/packages/o/openblas/xmake.lua
@@ -45,7 +45,7 @@ package("openblas")
 
     add_configs("shared", {description = "Build shared library.", default = true, type = "boolean", readonly = is_plat("windows")})
     add_configs("lapack", {description = "Build LAPACK", default = not is_plat("android"), type = "boolean", readonly = (is_plat("windows") or is_plat("android"))})
-    add_configs("dynamic_arch", {description = "Enable dynamic arch dispatch", default = (is_plat("linux") or is_plat("windows") or is_plat("mingw")), type = "boolean", readonly = not is_plat("linux")})
+    add_configs("dynamic_arch", {description = "Enable dynamic arch dispatch", default = (is_plat("linux") or is_plat("windows")), type = "boolean", readonly = not is_plat("linux")})
     add_configs("openmp", {description = "Compile with OpenMP enabled.", default = (is_plat("windows") or is_plat("linux")), type = "boolean", readonly = not is_plat("linux")})
     add_configs("fortran", {description = "Compile with Fortran enabled.", default = false, type = "boolean", readonly = (is_plat("windows") or is_plat("android"))})
     
@@ -57,10 +57,9 @@ package("openblas")
         add_syslinks("pthread")
     end
   
-    on_load("linux", function (package)
-        if package:config("openmp") then
-            package:add("deps", "openmp")
-        end
+    on_load("linux", "macosx", "mingw", function (package)
+        if package:config("openmp") then package:add("deps", "openmp") end
+        if package:config("fortran") then package:add("deps", "gfortran", {system = true}) end
     end)
 
     on_load("windows|x64", "windows|x86", function (package)
@@ -82,6 +81,7 @@ package("openblas")
         table.insert(configs, "-DNOFORTRAN=" .. (package:config("fortran") and "OFF" or "ON"))
         if package:is_plat("mingw") then
             table.insert(configs, "-DTARGET=GENERIC")
+            if package:is_arch("i386", "x86") then table.insert(configs, "BINARY=32") end
         end
         if package:is_plat("macosx") and package:is_arch("arm64") then
             table.insert(configs, "-DTARGET=VORTEX") 


### PR DESCRIPTION
Reworked the package for more granular control over the compilation of the library.

- Switch to cmake build.
- Removed fortran option. OpenBLAS has the option to compile LAPACK from C sources and I believe this should be the default.
- Added dynamic arch compilation option using the default target preset provided by OpenBLAS.
- Simplified how openmp is added.