### PR TITLE
Auto-update enet6 to v6.1.0

### DIFF
--- a/packages/e/enet6/xmake.lua
+++ b/packages/e/enet6/xmake.lua
@@ -6,6 +6,7 @@ package("enet6")
     add_urls("https://github.com/SirLynix/enet6/archive/refs/tags/$(version).tar.gz",
              "https://github.com/SirLynix/enet6.git")
 
+    add_versions("v6.1.0", "d4cdf02651d0b7c48150b07dba127951141f8c52a8ae002c1056dc6a018a6d10")
     add_versions("v6.0.2", "e4678f2d22ea689b7de66bffb553c9f60d429051f44ca6177e8364eb960c7503")
     add_versions("v6.0.1", "8df91f35d2edc78113924de95946680175007e249c3afd401ec4ad9a1e9572d9")
     add_versions("v6.0.0", "4a6358fcf81a0011d7342349d60941201f88c1c88f124f583a502e4591030a88")

--- a/packages/e/enet6/xmake.lua
+++ b/packages/e/enet6/xmake.lua
@@ -22,7 +22,9 @@ package("enet6")
     end)
 
     on_install(function (package)
-        import("package.tools.xmake").install(package)
+        local configs = {}
+        configs.examples = false
+        import("package.tools.xmake").install(package, configs)
    end)
 
     on_test(function (package)


### PR DESCRIPTION
New version of enet6 detected (package version: v6.0.2, last github version: v6.1.0)