### PR TITLE
Auto-update hlslpp to 3.4

### DIFF
--- a/packages/h/hlslpp/xmake.lua
+++ b/packages/h/hlslpp/xmake.lua
@@ -5,6 +5,7 @@ package("hlslpp")
     set_license("MIT")
 
     add_urls("https://github.com/redorav/hlslpp/archive/refs/tags/$(version).tar.gz")
+    add_versions("3.4", "14541f5350849f04785280add677d7ee4c9a224376e0644beb71318ef18f3531")
     add_versions("3.1", "6f933e43bf8150a41d76a188377e59007897dc87e96be30608e7f2007605d5c4")
     add_versions("3.2.3", "132149d25306cdc56a87c1d6a4a93d3200de4864b5d27d758d235ce4ace64498")
 


### PR DESCRIPTION
New version of hlslpp detected (package version: nil, last github version: 3.4)