### PR TITLE
Auto-update dr_mp3 to 0.6.39

### DIFF
--- a/packages/d/dr_mp3/xmake.lua
+++ b/packages/d/dr_mp3/xmake.lua
@@ -5,6 +5,7 @@ package("dr_mp3")
     set_license("MIT")
 
     set_urls("https://github.com/mackron/dr_libs.git", {submodules = false})
+    add_versions("0.6.39", "da35f9d6c7374a95353fd1df1d394d44ab66cf01")
     add_versions("0.6.38", "01d23df76776faccee3bc456f685900dcc273b4c")
     add_versions("0.6.37", "1b0bc87c6b9b04052e6ef0117396dab8482c250e")
     add_versions("0.6.36", "b7f4c04e77b4c14347b74503e4ce93494e314283")


### PR DESCRIPTION
New version of dr_mp3 detected (package version: 0.6.38, last github version: 0.6.39)