### PR TITLE
Auto-update hffix to v1.4.0

### DIFF
--- a/packages/h/hffix/xmake.lua
+++ b/packages/h/hffix/xmake.lua
@@ -7,6 +7,7 @@ package("hffix")
 
     add_urls("https://github.com/jamesdbrock/hffix/archive/refs/tags/$(version).zip",
              "https://github.com/jamesdbrock/hffix.git")
+    add_versions("v1.4.0", "b0dd5dfc5892b7336304274a4334d849d5b6778f0de2f7c2728957cdf2d9beed")
     add_versions("v1.1.0", "7646ddb8ca19da31a8835b64493100a0f2239c28980f590918e0b5bfab4d736d")
 
     on_install("linux", "macosx", "bsd", function (package)


### PR DESCRIPTION
New version of hffix detected (package version: nil, last github version: v1.4.0)