### PR TITLE
Auto-update utf8proc to v2.9.0

### DIFF
--- a/packages/u/utf8proc/xmake.lua
+++ b/packages/u/utf8proc/xmake.lua
@@ -6,6 +6,7 @@ package("utf8proc")
 
     add_urls("https://github.com/JuliaStrings/utf8proc/archive/refs/tags/$(version).tar.gz",
              "https://github.com/JuliaStrings/utf8proc.git")
+    add_versions("v2.9.0", "18c1626e9fc5a2e192311e36b3010bfc698078f692888940f1fa150547abb0c1")
     add_versions("v2.7.0", "4bb121e297293c0fd55f08f83afab6d35d48f0af4ecc07523ad8ec99aa2b12a1")
     add_versions("v2.8.0", "a0a60a79fe6f6d54e7d411facbfcc867a6e198608f2cd992490e46f04b1bcecc")
 


### PR DESCRIPTION
New version of utf8proc detected (package version: v2.8.0, last github version: v2.9.0)