### PR TITLE
Fix bug on zlib: global 'check_cincludes' is not callable

### DIFF
--- a/packages/z/zlib/xmake.lua
+++ b/packages/z/zlib/xmake.lua
@@ -34,6 +34,7 @@ package("zlib")
     on_install(function (package)
         io.writefile("xmake.lua", [[
             includes("@builtin/check")
+            includes("check_cincludes.lua")
             add_rules("mode.debug", "mode.release")
             target("zlib")
                 set_kind("$(kind)")


### PR DESCRIPTION
编译zlib的时候会出现global 'check_cincludes' is not callable