### PR TITLE
Auto-update libpqxx to 7.8.1

### DIFF
--- a/packages/l/libpqxx/xmake.lua
+++ b/packages/l/libpqxx/xmake.lua
@@ -4,6 +4,7 @@ package("libpqxx")
 
     add_urls("https://github.com/jtv/libpqxx/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jtv/libpqxx.git")
+    add_versions("7.8.1", "0f4c0762de45a415c9fd7357ce508666fa88b9a4a463f5fb76c235bc80dd6a84")
     add_versions("7.7.0", "2d99de960aa3016915bc69326b369fcee04425e57fbe9dad48dd3fa6203879fb")
 
     add_deps("cmake", "python 3.x")


### PR DESCRIPTION
New version of libpqxx detected (package version: 7.7.0, last github version: 7.8.1)