### PR TITLE
Auto-update yoga to v3.0.0

### DIFF
--- a/packages/y/yoga/xmake.lua
+++ b/packages/y/yoga/xmake.lua
@@ -6,6 +6,7 @@ package("yoga")
     add_urls("https://github.com/facebook/yoga/archive/refs/tags/$(version).tar.gz",
              "https://github.com/facebook/yoga.git")
 
+    add_versions("v3.0.0", "da4739061315fd5b6442e0658c2541db24ded359f41525359d5e61edb2f45297")
     add_versions("v2.0.1", "4c80663b557027cdaa6a836cc087d735bb149b8ff27cbe8442fc5e09cec5ed92")
 
     add_configs("shared", {description = "Build shared binaries", default = false, type = "boolean", readonly = true})


### PR DESCRIPTION
New version of yoga detected (package version: nil, last github version: v3.0.0)