### PR TITLE
Auto-update effolkronium-random to v1.5.0

### DIFF
--- a/packages/e/effolkronium-random/xmake.lua
+++ b/packages/e/effolkronium-random/xmake.lua
@@ -6,6 +6,7 @@ package("effolkronium-random")
 
     add_urls("https://github.com/effolkronium/random/archive/refs/tags/$(version).tar.gz",
              "https://github.com/effolkronium/random.git")
+    add_versions("v1.5.0", "c05a042f8daf54913e3a836e10a213bbbeaf09a89630649bd0011fe65eff50d9")
     add_versions("v1.4.1", "ec6beb67496ad2ce722d311d3fa5efb7e847dac5fd1c16b8920b51562fe20f53")
 
     on_install(function (package)


### PR DESCRIPTION
New version of effolkronium-random detected (package version: nil, last github version: v1.5.0)