### PR TITLE
Auto-update xtl to 0.7.7

### DIFF
--- a/packages/x/xtl/xmake.lua
+++ b/packages/x/xtl/xmake.lua
@@ -7,6 +7,7 @@ package("xtl")
 
     add_urls("https://github.com/xtensor-stack/xtl/archive/refs/tags/$(version).tar.gz",
              "https://github.com/xtensor-stack/xtl.git")
+    add_versions("0.7.7", "44fb99fbf5e56af5c43619fc8c29aa58e5fad18f3ba6e7d9c55c111b62df1fbb")
     add_versions("0.7.2", "95c221bdc6eaba592878090916383e5b9390a076828552256693d5d97f78357c")
     add_versions("0.7.3", "f4a81e3c9ca9ddb42bd4373967d4859ecfdca1aba60b9fa6ced6c84d8b9824ff")
     add_versions("0.7.4", "3c88be0e696b64150c4de7a70f9f09c00a335186b0b0b409771ef9f56bca7d9a")


### PR DESCRIPTION
New version of xtl detected (package version: 0.7.6, last github version: 0.7.7)