### PR TITLE
Auto-update libsais to v2.8.0

### DIFF
--- a/packages/l/libsais/xmake.lua
+++ b/packages/l/libsais/xmake.lua
@@ -5,6 +5,7 @@ package("libsais")
 
     add_urls("https://github.com/IlyaGrebnov/libsais/archive/refs/tags/$(version).tar.gz",
              "https://github.com/IlyaGrebnov/libsais.git")
+    add_versions("v2.8.0", "71f608d1e2a28652e66076f42becc3bbd3e0c8a21ba11a4de226a51459e894a9")
     add_versions("v2.7.5", "613c597b64fb096738d4084e0f2eb3b490aded7295cffc7fb23bdccc30097ebf")
     add_versions("v2.7.3", "45d37dc12975c4d40db786f322cd6dcfd9f56a8f23741205fcd0fca6ec0bf246")
     add_versions("v2.7.1", "5f459ad90cd007c30aaefb7d122bba2a4307ea02915c56381be4b331cca92545")


### PR DESCRIPTION
New version of libsais detected (package version: nil, last github version: v2.8.0)