### PR TITLE
libpng: Compile using xmake on all platforms

### DIFF
--- a/packages/l/libpng/xmake.lua
+++ b/packages/l/libpng/xmake.lua
@@ -27,7 +27,7 @@ package("libpng")
         add_extsources("brew::libpng")
     end
 
-    on_install("windows", "mingw", "macosx|arm64", "android", "iphoneos", "cross", "bsd", "wasm", function (package)
+    on_install(function (package)
         io.writefile("xmake.lua", [[
             add_rules("mode.debug", "mode.release")
             add_requires("zlib")
@@ -72,19 +72,6 @@ package("libpng")
         end
         os.cp("scripts/pnglibconf.h.prebuilt", "pnglibconf.h")
         import("package.tools.xmake").install(package, configs)
-    end)
-
-    on_install("macosx|x86_64", "linux", function (package)
-        local configs = {}
-        table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
-        table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
-        if package:config("pic") ~= false then
-            table.insert(configs, "--with-pic")
-        end
-        if not package:dep("zlib"):is_system() then
-            table.insert(configs, "--with-zlib-prefix=" .. package:dep("zlib"):installdir())
-        end
-        import("package.tools.autoconf").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/l/libpng/xmake.lua
+++ b/packages/l/libpng/xmake.lua
@@ -61,11 +61,6 @@ package("libpng")
                 end
         ]])
         local configs = {}
-        if package:config("shared") then
-            configs.kind = "shared"
-        elseif not package:is_plat("windows", "mingw") and package:config("pic") ~= false then
-            configs.cxflags = "-fPIC"
-        end
         if package:is_plat("android") and package:is_arch("armeabi-v7a") then
             io.replace("arm/filter_neon.S", ".func", ".hidden", {plain = true})
             io.replace("arm/filter_neon.S", ".endfunc", "", {plain = true})


### PR DESCRIPTION
This fixes an error if zlib is found by xmake

```
pinging the host(github.com) ... 18 ms
pinging the host(download.savannah.gnu.org) ... 96 ms
pinging the host(downloads.sourceforge.net) ... 144 ms
pinging the host(gitlab.freedesktop.org) ... 65535 ms
/usr/bin/tar -xf v1.6.42.tar.gz -C source.tmp
./configure --enable-shared=no --enable-static=yes --with-pic --with-zlib-prefix=/home/lynix/.xmake/packages/z/zlib/v1.3.1/994fafa590ed48ac9f71516cc846d155 --prefix=/home/lynix/.xmake/packages/l/libpng/v1.6.42/dee67a21a7974735aa2865c15ac96579 --with-pic
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a race-free mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether to enable maintainer-specific portions of Makefiles... no
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
checking whether gcc understands -c and -o together... yes
checking whether make supports the include directive... yes (GNU style)
checking dependency style of gcc... gcc3
checking dependency style of gcc... gcc3
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking for a sed that does not truncate output... /usr/bin/sed
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for fgrep... /usr/bin/grep -F
checking how to print strings... printf
checking for ld used by gcc... /usr/bin/ld
checking if the linker (/usr/bin/ld) is GNU ld... yes
checking how to run the C preprocessor... gcc -E
checking for gawk... (cached) gawk
checking whether ln -s works... yes
checking whether make sets $(MAKE)... (cached) yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/bin/ld option to reload object files... -r
checking for file... file
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ar... ar
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking command to parse /usr/bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for a working dd... /usr/bin/dd
checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
checking for mt... mt
checking if mt is a manifest tool... no
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... yes
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... no
checking whether to build static libraries... yes
checking that AWK works... ok
checking if we need to force back C standard to C89... no
checking whether struct tm is in sys/time.h or time.h... time.h
checking for C/C++ restrict keyword... __restrict__
checking for pow... no
checking for pow in -lm... yes
checking for clock_gettime... yes
checking for zlibVersion in -lz... no
checking for /home/lynix/.xmake/packages/z/zlib/v1.3.1/994fafa590ed48ac9f71516cc846d155zlibVersion in -lz... no
configure: error: zlib not installed
error: @programdir/core/sandbox/modules/os.lua:378: execv(./configure --enable-shared=no --enable-static=yes --with-pic --with-zlib-prefix=/home/lynix/.xmake/packages/z/zlib/v1.3.1/994fafa590ed48ac9f71516cc846d155 --prefix=/home/lynix/.xmake/packages/l/libpng/v1.6.42/dee67a21a7974735aa2865c15ac96579 --with-pic) failed(1)
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:949]:
    [@programdir/core/sandbox/modules/os.lua:378]:
    [@programdir/core/sandbox/modules/os.lua:291]: in function 'vrunv'
    [@programdir/modules/package/tools/autoconf.lua:454]: in function 'configure'
    [@programdir/modules/package/tools/autoconf.lua:478]: in function 'build'
    [@programdir/modules/package/tools/autoconf.lua:507]: in function 'install'
    [...make/repositories/xmake-repo/packages/l/libpng/xmake.lua:87]: in function 'script'
    [...dir/modules/private/action/require/impl/utils/filter.lua:114]: in function 'call'
    [.../modules/private/action/require/impl/actions/install.lua:369]:

  => install libpng v1.6.42 .. failed
```