### PR TITLE
Auto-update pocketpy to v1.4.1

### DIFF
--- a/packages/p/pocketpy/xmake.lua
+++ b/packages/p/pocketpy/xmake.lua
@@ -6,6 +6,7 @@ package("pocketpy")
 
     add_urls("https://github.com/blueloveTH/pocketpy/releases/download/$(version)/pocketpy.h")
 
+    add_versions("v1.4.1", "73ffa000a297d34de6bafd7a5fceffe30bd1fc1392d0012dc791c3a423236270")
     add_versions("v0.9.0", "0da63afb3ea4ebb8b686bfe33b4c7556c0a927cd98ccf3c7a3fb4aa216fbf30b")
 
     on_install("windows|x64", "linux", "macosx", "android", function (package)


### PR DESCRIPTION
New version of pocketpy detected (package version: v0.9.0, last github version: v1.4.1)