### PR TITLE
Auto-update aws-c-sdkutils to v0.1.15

### DIFF
--- a/packages/a/aws-c-sdkutils/xmake.lua
+++ b/packages/a/aws-c-sdkutils/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-sdkutils")
     add_urls("https://github.com/awslabs/aws-c-sdkutils/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-sdkutils.git")
 
+    add_versions("v0.1.15", "15fa30b8b0a357128388f2f40ab0ba3df63742fd333cc2f89cb91a9169f03bdc")
     add_versions("v0.1.12", "c876c3ce2918f1181c24829f599c8f06e29733f0bd6556d4c4fb523390561316")
 
     add_configs("asan", {description = "Enable Address Sanitize.", default = false, type = "boolean"})

--- a/packages/a/aws-c-sdkutils/xmake.lua
+++ b/packages/a/aws-c-sdkutils/xmake.lua
@@ -19,7 +19,7 @@ package("aws-c-sdkutils")
     on_install("windows|x64", "windows|x86", "linux", "macosx", "bsd", "msys", "android", "iphoneos", "cross", "wasm", function (package)
         local aws_cmakedir = package:dep("aws-c-common"):installdir("lib", "cmake")
         local aws_c_common_configdir = package:dep("aws-c-common"):installdir("lib", "aws-c-common", "cmake")
-        if package:is_plat("windows") then
+        if is_host("windows") then
             aws_cmakedir = aws_cmakedir:gsub("\\", "/")
             aws_c_common_configdir = aws_c_common_configdir:gsub("\\", "/")
         end


### PR DESCRIPTION
New version of aws-c-sdkutils detected (package version: nil, last github version: v0.1.15)