### PR TITLE
Auto-update dbg-macro to v0.5.1

### DIFF
--- a/packages/d/dbg-macro/xmake.lua
+++ b/packages/d/dbg-macro/xmake.lua
@@ -6,6 +6,7 @@ package("dbg-macro")
 
     add_urls("https://github.com/sharkdp/dbg-macro/archive/refs/tags/$(version).tar.gz",
              "https://github.com/sharkdp/dbg-macro.git")
+    add_versions("v0.5.1", "fffea75f067c69995853dc790626887788e2c4c9eb0a5a0014a4501d2b6b9909")
     add_versions("v0.4.0", "e44a1206fbfd1d3dc8ad649f387df479d288b08c80cf2f1239ccb4e26148d781")
     add_versions("v0.5.0", "dac4907aadf39dbd9eac279a214c59ad30af6c0c3d585688242f73cb1a9ce243")
 


### PR DESCRIPTION
New version of dbg-macro detected (package version: nil, last github version: v0.5.1)