### PR TITLE
Support bzip2 on clang

### DIFF
--- a/packages/b/bzip2/port/xmake.lua
+++ b/packages/b/bzip2/port/xmake.lua
@@ -19,7 +19,7 @@ target("bz2")
         set_filename("libbz2.dll")
         add_files("libbz2.def")
     end
-    if is_plat("wasm") then
+    if is_plat("wasm") or has_tool("cc", "clang", "clangxx") then
         add_defines("BZ_STRICT_ANSI")
     end
 


### PR DESCRIPTION
Without BZ_STRICT_ANSI macros:

```error: bzlib.c:1431:10: error: incompatible integer to pointer conversion assigning to 'FILE *' (aka 'struct _IO_FILE *') from 'int' [-Wint-conversion]
 1431 |       fp = fdopen(fd,mode2);
      |          ^ ~~~~~~~~~~~~~~~~
1 error generated.
error: execv(xmake build --verbose) failed(255)
  => install bzip2 1.0.8 .. failed
```