### PR TITLE
Auto-update ada to 2.7.6

### DIFF
--- a/packages/a/ada/xmake.lua
+++ b/packages/a/ada/xmake.lua
@@ -7,6 +7,7 @@ package("ada")
     set_urls("https://github.com/ada-url/ada/archive/refs/tags/v$(version).tar.gz",
              "https://github.com/ada-url/ada.git")
 
+    add_versions("2.7.6", "e2822783913c50b9f5c0f20b5259130a7bdc36e87aba1cc38a5de461fe45288f")
     add_versions("2.3.1", "298992ec0958979090566c7835ea60c14f5330d6372ee092ef6eee1d2e6ac079")
     add_versions("2.4.0", "14624f1dfd966fee85272688064714172ff70e6e304a1e1850f352a07e4c6dc7")
     add_versions("2.4.1", "e9359937e7aeb8e5889515c0a9e22cd5da50e9b053038eb092135a0e64888fe7")


### PR DESCRIPTION
New version of ada detected (package version: 2.4.1, last github version: 2.7.6)