### PR TITLE
Auto-update aws-c-io to v0.14.5

### DIFF
--- a/packages/a/aws-c-io/xmake.lua
+++ b/packages/a/aws-c-io/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-io")
     add_urls("https://github.com/awslabs/aws-c-io/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-io.git")
 
+    add_versions("v0.14.5", "2700bcde062f7de1c1cbfd236b9fdfc9b24b4aa6dc0fb09bb156e16e07ebd0b6")
     add_versions("v0.13.32", "2a6b18c544d014ca4f55cb96002dbbc1e52a2120541c809fa974cb0838ea72cc")
 
     add_configs("asan", {description = "Enable Address Sanitize.", default = false, type = "boolean"})


### PR DESCRIPTION
New version of aws-c-io detected (package version: nil, last github version: v0.14.5)