### PR TITLE
Auto-update draco to 1.5.7

### DIFF
--- a/packages/d/draco/xmake.lua
+++ b/packages/d/draco/xmake.lua
@@ -6,6 +6,7 @@ package("draco")
 
     add_urls("https://github.com/google/draco/archive/refs/tags/$(version).tar.gz",
              "https://github.com/google/draco.git")
+    add_versions("1.5.7", "bf6b105b79223eab2b86795363dfe5e5356050006a96521477973aba8f036fe1")
     add_versions("1.4.1", "83aa5637d36a835103a61f96af7ff04c6d6528e643909466595d51ee715417a9")
     add_versions("1.5.0", "81a91dcc6f22170a37ef67722bb78d018e642963e6c56e373560445ce7468a20")
     add_versions("1.5.6", "2cc1f0904545e2a5d1f8fa060509e454bfd59363dff9263dbe0601571594279b")


### PR DESCRIPTION
New version of draco detected (package version: nil, last github version: 1.5.7)