### PR TITLE
Auto-update amgcl to 1.4.4

### DIFF
--- a/packages/a/amgcl/xmake.lua
+++ b/packages/a/amgcl/xmake.lua
@@ -6,6 +6,7 @@ package("amgcl")
 
     add_urls("https://github.com/ddemidov/amgcl/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ddemidov/amgcl.git")
+    add_versions("1.4.4", "02fd5418e14d669422f65fc739ce72bf9516ced2d8942574d4b8caa05dda9d8c")
     add_versions("1.4.0", "018b824396494c8958faa6337cebcaba48a2584d828f279eef0bbf9e05f900a7")
     add_versions("1.4.2", "db0de6b75e6c205f44542c3ac8d9935c8357a58072963228d0bb11a54181aea8")
     add_versions("1.4.3", "e920d5767814ce697d707d1f359a16c9b9eb79eba28fe19e14c18c2a505fe0ad")


### PR DESCRIPTION
New version of amgcl detected (package version: nil, last github version: 1.4.4)