### PR TITLE
Fix bzip2 compilation on clang 15+

### DIFF
--- a/packages/b/bzip2/port/xmake.lua
+++ b/packages/b/bzip2/port/xmake.lua
@@ -19,7 +19,7 @@ target("bz2")
         set_filename("libbz2.dll")
         add_files("libbz2.def")
     end
-    if is_plat("wasm") then
+    if is_plat("wasm") or has_tool("cc", "clang", "clangxx") then
         add_defines("BZ_STRICT_ANSI")
     end
 

--- a/packages/b/bzip2/port/xmake.lua
+++ b/packages/b/bzip2/port/xmake.lua
@@ -19,9 +19,13 @@ target("bz2")
         set_filename("libbz2.dll")
         add_files("libbz2.def")
     end
-    if is_plat("wasm") or has_tool("cc", "clang", "clangxx") then
+    if is_plat("wasm") then
         add_defines("BZ_STRICT_ANSI")
     end
+    if has_tool("cc", "clang", "clangxx") then
+        add_cflags("-Wno-error=int-conversion")
+    end
+
 
 if has_config("enable_tools") then
 

--- a/packages/b/bzip2/port/xmake.lua
+++ b/packages/b/bzip2/port/xmake.lua
@@ -22,10 +22,7 @@ target("bz2")
     if is_plat("wasm") then
         add_defines("BZ_STRICT_ANSI")
     end
-    if has_tool("cc", "clang", "clangxx") then
-        add_cflags("-Wno-error=int-conversion")
-    end
-
+    add_cflags("clang::-Wno-error=int-conversion")
 
 if has_config("enable_tools") then
 


### PR DESCRIPTION
In clang 15+ versions they made "-Wint-conversion" as an error:
https://www.redhat.com/zh/blog/new-warnings-and-errors-clang-15

```
bzlib.c:1431:12: warning: implicit declaration of function 'fdopen' [-Wimplicit-function-declaration]
 1431 |       fp = fdopen(fd,mode2);
      |            ^
bzlib.c:1431:10: warning: incompatible integer to pointer conversion assigning to 'FILE *' (aka 'struct _IO_FILE *') from 'int' [-Wint-conversion]
 1431 |       fp = fdopen(fd,mode2);

bzip2.c:967:7: warning: incompatible integer to pointer conversion assigning to 'FILE *' (aka 'struct _IO_FILE *') from 'int' [-Wint-conversion]
  967 |    fp = fdopen(fh, mode);
```
