### PR TITLE
Auto-update libpng to v1.6.43

### DIFF
--- a/packages/l/libpng/xmake.lua
+++ b/packages/l/libpng/xmake.lua
@@ -6,6 +6,7 @@ package("libpng")
     add_urls("https://github.com/glennrp/libpng/archive/refs/tags/$(version).tar.gz")
     add_urls("https://github.com/glennrp/libpng.git")
 
+    add_versions("v1.6.43", "fecc95b46cf05e8e3fc8a414750e0ba5aad00d89e9fdf175e94ff041caf1a03a")
     add_versions("v1.6.42", "fe89de292e223829859d21990d9c4d6b7e30e295a268f6a53a022611aa98bd67")
     add_versions("v1.6.40", "62d25af25e636454b005c93cae51ddcd5383c40fa14aa3dae8f6576feb5692c2")
     add_versions("v1.6.37", "ca74a0dace179a8422187671aee97dd3892b53e168627145271cad5b5ac81307")


### PR DESCRIPTION
New version of libpng detected (package version: v1.6.42, last github version: v1.6.43)