### PR TITLE
Auto-update c-blosc2 to v2.13.2

### DIFF
--- a/packages/c/c-blosc2/xmake.lua
+++ b/packages/c/c-blosc2/xmake.lua
@@ -6,6 +6,7 @@ package("c-blosc2")
     add_urls("https://github.com/Blosc/c-blosc2/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Blosc/c-blosc2.git")
 
+    add_versions("v2.13.2", "f2adcd9615f138d1bb16dc27feadab1bb1eab01d77e5e2323d14ad4ca8c3ca21")
     add_versions("v2.10.2", "069785bc14c006c7dab40ea0c620bdf3eb8752663fd55c706d145bceabc2a31d")
 
     add_configs("lz4", {description = "Enable LZ4 support.", default = true, type = "boolean"})


### PR DESCRIPTION
New version of c-blosc2 detected (package version: nil, last github version: v2.13.2)