### PR TITLE
wasm-micro-runtime: refractor build script

### DIFF
--- a/packages/w/wasm-micro-runtime/patches/1.2.3/cmake.patch
+++ b/packages/w/wasm-micro-runtime/patches/1.2.3/cmake.patch
@@ -1,0 +1,84 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fbea2616..cf54b968 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -108,16 +108,12 @@ endif ()
+ set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+ 
+ # Set the strip command based on the system (GNU or Clang)
+-if (CMAKE_STRIP)
+-    set (CMAKE_STRIP_FLAGS "--strip-all")
+-endif ()
++
+ 
+ include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
+ 
+-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow -Wno-unused-parameter")
+ # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
+ 
+-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wno-unused")
+ 
+ if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
+   if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
+@@ -134,42 +130,35 @@ endif ()
+ #set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-z,noexecstack,-z,relro,-z,now")
+ 
+ include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
+-
++if (NOT BUILD_SHARED_LIBS)
+ # STATIC LIBRARY
+ add_library(iwasm_static STATIC ${WAMR_RUNTIME_LIB_SOURCE})
+ set_target_properties (iwasm_static PROPERTIES OUTPUT_NAME vmlib)
+ target_include_directories(iwasm_static INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
+-target_link_libraries (iwasm_static INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
++target_link_libraries (iwasm_static INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
+ if (WAMR_BUILD_WASM_CACHE EQUAL 1)
+   target_link_libraries(iwasm_static INTERFACE boringssl_crypto)
+ endif ()
+ 
+ install (TARGETS iwasm_static ARCHIVE DESTINATION lib)
+ 
+-# If it's a Release build, strip the static library
+-if (CMAKE_STRIP AND CMAKE_BUILD_TYPE STREQUAL "Release")
+-  # Strip static library
+-  message (STATUS "Stripping static library after build!")
+-  add_custom_command (TARGET iwasm_static POST_BUILD
+-      COMMAND ${CMAKE_STRIP} ${CMAKE_STRIP_FLAGS} $<TARGET_FILE:iwasm_static>
+-  )
+-endif ()
++else ()
+ 
+ # SHARED LIBRARY
+ add_library (iwasm_shared SHARED ${WAMR_RUNTIME_LIB_SOURCE})
+ set_target_properties (iwasm_shared PROPERTIES OUTPUT_NAME iwasm)
+ target_include_directories(iwasm_shared INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
+-target_link_libraries (iwasm_shared INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
++target_link_libraries (iwasm_shared INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
+ if (WAMR_BUILD_WASM_CACHE EQUAL 1)
+   target_link_libraries(iwasm_shared INTERFACE boringssl_crypto)
+ endif ()
+-
++target_link_libraries (iwasm_shared ntdll)
+ if (MINGW)
+   target_link_libraries (iwasm_shared -lWs2_32)
+ endif ()
+ 
+ install (TARGETS iwasm_shared LIBRARY DESTINATION lib)
+-
++endif ()
+ # HEADERS
+ install (FILES
+     ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_c_api.h
+@@ -177,11 +166,4 @@ install (FILES
+     ${WAMR_ROOT_DIR}/core/iwasm/include/lib_export.h
+     DESTINATION include)
+ 
+-# If it's a Release build, strip the shared library
+-if (CMAKE_STRIP AND CMAKE_BUILD_TYPE STREQUAL "Release")
+-  # Strip shared library
+-  message (STATUS "Stripping shared library after build!")
+-  add_custom_command (TARGET iwasm_shared POST_BUILD
+-      COMMAND ${CMAKE_STRIP} ${CMAKE_STRIP_FLAGS} $<TARGET_FILE:iwasm_shared>
+-  )
+-endif ()
++

--- a/packages/w/wasm-micro-runtime/patches/1.2.3/cmake.patch
+++ b/packages/w/wasm-micro-runtime/patches/1.2.3/cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fbea2616..cf54b968 100644
+index fbea2616..a1952ca8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -108,16 +108,12 @@ endif ()
@@ -20,7 +20,7 @@ index fbea2616..cf54b968 100644
  
  if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
    if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
-@@ -134,42 +130,35 @@ endif ()
+@@ -134,42 +130,37 @@ endif ()
  #set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-z,noexecstack,-z,relro,-z,now")
  
  include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
@@ -58,7 +58,9 @@ index fbea2616..cf54b968 100644
    target_link_libraries(iwasm_shared INTERFACE boringssl_crypto)
  endif ()
 -
++if (WIN32)
 +target_link_libraries (iwasm_shared ntdll)
++endif ()
  if (MINGW)
    target_link_libraries (iwasm_shared -lWs2_32)
  endif ()
@@ -69,7 +71,7 @@ index fbea2616..cf54b968 100644
  # HEADERS
  install (FILES
      ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_c_api.h
-@@ -177,11 +166,4 @@ install (FILES
+@@ -177,11 +168,4 @@ install (FILES
      ${WAMR_ROOT_DIR}/core/iwasm/include/lib_export.h
      DESTINATION include)
  

--- a/packages/w/wasm-micro-runtime/patches/1.2.3/cmake.patch
+++ b/packages/w/wasm-micro-runtime/patches/1.2.3/cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fbea2616..aec8194b 100644
+index fbea2616..a1952ca8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -108,16 +108,12 @@ endif ()
@@ -31,10 +31,9 @@ index fbea2616..aec8194b 100644
  set_target_properties (iwasm_static PROPERTIES OUTPUT_NAME vmlib)
  target_include_directories(iwasm_static INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
 -target_link_libraries (iwasm_static INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
-+target_link_libraries (iwasm_static PRIVATE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
++target_link_libraries (iwasm_static INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
  if (WAMR_BUILD_WASM_CACHE EQUAL 1)
--  target_link_libraries(iwasm_static INTERFACE boringssl_crypto)
-+  target_link_libraries(iwasm_static PRIVATE boringssl_crypto)
+   target_link_libraries(iwasm_static INTERFACE boringssl_crypto)
  endif ()
  
  install (TARGETS iwasm_static ARCHIVE DESTINATION lib)
@@ -54,15 +53,14 @@ index fbea2616..aec8194b 100644
  set_target_properties (iwasm_shared PROPERTIES OUTPUT_NAME iwasm)
  target_include_directories(iwasm_shared INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
 -target_link_libraries (iwasm_shared INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
-+target_link_libraries (iwasm_shared PRIVATE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
++target_link_libraries (iwasm_shared INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
  if (WAMR_BUILD_WASM_CACHE EQUAL 1)
--  target_link_libraries(iwasm_shared INTERFACE boringssl_crypto)
-+  target_link_libraries(iwasm_shared PRIVATE boringssl_crypto)
-+endif ()
-+if (WIN32)
-+target_link_libraries (iwasm_shared ntdll)
+   target_link_libraries(iwasm_shared INTERFACE boringssl_crypto)
  endif ()
 -
++if (WIN32)
++target_link_libraries (iwasm_shared ntdll)
++endif ()
  if (MINGW)
    target_link_libraries (iwasm_shared -lWs2_32)
  endif ()

--- a/packages/w/wasm-micro-runtime/patches/1.2.3/cmake.patch
+++ b/packages/w/wasm-micro-runtime/patches/1.2.3/cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fbea2616..a1952ca8 100644
+index fbea2616..aec8194b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -108,16 +108,12 @@ endif ()
@@ -31,9 +31,10 @@ index fbea2616..a1952ca8 100644
  set_target_properties (iwasm_static PROPERTIES OUTPUT_NAME vmlib)
  target_include_directories(iwasm_static INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
 -target_link_libraries (iwasm_static INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
-+target_link_libraries (iwasm_static INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
++target_link_libraries (iwasm_static PRIVATE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
  if (WAMR_BUILD_WASM_CACHE EQUAL 1)
-   target_link_libraries(iwasm_static INTERFACE boringssl_crypto)
+-  target_link_libraries(iwasm_static INTERFACE boringssl_crypto)
++  target_link_libraries(iwasm_static PRIVATE boringssl_crypto)
  endif ()
  
  install (TARGETS iwasm_static ARCHIVE DESTINATION lib)
@@ -53,14 +54,15 @@ index fbea2616..a1952ca8 100644
  set_target_properties (iwasm_shared PROPERTIES OUTPUT_NAME iwasm)
  target_include_directories(iwasm_shared INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
 -target_link_libraries (iwasm_shared INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
-+target_link_libraries (iwasm_shared INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
++target_link_libraries (iwasm_shared PRIVATE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
  if (WAMR_BUILD_WASM_CACHE EQUAL 1)
-   target_link_libraries(iwasm_shared INTERFACE boringssl_crypto)
- endif ()
--
+-  target_link_libraries(iwasm_shared INTERFACE boringssl_crypto)
++  target_link_libraries(iwasm_shared PRIVATE boringssl_crypto)
++endif ()
 +if (WIN32)
 +target_link_libraries (iwasm_shared ntdll)
-+endif ()
+ endif ()
+-
  if (MINGW)
    target_link_libraries (iwasm_shared -lWs2_32)
  endif ()

--- a/packages/w/wasm-micro-runtime/patches/1.3.2/cmake.patch
+++ b/packages/w/wasm-micro-runtime/patches/1.3.2/cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1c879949..7655a215 100644
+index 1c879949..8f8a73c7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -109,10 +109,8 @@ set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
@@ -13,7 +13,7 @@ index 1c879949..7655a215 100644
  
  if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
    if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
-@@ -131,31 +129,32 @@ endif ()
+@@ -131,31 +129,34 @@ endif ()
  include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
  
  # STATIC LIBRARY
@@ -40,7 +40,9 @@ index 1c879949..7655a215 100644
    target_link_libraries(iwasm_shared INTERFACE boringssl_crypto)
  endif ()
 -
-+target_link_libraries (iwasm_shared ntdll)
++if (WIN32)
++  target_link_libraries (iwasm_shared ntdll)
++endif ()
  if (MINGW)
    target_link_libraries (iwasm_shared -lWs2_32)
  endif ()

--- a/packages/w/wasm-micro-runtime/patches/1.3.2/cmake.patch
+++ b/packages/w/wasm-micro-runtime/patches/1.3.2/cmake.patch
@@ -1,0 +1,53 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1c879949..7655a215 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -109,10 +109,8 @@ set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+ 
+ include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
+ 
+-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wshadow -Wno-unused-parameter")
+ # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wsign-conversion")
+ 
+-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat -Wformat-security -Wno-unused")
+ 
+ if (WAMR_BUILD_TARGET MATCHES "X86_.*" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
+   if (NOT (CMAKE_C_COMPILER MATCHES ".*clang.*" OR CMAKE_C_COMPILER_ID MATCHES ".*Clang"))
+@@ -131,31 +129,32 @@ endif ()
+ include (${SHARED_DIR}/utils/uncommon/shared_uncommon.cmake)
+ 
+ # STATIC LIBRARY
++if (NOT BUILD_SHARED_LIBS)
+ add_library(iwasm_static STATIC ${WAMR_RUNTIME_LIB_SOURCE})
+ set_target_properties (iwasm_static PROPERTIES OUTPUT_NAME vmlib)
+ target_include_directories(iwasm_static INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
+-target_link_libraries (iwasm_static INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
++target_link_libraries (iwasm_static INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
+ if (WAMR_BUILD_WASM_CACHE EQUAL 1)
+   target_link_libraries(iwasm_static INTERFACE boringssl_crypto)
+ endif ()
+ 
+ install (TARGETS iwasm_static ARCHIVE DESTINATION lib)
+-
++else ()
+ # SHARED LIBRARY
+ add_library (iwasm_shared SHARED ${WAMR_RUNTIME_LIB_SOURCE})
+ set_target_properties (iwasm_shared PROPERTIES OUTPUT_NAME iwasm)
+ target_include_directories(iwasm_shared INTERFACE ${WAMR_ROOT_DIR}/core/iwasm/include)
+-target_link_libraries (iwasm_shared INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
++target_link_libraries (iwasm_shared INTERFACE ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS})
+ if (WAMR_BUILD_WASM_CACHE EQUAL 1)
+   target_link_libraries(iwasm_shared INTERFACE boringssl_crypto)
+ endif ()
+-
++target_link_libraries (iwasm_shared ntdll)
+ if (MINGW)
+   target_link_libraries (iwasm_shared -lWs2_32)
+ endif ()
+ 
+ install (TARGETS iwasm_shared LIBRARY DESTINATION lib)
+-
++endif ()
+ # HEADERS
+ install (FILES
+     ${WAMR_ROOT_DIR}/core/iwasm/include/wasm_c_api.h

--- a/packages/w/wasm-micro-runtime/patches/libc_uvwasi.patch
+++ b/packages/w/wasm-micro-runtime/patches/libc_uvwasi.patch
@@ -1,0 +1,53 @@
+diff --git a/core/iwasm/libraries/libc-uvwasi/libc_uvwasi.cmake b/core/iwasm/libraries/libc-uvwasi/libc_uvwasi.cmake
+index 7a3bfbdc..3c8c4b19 100644
+--- a/core/iwasm/libraries/libc-uvwasi/libc_uvwasi.cmake
++++ b/core/iwasm/libraries/libc-uvwasi/libc_uvwasi.cmake
+@@ -12,48 +12,6 @@ include(FetchContent)
+ # Point CMake at the custom modules to find libuv and uvwasi
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+ 
+-## libuv
+-find_package(LIBUV QUIET)
+-if (LIBUV_FOUND)
+-    include_directories(${LIBUV_INCLUDE_DIR})
+-else()
+-    FetchContent_Declare(
+-        libuv
+-        GIT_REPOSITORY https://github.com/libuv/libuv.git
+-        GIT_TAG ${LIBUV_VERSION}
+-    )
+-    FetchContent_GetProperties(libuv)
+-    if (NOT libuv_POPULATED)
+-        message("-- Fetching libuv ..")
+-        FetchContent_Populate(libuv)
+-        include_directories("${libuv_SOURCE_DIR}/include")
+-        add_subdirectory(${libuv_SOURCE_DIR} ${libuv_BINARY_DIR} EXCLUDE_FROM_ALL)
+-        set (LIBUV_LIBRARIES uv_a)
+-        set_target_properties(uv_a PROPERTIES POSITION_INDEPENDENT_CODE 1)
+-    endif()
+-endif()
+-
+-## uvwasi
+-find_package(UVWASI QUIET)
+-if (UVWASI_FOUND)
+-    include_directories(${UVWASI_INCLUDE_DIR})
+-else()
+-    FetchContent_Declare(
+-        uvwasi
+-        GIT_REPOSITORY https://github.com/nodejs/uvwasi.git
+-        GIT_TAG main
+-    )
+-    FetchContent_GetProperties(uvwasi)
+-    if (NOT uvwasi_POPULATED)
+-        message("-- Fetching uvwasi ..")
+-        FetchContent_Populate(uvwasi)
+-        include_directories("${uvwasi_SOURCE_DIR}/include")
+-        add_subdirectory(${uvwasi_SOURCE_DIR} ${uvwasi_BINARY_DIR} EXCLUDE_FROM_ALL)
+-        set (UVWASI_LIBRARIES uvwasi_a)
+-        set_target_properties(uvwasi_a PROPERTIES POSITION_INDEPENDENT_CODE 1)
+-    endif()
+-endif()
+-
+ set (UV_A_LIBS ${LIBUV_LIBRARIES} ${UVWASI_LIBRARIES})
+ 
+ file (GLOB_RECURSE source_all ${LIBC_WASI_DIR}/*.c)

--- a/packages/w/wasm-micro-runtime/patches/ntapi.patch
+++ b/packages/w/wasm-micro-runtime/patches/ntapi.patch
@@ -1,0 +1,36 @@
+diff --git a/core/shared/platform/windows/win_clock.c b/core/shared/platform/windows/win_clock.c
+index c96bdfb3..48e2c449 100644
+--- a/core/shared/platform/windows/win_clock.c
++++ b/core/shared/platform/windows/win_clock.c
+@@ -55,14 +55,30 @@ os_clock_res_get(__wasi_clockid_t clock_id, __wasi_timestamp_t *resolution)
+         case __WASI_CLOCK_THREAD_CPUTIME_ID:
+         {
+ #if WINAPI_PARTITION_DESKTOP
++            HMODULE ntdll = LoadLibrary("ntdll.dll");
++            if (!ntdll) {
++                return __WASI_ENOTSUP;
++            }
++
++            typedef NTSTATUS(NTAPI *LPFN_NtQueryTimerResolution)(
++                OUT PULONG MinimumResolution,
++                OUT PULONG MaximumResolution,
++                OUT PULONG CurrentResolution
++            );
++            LPFN_NtQueryTimerResolution pNtQueryTimerResolution = (LPFN_NtQueryTimerResolution)GetProcAddress(ntdll, "NtQueryTimerResolution");
++            if (!pNtQueryTimerResolution) {
++                return __WASI_ENOTSUP;
++            }
++
+             ULONG maximum_time;
+             ULONG minimum_time;
+             ULONG current_time;
+             NTSTATUS
+-            status = NtQueryTimerResolution(&maximum_time, &minimum_time,
++            status = pNtQueryTimerResolution(&maximum_time, &minimum_time,
+                                             &current_time);
+             uint64 result = (uint64)current_time * NANOSECONDS_PER_TICK;
+             *resolution = result / (uint64)NANOSECONDS_PER_SECOND;
++            FreeLibrary(ntdll);
+             return error;
+ #else
+             return __WASI_ENOTSUP;

--- a/packages/w/wasm-micro-runtime/xmake.lua
+++ b/packages/w/wasm-micro-runtime/xmake.lua
@@ -24,7 +24,7 @@ package("wasm-micro-runtime")
     add_configs("libc", {description = "Choose libc", default = "builtin", type = "string", values = {"builtin", "wasi", "uvwasi"}})
     add_configs("libc_builtin", {description = "Enable builtin libc", default = false, type = "boolean"})
     add_configs("libc_wasi", {description = "Enable wasi libc", default = false, type = "boolean"})
-    add_configs("libc_uvwasi", {description = "Enable uvwasi libc", default = true, type = "boolean"})
+    add_configs("libc_uvwasi", {description = "Enable uvwasi libc", default = false, type = "boolean"})
     add_configs("multi_module", {description = "Enable multiple modules", default = false, type = "boolean"})
     add_configs("mini_loader", {description = "Enable wasm mini loader", default = false, type = "boolean"})
     add_configs("wasi_threads", {description = "Enable wasi threads library", default = false, type = "boolean"})
@@ -53,10 +53,7 @@ package("wasm-micro-runtime")
     end)
 
     on_install("windows", "linux", "macosx", "bsd", "android", function (package)
-        local configs = {}
-        if package:version():lt("1.3.2") and package:is_plat("windows", "android") then
-            table.insert(configs, "-DWAMR_BUILD_INVOKE_NATIVE_GENERAL=1")
-        end
+        local configs = {"-DWAMR_BUILD_INVOKE_NATIVE_GENERAL=1"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         if package:is_plat("windows") and (not package:config("shared")) then

--- a/packages/w/wasm-micro-runtime/xmake.lua
+++ b/packages/w/wasm-micro-runtime/xmake.lua
@@ -40,6 +40,9 @@ package("wasm-micro-runtime")
     add_deps("cmake")
 
     on_load(function (package)
+        if package:is_plat("windows") and winos.version():le("10.0.17763") then
+            package:add("patches", "1.3.2", path.join(os.scriptdir(), "patches", "ntapi.patch"), "436c3f6bbb536a362e277d654ef8dc74e0d757dd815de2d89209bd2a9ac2f114")
+        end
         if package:config("libc_uvwasi") or package:config("libc") == "uvwasi" then
             if package:is_plat("windows", "linux", "macosx") then
                 package:add("deps", "uvwasi")

--- a/packages/w/wasm-micro-runtime/xmake.lua
+++ b/packages/w/wasm-micro-runtime/xmake.lua
@@ -6,15 +6,14 @@ package("wasm-micro-runtime")
     add_urls("https://github.com/bytecodealliance/wasm-micro-runtime/archive/refs/tags/WAMR-$(version).tar.gz", {excludes = {"*/language-bindings/python/LICENSE"}})
     add_urls("https://github.com/bytecodealliance/wasm-micro-runtime.git")
 
-    -- add_versions("1.3.2", "58961ba387ed66ace2dd903597f1670a42b8154a409757ae6f06f43fe867a98c")
+    add_versions("1.3.2", "58961ba387ed66ace2dd903597f1670a42b8154a409757ae6f06f43fe867a98c")
     add_versions("1.2.3", "85057f788630dc1b8c371f5443cc192627175003a8ea63c491beaff29a338346")
 
-    -- add_patches("1.3.2", path.join(os.scriptdir(), "patches", "1.3.2", "cmake.patch"), "cf0e992bdf3fe03f7dc03624fd757444291a5286b1ceef6532bbf3f9567f394b")
-    add_patches("1.2.3", path.join(os.scriptdir(), "patches", "1.2.3", "cmake.patch"), "5e061812f637bb83d96a878d058b5e19165a3d3846fa6f9684a811d0fd326e9a")
+    add_patches("1.3.2", path.join(os.scriptdir(), "patches", "1.3.2", "cmake.patch"), "cf0e992bdf3fe03f7dc03624fd757444291a5286b1ceef6532bbf3f9567f394b")
+    add_patches("1.2.3", path.join(os.scriptdir(), "patches", "1.2.3", "cmake.patch"), "97d99509997b86d24a84cd1b2eca0d4dace7b460d5cb85bc23881d02e7ef08ed")
 
-    if is_plat("windows", "linux", "macosx") then
-        add_patches("1.2.3", path.join(os.scriptdir(), "patches", "libc_uvwasi.patch"), "e83ff42588cc112588c7fde48a1bd9df7ffa8fa41f70dd99af5d6b0325ce46f7")
-    end
+    add_patches("1.3.2", path.join(os.scriptdir(), "patches", "libc_uvwasi.patch"), "e83ff42588cc112588c7fde48a1bd9df7ffa8fa41f70dd99af5d6b0325ce46f7")
+    add_patches("1.2.3", path.join(os.scriptdir(), "patches", "libc_uvwasi.patch"), "e83ff42588cc112588c7fde48a1bd9df7ffa8fa41f70dd99af5d6b0325ce46f7")
 
     add_configs("interp", {description = "Enable interpreter", default = true, type = "boolean"})
     add_configs("fast_interp", {description = "Enable fast interpreter", default = false, type = "boolean"})
@@ -44,6 +43,8 @@ package("wasm-micro-runtime")
         if package:config("libc_uvwasi") or package:config("libc") == "uvwasi" then
             if package:is_plat("windows", "linux", "macosx") then
                 package:add("deps", "uvwasi")
+            else
+                raise("xrepo(uvwasi) only support windows/linux/macosx")
             end
         end
         if package:config("jit", "fast_jit") then

--- a/packages/w/wasm-micro-runtime/xmake.lua
+++ b/packages/w/wasm-micro-runtime/xmake.lua
@@ -10,7 +10,7 @@ package("wasm-micro-runtime")
     add_versions("1.2.3", "85057f788630dc1b8c371f5443cc192627175003a8ea63c491beaff29a338346")
 
     -- add_patches("1.3.2", path.join(os.scriptdir(), "patches", "1.3.2", "cmake.patch"), "cf0e992bdf3fe03f7dc03624fd757444291a5286b1ceef6532bbf3f9567f394b")
-    add_patches("1.2.3", path.join(os.scriptdir(), "patches", "1.2.3", "cmake.patch"), "aea0f01a4e1df3fe6f6faa6191fbf9f017bfe5b0dbd0d08b9c0789ad5b096068")
+    add_patches("1.2.3", path.join(os.scriptdir(), "patches", "1.2.3", "cmake.patch"), "97d99509997b86d24a84cd1b2eca0d4dace7b460d5cb85bc23881d02e7ef08ed")
 
     add_patches("1.2.3", path.join(os.scriptdir(), "patches", "libc_uvwasi.patch"), "e83ff42588cc112588c7fde48a1bd9df7ffa8fa41f70dd99af5d6b0325ce46f7")
 

--- a/packages/w/wasm-micro-runtime/xmake.lua
+++ b/packages/w/wasm-micro-runtime/xmake.lua
@@ -3,10 +3,16 @@ package("wasm-micro-runtime")
     set_description("WebAssembly Micro Runtime (WAMR)")
     set_license("Apache-2.0")
 
-    add_urls("https://github.com/bytecodealliance/wasm-micro-runtime/archive/refs/tags/WAMR-$(version).tar.gz",
-             "https://github.com/bytecodealliance/wasm-micro-runtime.git")
+    add_urls("https://github.com/bytecodealliance/wasm-micro-runtime/archive/refs/tags/WAMR-$(version).tar.gz", {excludes = {"*/language-bindings/python/LICENSE"}})
+    add_urls("https://github.com/bytecodealliance/wasm-micro-runtime.git")
 
+    -- add_versions("1.3.2", "58961ba387ed66ace2dd903597f1670a42b8154a409757ae6f06f43fe867a98c")
     add_versions("1.2.3", "85057f788630dc1b8c371f5443cc192627175003a8ea63c491beaff29a338346")
+
+    -- add_patches("1.3.2", path.join(os.scriptdir(), "patches", "1.3.2", "cmake.patch"), "cf0e992bdf3fe03f7dc03624fd757444291a5286b1ceef6532bbf3f9567f394b")
+    add_patches("1.2.3", path.join(os.scriptdir(), "patches", "1.2.3", "cmake.patch"), "aea0f01a4e1df3fe6f6faa6191fbf9f017bfe5b0dbd0d08b9c0789ad5b096068")
+
+    add_patches("1.2.3", path.join(os.scriptdir(), "patches", "libc_uvwasi.patch"), "e83ff42588cc112588c7fde48a1bd9df7ffa8fa41f70dd99af5d6b0325ce46f7")
 
     add_configs("interp", {description = "Enable interpreter", default = true, type = "boolean"})
     add_configs("fast_interp", {description = "Enable fast interpreter", default = false, type = "boolean"})
@@ -15,6 +21,9 @@ package("wasm-micro-runtime")
     add_configs("jit", {description = "Enable JIT", default = false, type = "boolean", readonly = true})
     add_configs("fast_jit", {description = "Enable Fast JIT", default = false, type = "boolean", readonly = true})
     add_configs("libc", {description = "Choose libc", default = "builtin", type = "string", values = {"builtin", "wasi", "uvwasi"}})
+    add_configs("libc_builtin", {description = "Enable builtin libc", default = false, type = "boolean"})
+    add_configs("libc_wasi", {description = "Enable wasi libc", default = false, type = "boolean"})
+    add_configs("libc_uvwasi", {description = "Enable uvwasi libc", default = true, type = "boolean"})
     add_configs("multi_module", {description = "Enable multiple modules", default = false, type = "boolean"})
     add_configs("mini_loader", {description = "Enable wasm mini loader", default = false, type = "boolean"})
     add_configs("wasi_threads", {description = "Enable wasi threads library", default = false, type = "boolean"})
@@ -22,15 +31,15 @@ package("wasm-micro-runtime")
     add_configs("ref_types", {description = "Enable reference types", default = false, type = "boolean"})
 
     if is_plat("windows", "mingw") then
-        add_syslinks("ws2_32")
+        add_syslinks("ntdll", "ws2_32")
     elseif is_plat("linux", "bsd") then
-        add_syslinks("m", "pthread")
+        add_syslinks("m", "dl", "pthread")
     end
 
     add_deps("cmake")
 
     on_load(function (package)
-        if package:config("libc") == "uvwasi" then
+        if package:config("libc_uvwasi") or package:config("libc") == "uvwasi" then
             package:add("deps", "uvwasi")
         end
         if package:config("jit", "fast_jit") then
@@ -38,12 +47,12 @@ package("wasm-micro-runtime")
         end
     end)
 
-    on_install("windows|x64", "windows|x86", "linux", "macosx", "bsd", "android", function (package)
-        local configs = {}
+    on_install("windows", "linux", "macosx", "bsd", "android", function (package)
+        local configs = {"-DWAMR_BUILD_INVOKE_NATIVE_GENERAL=1"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if package:is_plat("windows") and package:config("shared") then
-            table.insert(configs, "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON")
+        if package:is_plat("windows") and (not package:config("shared")) then
+            package:add("defines", "COMPILING_WASM_RUNTIME_API=1")
         end
 
         table.insert(configs, "-DWAMR_BUILD_INTERP=" .. (package:config("interp") and "1" or "0"))
@@ -52,9 +61,9 @@ package("wasm-micro-runtime")
         table.insert(configs, "-DWAMR_BUILD_JIT=" .. (package:config("jit") and "1" or "0"))
         table.insert(configs, "-DWAMR_BUILD_FAST_JIT=" .. (package:config("fast_jit") and "1" or "0"))
 
-        table.insert(configs, "-DWAMR_BUILD_LIBC_BUILTIN=" .. ((package:config("libc") == "builtin") and "1" or "0"))
-        table.insert(configs, "-DWAMR_BUILD_LIBC_WASI=" .. ((package:config("libc") == "wasi") and "1" or "0"))
-        table.insert(configs, "-DWAMR_BUILD_LIBC_UVWASI=" .. ((package:config("libc") == "uvwasi") and "1" or "0"))
+        table.insert(configs, "-DWAMR_BUILD_LIBC_BUILTIN=" .. (package:config("libc_builtin") and "1" or "0"))
+        table.insert(configs, "-DWAMR_BUILD_LIBC_WASI=" .. (package:config("libc_wasi") and "1" or "0"))
+        table.insert(configs, "-DWAMR_BUILD_LIBC_UVWASI=" .. (package:config("libc_uvwasi") and "1" or "0"))
 
         table.insert(configs, "-DWAMR_BUILD_MULTI_MODULE=" .. (package:config("multi_module") and "1" or "0"))
         table.insert(configs, "-DWAMR_BUILD_MINI_LOADER=" .. (package:config("mini_loader") and "1" or "0"))
@@ -62,28 +71,13 @@ package("wasm-micro-runtime")
         table.insert(configs, "-DWAMR_BUILD_SIMD=" .. (package:config("simd") and "1" or "0"))
         table.insert(configs, "-DWAMR_BUILD_REF_TYPES=" .. (package:config("ref_types") and "1" or "0"))
 
-        local plat
-        if package:is_plat("windows", "mingw") then
-            plat = "windows"
-        elseif package:is_plat("linux") then
-            plat = "linux"
-        elseif package:is_plat("macosx") then
-            plat = "darwin"
-        elseif package:is_plat("bsd") then
-            plat = "freebsd"
-        elseif package:is_plat("android") then
-            plat = "android"
-        elseif package:is_plat("iphoneos") then
-            plat = "ios"
+        local packagedeps
+        if package:config("libc_uvwasi") or package:config("libc") == "uvwasi" then
+            packagedeps = {"uvwasi", "libuv"}
         end
-
-        os.cp("core/iwasm/include", package:installdir())
-        os.cd("product-mini/platforms/" .. plat)
-        import("package.tools.cmake").install(package, configs)
-
-        os.trymv(package:installdir("lib", "*.dll"), package:installdir("bin"))
+        import("package.tools.cmake").install(package, configs, {packagedeps = packagedeps})
     end)
 
     on_test(function (package)
-        assert(package:has_cfuncs("wasm_engine_new", {includes = "wasm_c_api.h", {configs = {languages = "c99"}}}))
+        assert(package:has_cfuncs("wasm_engine_new", {includes = "wasm_c_api.h"}))
     end)

--- a/packages/w/wasm-micro-runtime/xmake.lua
+++ b/packages/w/wasm-micro-runtime/xmake.lua
@@ -52,7 +52,10 @@ package("wasm-micro-runtime")
     end)
 
     on_install("windows", "linux", "macosx", "bsd", "android", function (package)
-        local configs = {"-DWAMR_BUILD_INVOKE_NATIVE_GENERAL=1"}
+        local configs = {}
+        if package:version():lt("1.3.2") and package:is_plat("windows") then
+            table.insert(configs, "-DWAMR_BUILD_INVOKE_NATIVE_GENERAL=1")
+        end
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         if package:is_plat("windows") and (not package:config("shared")) then

--- a/packages/w/wasm-micro-runtime/xmake.lua
+++ b/packages/w/wasm-micro-runtime/xmake.lua
@@ -40,7 +40,7 @@ package("wasm-micro-runtime")
     add_deps("cmake")
 
     on_load(function (package)
-        if package:is_plat("windows") and winos.version():le("10.0.17763") then
+        if package:is_plat("windows") and package:is_arch("x86") and winos.version():le("10.0.17763") then
             package:add("patches", "1.3.2", path.join(os.scriptdir(), "patches", "ntapi.patch"), "436c3f6bbb536a362e277d654ef8dc74e0d757dd815de2d89209bd2a9ac2f114")
         end
         if package:config("libc_uvwasi") or package:config("libc") == "uvwasi" then

--- a/packages/w/wasm-micro-runtime/xmake.lua
+++ b/packages/w/wasm-micro-runtime/xmake.lua
@@ -79,6 +79,9 @@ package("wasm-micro-runtime")
             (package:config("libc_uvwasi") or package:config("libc") == "uvwasi") then
             packagedeps = {"uvwasi", "libuv"}
         end
+        if package:is_plat("android") then
+            table.insert(configs, "-DWAMR_BUILD_PLATFORM=android")
+        end
         import("package.tools.cmake").install(package, configs, {packagedeps = packagedeps})
     end)
 

--- a/packages/w/wasm-micro-runtime/xmake.lua
+++ b/packages/w/wasm-micro-runtime/xmake.lua
@@ -10,9 +10,11 @@ package("wasm-micro-runtime")
     add_versions("1.2.3", "85057f788630dc1b8c371f5443cc192627175003a8ea63c491beaff29a338346")
 
     -- add_patches("1.3.2", path.join(os.scriptdir(), "patches", "1.3.2", "cmake.patch"), "cf0e992bdf3fe03f7dc03624fd757444291a5286b1ceef6532bbf3f9567f394b")
-    add_patches("1.2.3", path.join(os.scriptdir(), "patches", "1.2.3", "cmake.patch"), "97d99509997b86d24a84cd1b2eca0d4dace7b460d5cb85bc23881d02e7ef08ed")
+    add_patches("1.2.3", path.join(os.scriptdir(), "patches", "1.2.3", "cmake.patch"), "5e061812f637bb83d96a878d058b5e19165a3d3846fa6f9684a811d0fd326e9a")
 
-    add_patches("1.2.3", path.join(os.scriptdir(), "patches", "libc_uvwasi.patch"), "e83ff42588cc112588c7fde48a1bd9df7ffa8fa41f70dd99af5d6b0325ce46f7")
+    if is_plat("windows", "linux", "macosx") then
+        add_patches("1.2.3", path.join(os.scriptdir(), "patches", "libc_uvwasi.patch"), "e83ff42588cc112588c7fde48a1bd9df7ffa8fa41f70dd99af5d6b0325ce46f7")
+    end
 
     add_configs("interp", {description = "Enable interpreter", default = true, type = "boolean"})
     add_configs("fast_interp", {description = "Enable fast interpreter", default = false, type = "boolean"})
@@ -23,7 +25,7 @@ package("wasm-micro-runtime")
     add_configs("libc", {description = "Choose libc", default = "builtin", type = "string", values = {"builtin", "wasi", "uvwasi"}})
     add_configs("libc_builtin", {description = "Enable builtin libc", default = false, type = "boolean"})
     add_configs("libc_wasi", {description = "Enable wasi libc", default = false, type = "boolean"})
-    add_configs("libc_uvwasi", {description = "Enable uvwasi libc", default = false, type = "boolean"})
+    add_configs("libc_uvwasi", {description = "Enable uvwasi libc", default = true, type = "boolean"})
     add_configs("multi_module", {description = "Enable multiple modules", default = false, type = "boolean"})
     add_configs("mini_loader", {description = "Enable wasm mini loader", default = false, type = "boolean"})
     add_configs("wasi_threads", {description = "Enable wasi threads library", default = false, type = "boolean"})
@@ -42,8 +44,6 @@ package("wasm-micro-runtime")
         if package:config("libc_uvwasi") or package:config("libc") == "uvwasi" then
             if package:is_plat("windows", "linux", "macosx") then
                 package:add("deps", "uvwasi")
-            else
-                raise("uvwasi only support windows/linux/macosx now!")
             end
         end
         if package:config("jit", "fast_jit") then
@@ -53,7 +53,7 @@ package("wasm-micro-runtime")
 
     on_install("windows", "linux", "macosx", "bsd", "android", function (package)
         local configs = {}
-        if package:version():lt("1.3.2") and package:is_plat("windows") then
+        if package:version():lt("1.3.2") and package:is_plat("windows", "android") then
             table.insert(configs, "-DWAMR_BUILD_INVOKE_NATIVE_GENERAL=1")
         end
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))


### PR DESCRIPTION
- Fix https://github.com/xmake-io/xmake-repo/issues/3380
- Fix static/shared build type (patch cmake)
- Support uvwasi on windows/linux/macosx (patch cmake)
- New version 1.3.2
