### PR TITLE
chipmunk2d: Set CP_USE_CGTYPES if precision is set

### DIFF
--- a/packages/c/chipmunk2d/xmake.lua
+++ b/packages/c/chipmunk2d/xmake.lua
@@ -31,8 +31,14 @@ package("chipmunk2d")
     on_load(function (package)
         if package:config("precision") == "double" then
             package:add("defines", "CP_USE_DOUBLES=1")
+            if package:is_plat("macosx", "iphoneos") then
+                package:add("defines", "CP_USE_CGTYPES=1")
+            end
         elseif package:config("precision") == "single" then
             package:add("defines", "CP_USE_DOUBLES=0")
+            if package:is_plat("macosx", "iphoneos") then
+                package:add("defines", "CP_USE_CGTYPES=0")
+            end
         end
     end)
 
@@ -50,9 +56,15 @@ package("chipmunk2d")
         end
         local opt = {}
         if package:config("precision") == "double" then
-            opt.cxflags = "-DCP_USE_DOUBLES=1"
+            opt.cxflags = {"-DCP_USE_DOUBLES=1"}
+            if package:is_plat("macosx", "iphoneos") then
+                table.insert(opt.cxflags, "CP_USE_CGTYPES=1")
+            end
         elseif package:config("precision") == "single" then
             opt.cxflags = "-DCP_USE_DOUBLES=0"
+            if package:is_plat("macosx", "iphoneos") then
+                table.insert(opt.cxflags, "CP_USE_CGTYPES=0")
+            end
         end
         import("package.tools.cmake").install(package, configs, opt)
         os.vcp("include/chipmunk", package:installdir("include"))

--- a/packages/c/chipmunk2d/xmake.lua
+++ b/packages/c/chipmunk2d/xmake.lua
@@ -61,7 +61,7 @@ package("chipmunk2d")
                 table.insert(opt.cxflags, "CP_USE_CGTYPES=1")
             end
         elseif package:config("precision") == "single" then
-            opt.cxflags = "-DCP_USE_DOUBLES=0"
+            opt.cxflags = {"-DCP_USE_DOUBLES=0"}
             if package:is_plat("macosx", "iphoneos") then
                 table.insert(opt.cxflags, "CP_USE_CGTYPES=0")
             end


### PR DESCRIPTION
on macOS / iOS, if CP_USE_CGTYPES is not defined, it overrides CP_USE_DOUBLES value
