### PR TITLE
Auto-update haclog to v0.1.6

### DIFF
--- a/packages/h/haclog/xmake.lua
+++ b/packages/h/haclog/xmake.lua
@@ -6,6 +6,7 @@ package("haclog")
     add_urls("https://github.com/MuggleWei/haclog/archive/refs/tags/$(version).tar.gz",
              "https://github.com/MuggleWei/haclog.git")
 
+    add_versions("v0.1.6", "3afdb52d21b03a085291074612c39fab3ef056b6b32071693df4a2b60b9b6554")
     add_versions("v0.0.5", "789340ba87ac076e4c5559e1e6e0bf4f1e17f2e55c4845d0f9fc8ead8e6d7f5f")
 
     if is_plat("linux", "bsd") then

--- a/packages/h/haclog/xmake.lua
+++ b/packages/h/haclog/xmake.lua
@@ -14,7 +14,7 @@ package("haclog")
     end
 
     on_load(function (package)
-        if package:is_cross() then
+        if package:is_plat("cross") then
             package:add("deps", "meson", "ninja")
         else
             package:add("deps", "cmake")
@@ -23,7 +23,7 @@ package("haclog")
 
     on_install("windows", "linux", "macosx", "android", "cross", function (package)
         local configs = {}
-        if package:is_cross() then
+        if package:is_plat("cross") then
             table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
             import("package.tools.meson").install(package, configs)
         else

--- a/packages/h/haclog/xmake.lua
+++ b/packages/h/haclog/xmake.lua
@@ -13,13 +13,24 @@ package("haclog")
         add_syslinks("pthread")
     end
 
-    add_deps("cmake")
+    on_load(function (package)
+        if package:is_cross() then
+            package:add("deps", "meson", "ninja")
+        else
+            package:add("deps", "cmake")
+        end
+    end)
 
     on_install("windows", "linux", "macosx", "android", "cross", function (package)
         local configs = {}
-        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
-        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        import("package.tools.cmake").install(package, configs)
+        if package:is_cross() then
+            table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
+            import("package.tools.meson").install(package, configs)
+        else
+            table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
+            table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+            import("package.tools.cmake").install(package, configs)
+        end
     end)
 
     on_test(function (package)


### PR DESCRIPTION
New version of haclog detected (package version: nil, last github version: v0.1.6)