### PR TITLE
bzip2 & brotli: Fix tests with ASan

### DIFF
--- a/packages/b/brotli/xmake.lua
+++ b/packages/b/brotli/xmake.lua
@@ -71,7 +71,21 @@ package("brotli")
 
     on_test(function(package)
         if not package:is_cross() then
-            os.vrun("brotli --version")
+            local envs
+            if package:is_plat("windows") then
+                import("core.tool.toolchain")
+                local msvc = toolchain.load("msvc")
+                if msvc and msvc:check() then
+                    envs = msvc:runenvs()
+                end
+            elseif package:is_plat("mingw") then
+                import("core.tool.toolchain")
+                local mingw = toolchain.load("mingw")
+                if mingw and mingw:check() then
+                    envs = mingw:runenvs()
+                end
+            end
+            os.vrunv("brotli", {"--version"}, envs)
         end
         assert(package:check_csnippets([[
             void test() {

--- a/packages/b/brotli/xmake.lua
+++ b/packages/b/brotli/xmake.lua
@@ -85,7 +85,7 @@ package("brotli")
                     envs = mingw:runenvs()
                 end
             end
-            os.vrunv("brotli", {"--version"}, envs)
+            os.vrunv("brotli", {"--version"}, {envs = envs})
         end
         assert(package:check_csnippets([[
             void test() {

--- a/packages/b/bzip2/xmake.lua
+++ b/packages/b/bzip2/xmake.lua
@@ -40,9 +40,9 @@ package("bzip2")
                     envs = mingw:runenvs()
                 end
             end
-            os.vrun("bunzip2 --help", {envs = envs})
-            os.vrun("bzcat --help", {envs = envs})
-            os.vrun("bzip2 --help", {envs = envs})
+            os.vrunv("bunzip2", {"--help"}, {envs = envs})
+            os.vrunv("bzcat", {"--help"}, {envs = envs})
+            os.vrunv("bzip2", {"--help"}, {envs = envs})
         end
 
         assert(package:has_cfuncs("BZ2_bzCompressInit", {includes = "bzlib.h"}))

--- a/packages/b/bzip2/xmake.lua
+++ b/packages/b/bzip2/xmake.lua
@@ -26,9 +26,23 @@ package("bzip2")
 
     on_test(function (package)
         if not package:is_cross() then
-            os.vrun("bunzip2 --help")
-            os.vrun("bzcat --help")
-            os.vrun("bzip2 --help")
+            local envs
+            if package:is_plat("windows") then
+                import("core.tool.toolchain")
+                local msvc = toolchain.load("msvc")
+                if msvc and msvc:check() then
+                    envs = msvc:runenvs()
+                end
+            elseif package:is_plat("mingw") then
+                import("core.tool.toolchain")
+                local mingw = toolchain.load("mingw")
+                if mingw and mingw:check() then
+                    envs = mingw:runenvs()
+                end
+            end
+            os.vrun("bunzip2 --help", {envs = envs})
+            os.vrun("bzcat --help", {envs = envs})
+            os.vrun("bzip2 --help", {envs = envs})
         end
 
         assert(package:has_cfuncs("BZ2_bzCompressInit", {includes = "bzlib.h"}))


### PR DESCRIPTION
I think this should be automated by xmake, but when building a lib with ASan and testing its binaries, it will fail on Windows:
```
install ok!
finding bzip2 from xmake ..
checking for xmake::bzip2 ... bzip2 1.0.8
{
  libfiles = {
    "C:\Users\lynix\AppData\Local\.xmake\packages\b\bzip2\1.0.8\83ee4cf31e5841d8a38c178e6ffab69b\lib\bz2.lib"
  },
  linkdirs = {
    "C:\Users\lynix\AppData\Local\.xmake\packages\b\bzip2\1.0.8\83ee4cf31e5841d8a38c178e6ffab69b\lib"
  },
  sysincludedirs = {
    "C:\Users\lynix\AppData\Local\.xmake\packages\b\bzip2\1.0.8\83ee4cf31e5841d8a38c178e6ffab69b\include"
  },
  version = "1.0.8",
  static = true,
  links = {
    "bz2"
  }
}

patching C:\Users\lynix\AppData\Local\.xmake\packages\b\bzip2\1.0.8\83ee4cf31e5841d8a38c178e6ffab69b\lib\pkgconfig\bzip2.pc ..
bunzip2 --help
error: @programdir\core\sandbox\modules\os.lua:337: exec(bunzip2 --help) failed(-1073741515)
stack traceback:
    [C]: in function 'error'
    [@programdir\core\base\os.lua:957]:
    [@programdir\core\sandbox\modules\os.lua:337]:
    [@programdir\core\sandbox\modules\os.lua:282]: in function 'vrun'
    [...xmake\repositories\xmake-repo\packages\b\bzip2\xmake.lua:29]: in function 'script'
    [...dir\modules\private\action\require\impl\utils\filter.lua:114]: in function 'call'
    [...dir\modules\private\action\require\impl\actions\test.lua:41]:
    [...\modules\private\action\require\impl\actions\install.lua:412]:

  => install bzip2 1.0.8 .. failed
error: @programdir\core\main.lua:306: @programdir\core\sandbox\modules\import\core\base\task.lua:65: @programdir\modules\async\runjobs.lua:320: ...\modules\private\action\require\impl\actions\install.lua:474: install failed!
stack traceback:
    [C]: in function 'error'
    [@programdir\core\base\os.lua:957]:
    [...\modules\private\action\require\impl\actions\install.lua:474]: in function 'catch'
    [@programdir\core\sandbox\modules\try.lua:123]: in function 'try'
    [...\modules\private\action\require\impl\actions\install.lua:333]:
    [...modules\private\action\require\impl\install_packages.lua:487]: in function 'jobfunc'
    [@programdir\modules\async\runjobs.lua:237]:

stack traceback:
        [C]: in function 'error'
        @programdir\core\base\os.lua:957: in function 'base/os.raiselevel'
        (...tail calls...)
        @programdir\core\main.lua:306: in upvalue 'cotask'
        @programdir\core\base\scheduler.lua:406: in function <@programdir\core\base\scheduler.lua:399>
```

this is because it doesn't find MSVC asan DLL (which are not in the PATH).

The same issue can occur with MinGW and its libstdc++ or pthread dlls (not the case here).

So this is a temporary fix until xmake can hopefully fix this.