### PR TITLE
Auto-update rtm to v2.3.1

### DIFF
--- a/packages/r/rtm/xmake.lua
+++ b/packages/r/rtm/xmake.lua
@@ -7,6 +7,7 @@ package("rtm")
     add_urls("https://github.com/nfrechette/rtm/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nfrechette/rtm.git")
 
+    add_versions("v2.3.1", "a16fc698feca580533fa12c92fe7d1df4f341f807df7ec314274659fdfec11fb")
     add_versions("v2.3.0", "2b5f2c3761bb52ae89802a574e9dc9949aec3b183f7e100b9b66a65adcc6f5ab")
     add_versions("v2.1.5", "afb05cb00b59498756ca197028de291a1960e58d5f6fcad161d8240682481eae")
 


### PR DESCRIPTION
New version of rtm detected (package version: nil, last github version: v2.3.1)