### PR TITLE
rework jdk toolchain 17 & 21

### DIFF
--- a/.github/workflows/macos_aarch64.yml
+++ b/.github/workflows/macos_aarch64.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13-xlarge]
+        os: [macos-14]
         arch: [arm64]
         kind: [static, shared]
 

--- a/.github/workflows/macos_aarch64.yml
+++ b/.github/workflows/macos_aarch64.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14]
+        os: [macos-13-xlarge]
         arch: [arm64]
         kind: [static, shared]
 

--- a/.github/workflows/macos_aarch64.yml
+++ b/.github/workflows/macos_aarch64.yml
@@ -1,0 +1,33 @@
+name: macOS
+
+on:
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14]
+        arch: [arm64]
+        kind: [static, shared]
+
+    runs-on: ${{ matrix.os }}
+
+    concurrency:
+        group: ${{ github.ref }}-${{ github.base_ref }}-${{ github.head_ref }}-macOS-${{ matrix.arch }}-${{ matrix.kind }}
+        cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v1
+      - uses: xmake-io/github-action-setup-xmake@v1
+        with:
+          xmake-version: branch@master
+          actions-cache-folder: '.xmake-cache'
+
+      - name: Tests
+        run: |
+          wget https://curl.haxx.se/ca/cacert.pem -O /tmp/cacert.pem
+          export CURL_CA_BUNDLE=/tmp/cacert.pem
+          xmake l ./scripts/test.lua -D -a ${{ matrix.arch }} -k ${{ matrix.kind }}

--- a/.github/workflows/macos_x64.yml
+++ b/.github/workflows/macos_x64.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13]
+        os: [macos-12]
         arch: [x86_64]
         kind: [static, shared]
 

--- a/.github/workflows/macos_x64.yml
+++ b/.github/workflows/macos_x64.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest]
-        arch: [x86_64, arm64]
+        os: [macos-14-large]
+        arch: [x86_64]
         kind: [static, shared]
 
     runs-on: ${{ matrix.os }}
@@ -31,4 +31,3 @@ jobs:
           wget https://curl.haxx.se/ca/cacert.pem -O /tmp/cacert.pem
           export CURL_CA_BUNDLE=/tmp/cacert.pem
           xmake l ./scripts/test.lua -D -a ${{ matrix.arch }} -k ${{ matrix.kind }}
-

--- a/.github/workflows/macos_x64.yml
+++ b/.github/workflows/macos_x64.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large]
+        os: [macos-13]
         arch: [x86_64]
         kind: [static, shared]
 

--- a/packages/o/openjdk/xmake.lua
+++ b/packages/o/openjdk/xmake.lua
@@ -4,23 +4,28 @@ package("openjdk")
     set_license("GPL-2.0")
 
     if is_host("windows", "mingw") then
-        add_urls("https://download.java.net/java/GA/jdk$(version)/6e380f22cbe7469fa75fb448bd903d8e/9/GPL/openjdk-$(version)_windows-x64_bin.zip")
-        add_versions("20.0.2", "7e5870fd2e19b87cbd1981c4ff7203897384c2eb104977f40ce4951b40ab433e")
+        add_urls("https://download.oracle.com/java/$(version)/latest/jdk-$(version)_windows-x64_bin.zip")
+        add_versions("17", "c98d85c8417703b0f72ddc5757ed66f3478ea7107b0e6d2a98cadbc73a45d77b")
+        add_versions("21", "776afe55020560f175d8099710d8ac07c4d40772c694385c3dd765117cbd0ac3")
     elseif is_host("linux") then
         if is_arch("x86_64") then
-            add_urls("https://download.java.net/java/GA/jdk$(version)/6e380f22cbe7469fa75fb448bd903d8e/9/GPL/openjdk-$(version)_linux-x64_bin.tar.gz")
-            add_versions("20.0.2", "beaf61959c2953310595e1162b0c626aef33d58628771033ff2936609661956c")
+            add_urls("https://download.oracle.com/java/$(version)/latest/jdk-$(version)_linux-x64_bin.tar.gz")
+            add_versions("17", "e4fb2df9a32a876afb0a6e17f54c594c2780e18badfa2e8fc99bc2656b0a57b1")
+            add_versions("21", "9f1f4a7f25ef6a73255657c40a6d7714f2d269cf15fb2ff1dc9c0c8b56623a6f")
         elseif is_arch("arm64") then
-            add_urls("https://download.java.net/java/GA/jdk$(version)/6e380f22cbe7469fa75fb448bd903d8e/9/GPL/openjdk-$(version)_linux-aarch64_bin.tar.gz")
-            add_versions("20.0.2", "3238c93267c663dbca00f5d5b0e3fbba40e1eea2b4281612f40542d208b6dd9a")
+            add_urls("https://download.oracle.com/java/$(version)/latest/jdk-$(version)_linux-aarch64_bin.tar.gz")
+            add_versions("17", "745e7a387e059ddc2481ccd209d691ca926fc0f35d523051822f24b296d17df7")
+            add_versions("21", "14504bcdea0d8bc3fe9f065924e9e2dc631317b023a722565c8239075f39062d")
         end
     elseif is_host("macosx") then
         if is_arch("x86_64") then
-            add_urls("https://download.java.net/java/GA/jdk$(version)/6e380f22cbe7469fa75fb448bd903d8e/9/GPL/openjdk-$(version)_macos-x64_bin.tar.gz")
-            add_versions("20.0.2", "c65ba92b73d8076e2a10029a0674d40ce45c3e0183a8063dd51281e92c9f43fc")
+            add_urls("https://download.oracle.com/java/$(version)/latest/jdk-$(version)_macos-x64_bin.tar.gz")
+            add_versions("17", "7b68b833f392aa543ba538f94c60fd477581fef96a9c1ae059fa4158e9ce75ff")
+            add_versions("21", "197a923b1f7ea2b224fafdfb9c3ef5fc8eb197d9817d7631d96da02b619f5975")
         elseif is_arch("arm64") then
-            add_urls("https://download.java.net/java/GA/jdk$(version)/6e380f22cbe7469fa75fb448bd903d8e/9/GPL/openjdk-$(version)_macos-x64_bin.tar.gz")
-            add_versions("20.0.2", "2e6522bb574f76cd3f81156acd59115a014bf452bbe4107f0d31ff9b41b3da57")
+            add_urls("https://download.oracle.com/java/$(version)/latest/jdk-$(version)_macos-aarch64_bin.tar.gz")
+            add_versions("17", "d5bec93922815e9337040678ddf3f40e50b63c2b588cf63574fa1f2010206042")
+            add_versions("21", "4b94951f03efe44cb6656e43f1098db3ce254a00412f9d22dff18a8328a7efdd")
         end
     end
 


### PR DESCRIPTION
* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

------

This pull request accomplishes two main tasks:

1. It removes the non-LTS version of JDK 20 and adds direct support for JDK 17 and JDK 21 LTS versions, which can now be downloaded directly from Oracle.
2. It adds support for macOS ARM instances in the CI pipeline. (GitHub provides free access to these instances for public repositories.) (This may be also helpful for folly build on arm64 macos)
