### PR TITLE
Auto-update coost to v3.0.2

### DIFF
--- a/packages/c/coost/xmake.lua
+++ b/packages/c/coost/xmake.lua
@@ -5,6 +5,7 @@ package("coost")
     add_urls("https://github.com/idealvin/coost/archive/refs/tags/$(version).tar.gz",
              "https://github.com/idealvin/coost.git")
 
+    add_versions("v3.0.2", "922ba21fb9a922c84f6a4b3bd568ed3b3463ccb1ae906cd7c49d90c7f0359b24")
     add_versions("v3.0.1", "f2285d59dc8317dd2494d7628a56f10de9b814d90b86aedf93a3305f94c6ae1a")
     add_versions("v3.0.0", "f962201201cd77aaf45f33d72bd012231a31d4310d30e9bb580ffb1e94c8148d")
 

--- a/packages/c/coost/xmake.lua
+++ b/packages/c/coost/xmake.lua
@@ -1,6 +1,7 @@
 package("coost")
     set_homepage("https://github.com/idealvin/coost")
     set_description("A tiny boost library in C++11.")
+    set_license("MIT")
 
     add_urls("https://github.com/idealvin/coost/archive/refs/tags/$(version).tar.gz",
              "https://github.com/idealvin/coost.git")
@@ -8,6 +9,8 @@ package("coost")
     add_versions("v3.0.2", "922ba21fb9a922c84f6a4b3bd568ed3b3463ccb1ae906cd7c49d90c7f0359b24")
     add_versions("v3.0.1", "f2285d59dc8317dd2494d7628a56f10de9b814d90b86aedf93a3305f94c6ae1a")
     add_versions("v3.0.0", "f962201201cd77aaf45f33d72bd012231a31d4310d30e9bb580ffb1e94c8148d")
+
+    add_patches("3.0.2", "https://github.com/idealvin/coost/commit/c9488af72e9086ef1d910e29f9efa4b4210a5190.patch", "837feb2b49dc5d162f27175627689680a61e54e761dcf972f0e27896249addc6")
 
     for _, name in ipairs({"libcurl", "openssl", "libbacktrace"}) do
         local default = false


### PR DESCRIPTION
New version of coost detected (package version: nil, last github version: v3.0.2)