### PR TITLE
Fix boost build with mingw toolchain which has spaces in its path.

### DIFF
--- a/packages/b/boost/xmake.lua
+++ b/packages/b/boost/xmake.lua
@@ -171,7 +171,7 @@ package("boost")
             else
                 cxx = cxx:gsub("gcc$", "g++")
                 cxx = cxx:gsub("clang$", "clang++")
-                return format("using gcc : : %s ;", cxx:gsub("\\", "/"))
+                return format("using gcc : : \"%s\" ;", cxx:gsub("\\", "/"))
             end
         end
 


### PR DESCRIPTION
Fix boost package when toolchain is set to MinGW and its path contain spaces. It led to the following error:
`error: provided command '"C:/Program" "Files/mydevtools/MinGW-w64/bin/x86_64-w64-mingw32-g++"' not found`

See https://github.com/xmake-io/xmake/issues/4745.