### PR TITLE
Auto-update reproc to v14.2.5

### DIFF
--- a/packages/r/reproc/xmake.lua
+++ b/packages/r/reproc/xmake.lua
@@ -6,6 +6,7 @@ package("reproc")
 
     add_urls("https://github.com/DaanDeMeyer/reproc/archive/refs/tags/$(version).tar.gz",
              "https://github.com/DaanDeMeyer/reproc.git")
+    add_versions("v14.2.5", "69467be0cfc80734b821c54ada263c8f1439f964314063f76b7cf256c3dc7ee8")
     add_versions("v14.2.4", "55c780f7faa5c8cabd83ebbb84b68e5e0e09732de70a129f6b3c801e905415dd")
     add_patches("v14.2.4", path.join(os.scriptdir(), "patches", "0001-to-head.diff"),
         "a5ed818fc36a93bf1f146e6b993e7d0e78daac9c3e5c005f7c84d3e7441f80bb")


### PR DESCRIPTION
New version of reproc detected (package version: nil, last github version: v14.2.5)