### PR TITLE
Auto-update mdns to 1.4.3

### DIFF
--- a/packages/m/mdns/xmake.lua
+++ b/packages/m/mdns/xmake.lua
@@ -5,6 +5,7 @@ package("mdns")
 
     add_urls("https://github.com/mjansson/mdns/archive/refs/tags/$(version).tar.gz",
              "https://github.com/mjansson/mdns.git")
+    add_versions("1.4.3", "be1fd8e35599cb7de179decbd0633c121d11a2dcb9cc193ff5c590bd0d480483")
     add_versions("1.4.2", "c69cfdebe28a489c85f33744f7811c40572a9769a81cd57ecc09ef95802347f2")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of mdns detected (package version: nil, last github version: 1.4.3)