### PR TITLE
Auto-update partio to v1.17.3

### DIFF
--- a/packages/p/partio/xmake.lua
+++ b/packages/p/partio/xmake.lua
@@ -6,6 +6,7 @@ package("partio")
 
     add_urls("https://github.com/wdas/partio/archive/refs/tags/$(version).tar.gz",
              "https://github.com/wdas/partio.git")
+    add_versions("v1.17.3", "08a571ca75cf133f373415dfd50b7d0e33a0dd1811dfb63409f0ae46652033c1")
     add_versions("v1.14.0", "f98874b781e92ab9b5d0575cabc437d27274cd91cb581f80960918efa491f902")
     add_versions("v1.14.6", "53a5754d6b2fc3e184953d985c233118ef0ab87169f34e3aec4a7e6d20cd9bd4")
     add_versions("v1.17.1", "5d00fbfc55817acb310bcaf61212a78b2c602e08b839060dfee69570b4b82464")


### PR DESCRIPTION
New version of partio detected (package version: nil, last github version: v1.17.3)