### PR TITLE
Auto-update hypre to v2.31.0

### DIFF
--- a/packages/h/hypre/xmake.lua
+++ b/packages/h/hypre/xmake.lua
@@ -5,6 +5,7 @@ package("hypre")
 
     add_urls("https://github.com/hypre-space/hypre/archive/refs/tags/$(version).tar.gz",
              "https://github.com/hypre-space/hypre.git")
+    add_versions("v2.31.0", "9a7916e2ac6615399de5010eb39c604417bb3ea3109ac90e199c5c63b0cb4334")
     add_versions("v2.30.0", "8e2af97d9a25bf44801c6427779f823ebc6f306438066bba7fcbc2a5f9b78421")
     add_versions("v2.20.0", "5be77b28ddf945c92cde4b52a272d16fb5e9a7dc05e714fc5765948cba802c01")
     add_versions("v2.23.0", "8a9f9fb6f65531b77e4c319bf35bfc9d34bf529c36afe08837f56b635ac052e2")


### PR DESCRIPTION
New version of hypre detected (package version: nil, last github version: v2.31.0)