### PR TITLE
Auto-update aws-checksums to v0.1.18

### DIFF
--- a/packages/a/aws-checksums/xmake.lua
+++ b/packages/a/aws-checksums/xmake.lua
@@ -6,6 +6,7 @@ package("aws-checksums")
     add_urls("https://github.com/awslabs/aws-checksums/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-checksums.git")
 
+    add_versions("v0.1.18", "bdba9d0a8b8330a89c6b8cbc00b9aa14f403d3449b37ff2e0d96d62a7301b2ee")
     add_versions("v0.1.17", "83c1fbae826631361a529e9565e64a942c412baaec6b705ae5da3f056b97b958")
 
     add_configs("asan", {description = "Enable Address Sanitize.", default = false, type = "boolean"})


### PR DESCRIPTION
New version of aws-checksums detected (package version: nil, last github version: v0.1.18)