### PR TITLE
Fix Clang errors with imgui

### DIFF
--- a/packages/i/imgui/port/xmake.lua
+++ b/packages/i/imgui/port/xmake.lua
@@ -1,6 +1,6 @@
 add_rules("mode.debug", "mode.release")
 add_rules("utils.install.cmake_importfiles")
-set_languages("cxx11")
+set_languages("cxx14")
 
 option("dx9",              {showmenu = true,  default = false})
 option("dx10",             {showmenu = true,  default = false})
@@ -129,7 +129,7 @@ target("imgui")
         add_files("backends/imgui_impl_win32.cpp")
         add_headerfiles("(backends/imgui_impl_win32.h)")
     end
-    
+
     if has_config("wgpu") then
         add_files("backends/imgui_impl_wgpu.cpp")
         add_headerfiles("(backends/imgui_impl_wgpu.h)")

--- a/packages/i/imgui/xmake.lua
+++ b/packages/i/imgui/xmake.lua
@@ -172,5 +172,5 @@ package("imgui")
                 ImGui::Render();
                 ImGui::DestroyContext();
             }
-        ]]}, {configs = {languages = "c++11"}, includes = includes}))
+        ]]}, {configs = {languages = "c++14"}, includes = includes}))
     end)


### PR DESCRIPTION
This is a similar problem to #1493. When using Clang on Windows with the Microsoft STL, imgui fails to install because it is set to compile with C++11 but some STL headers use C++14 features:

```
error: C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\utility:162:22: error: 'auto' return without trailing return type; deduced return types are a C++14 extension
  162 | _NODISCARD constexpr auto&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
      |                      ^
In file included from misc\cpp\imgui_stdlib.cpp:11:
In file included from misc\cpp\imgui_stdlib.h:12:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\string:10:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\xstring:14:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\xmemory:15:
if you want to get more verbose errors, please see:
  -> C:\Users\Aidan\AppData\Local\.xmake\cache\packages\2403\i\imgui\v1.90.3-docking\installdir.failed\logs\install.txt
error: install failed!
```

Configuration: `xmake f --toolchain=clang`

This patch updates imgui to compile with C++14 which fixes these errors.