### PR TITLE
Auto-update mariadb-connector-c to 3.3.9

### DIFF
--- a/packages/m/mariadb-connector-c/xmake.lua
+++ b/packages/m/mariadb-connector-c/xmake.lua
@@ -6,8 +6,8 @@ package("mariadb-connector-c")
     add_urls("https://github.com/mariadb-corporation/mariadb-connector-c/archive/refs/tags/v$(version).tar.gz")
 
     add_versions("3.3.9", "062b9ec5c26cbb236a78f0ba26981272053f59bdfc113040bab904a9da36d31f")
-    add_versions("3.1.13", "361136e9c365259397190109d50f8b6a65c628177792273b4acdb6978942b5e7")
     add_versions("3.3.4", "ea6a23850d6a2f6f2e0d9e9fdb7d94fe905a4317f73842272cf121ed25903e1f")
+    add_versions("3.1.13", "361136e9c365259397190109d50f8b6a65c628177792273b4acdb6978942b5e7")
 
     add_deps("cmake")
 
@@ -56,6 +56,7 @@ package("mariadb-connector-c")
     on_install("bsd", "linux", "windows", function(package)
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DCMAKE_COMPILE_WARNING_AS_ERROR=OFF")
         for name, enabled in pairs(package:configs()) do
             if not package:extraconf("configs", name, "builtin") then
                 if enabled then

--- a/packages/m/mariadb-connector-c/xmake.lua
+++ b/packages/m/mariadb-connector-c/xmake.lua
@@ -5,6 +5,7 @@ package("mariadb-connector-c")
 
     add_urls("https://github.com/mariadb-corporation/mariadb-connector-c/archive/refs/tags/v$(version).tar.gz")
 
+    add_versions("3.3.9", "062b9ec5c26cbb236a78f0ba26981272053f59bdfc113040bab904a9da36d31f")
     add_versions("3.1.13", "361136e9c365259397190109d50f8b6a65c628177792273b4acdb6978942b5e7")
     add_versions("3.3.4", "ea6a23850d6a2f6f2e0d9e9fdb7d94fe905a4317f73842272cf121ed25903e1f")
 

--- a/packages/m/mariadb-connector-c/xmake.lua
+++ b/packages/m/mariadb-connector-c/xmake.lua
@@ -54,9 +54,9 @@ package("mariadb-connector-c")
     end)
 
     on_install("bsd", "linux", "windows", function(package)
+        io.replace("CMakeLists.txt", "-Werror", "", {plain = true})
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-        table.insert(configs, "-DCMAKE_COMPILE_WARNING_AS_ERROR=OFF")
         for name, enabled in pairs(package:configs()) do
             if not package:extraconf("configs", name, "builtin") then
                 if enabled then


### PR DESCRIPTION
New version of mariadb-connector-c detected (package version: 3.3.4, last github version: 3.3.9)