### PR TITLE
Auto-update winreg to v6.2.0

### DIFF
--- a/packages/w/winreg/xmake.lua
+++ b/packages/w/winreg/xmake.lua
@@ -7,6 +7,7 @@ package("winreg")
     add_urls("https://github.com/GiovanniDicanio/WinReg/archive/refs/tags/$(version).tar.gz",
              "https://github.com/GiovanniDicanio/WinReg.git")
 
+    add_versions("v6.2.0", "9dc1b287fb8c765a35791bf0deea0da81e52a969827bc2d8777f54f26ade588d")
     add_versions("v6.1.0", "d4118ccfd4f4edee29e0f6b3706979791ad537278e2f74818c150bb66f8fcc53")
 
     on_install("windows", "mingw", "msys", function (package)


### PR DESCRIPTION
New version of winreg detected (package version: nil, last github version: v6.2.0)