### PR TITLE
Auto-update implot to v0.16

### DIFF
--- a/packages/i/implot/xmake.lua
+++ b/packages/i/implot/xmake.lua
@@ -6,6 +6,7 @@ package("implot")
     add_urls("https://github.com/epezent/implot/archive/refs/tags/$(version).tar.gz",
              "https://github.com/epezent/implot.git")
 
+    add_versions("v0.16", "961df327d8a756304d1b0a67316eebdb1111d13d559f0d3415114ec0eb30abd1")
     add_versions("v0.15", "3df87e67a1e28db86828059363d78972a298cd403ba1f5780c1040e03dfa2672")
 
     add_deps("imgui")


### PR DESCRIPTION
New version of implot detected (package version: nil, last github version: v0.16)