### PR TITLE
Auto-update tree-sitter to 0.22.2

### DIFF
--- a/packages/t/tree-sitter/xmake.lua
+++ b/packages/t/tree-sitter/xmake.lua
@@ -5,6 +5,7 @@ package("tree-sitter")
 
     add_urls("https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v$(version).zip")
 
+    add_versions("0.22.2", "df0cd4aacc53b6feb9519dd4b74a7a6c8b7f3f7381fcf7793250db3e5e63fb80")
     add_versions("0.21.0", "874794e6b3b985f7f9e87dfe29e4bfdbe5c0339e67740f35dfc4fa85804ba708")
 
     on_install(function(package)


### PR DESCRIPTION
New version of tree-sitter detected (package version: nil, last github version: 0.22.2)