### PR TITLE
Auto-update suitesparse to v7.6.0

### DIFF
--- a/packages/s/suitesparse/xmake.lua
+++ b/packages/s/suitesparse/xmake.lua
@@ -5,6 +5,7 @@ package("suitesparse")
 
     add_urls("https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/$(version).tar.gz",
              "https://github.com/DrTimothyAldenDavis/SuiteSparse.git")
+    add_versions("v7.6.0", "19cbeb9964ebe439413dd66d82ace1f904adc5f25d8a823c1b48c34bd0d29ea5")
     add_versions("v5.10.1", "acb4d1045f48a237e70294b950153e48dce5b5f9ca8190e86c2b8c54ce00a7ee")
     add_versions("v5.12.0", "5fb0064a3398111976f30c5908a8c0b40df44c6dd8f0cc4bfa7b9e45d8c647de")
     add_versions("v5.13.0", "59c6ca2959623f0c69226cf9afb9a018d12a37fab3a8869db5f6d7f83b6b147d")


### PR DESCRIPTION
New version of suitesparse detected (package version: v7.5.1, last github version: v7.6.0)