### PR TITLE
Add system include option for GLFW

### DIFF
--- a/packages/g/glfw/xmake.lua
+++ b/packages/g/glfw/xmake.lua
@@ -15,7 +15,7 @@ package("glfw")
     add_versions("3.3.9", "a7e7faef424fcb5f83d8faecf9d697a338da7f7a906fc1afbc0e1879ef31bd53")
     add_versions("3.4", "c038d34200234d071fae9345bc455e4a8f2f544ab60150765d7704e08f3dac01")
 
-    add_configs("glfw_include", {description = "Choose submodules enabled in glfw", default = "none", type = "string", values = {"none", "vulkan", "glu", "glext", "es2", "es3"}})
+    add_configs("glfw_include", {description = "Choose submodules enabled in glfw", default = "none", type = "string", values = {"none", "vulkan", "glu", "glext", "es2", "es3", "system"}})
     add_configs("x11", {description = "Build support for X11", default = is_plat("linux"), type = "boolean"})
     add_configs("wayland", {description = "Build support for Wayland", default = false, type = "boolean"})
 
@@ -36,7 +36,10 @@ package("glfw")
     end
 
     on_load(function (package)
-        package:add("defines", "GLFW_INCLUDE_" .. package:config("glfw_include"):upper())
+        local glfw_include = package:config("glfw_include")
+        if glfw_include ~= "system" then
+            package:add("defines", "GLFW_INCLUDE_" .. glfw_include:upper())
+        end
         if package:config("x11") then
             package:add("deps", "libx11", "libxrandr", "libxrender", "libxinerama", "libxfixes", "libxcursor", "libxi", "libxext")
         end


### PR DESCRIPTION
When no `GLFW_INCLUDE_` macro is defined, GLFW includes the OpenGL headers from the system. (https://www.glfw.org/docs/latest/build_guide.html#build_macros)