### PR TITLE
Auto-update fluidsynth to v2.3.4

### DIFF
--- a/packages/f/fluidsynth/xmake.lua
+++ b/packages/f/fluidsynth/xmake.lua
@@ -6,6 +6,7 @@ package("fluidsynth")
 
     add_urls("https://github.com/FluidSynth/fluidsynth/archive/refs/tags/$(version).zip",
              "https://github.com/FluidSynth/fluidsynth.git")
+    add_versions("v2.3.4", "abb03ece76da37e471373f8a872c80f012fb758213affd40bf3d0b23c268efcf")
     add_versions("v2.3.3", "0ab6f1aae1c7652b9249de2d98070313f3083046fddd673277556f1cca65568e")
 
     if is_plat("windows", "macosx") then


### PR DESCRIPTION
New version of fluidsynth detected (package version: nil, last github version: v2.3.4)