### PR TITLE
Auto-update pyincpp to v1.4.1

### DIFF
--- a/packages/p/pyincpp/xmake.lua
+++ b/packages/p/pyincpp/xmake.lua
@@ -6,6 +6,7 @@ package("pyincpp")
     add_urls("https://github.com/chen-qingyu/pyincpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/chen-qingyu/pyincpp.git")
 
+    add_versions("v1.4.1", "f3de3b5044a5c640811e87782264acbaf14697cd8c35bb21ddcd4de5664a60d0")
     add_versions("v1.3.3", "2689349de9faa35d8bbefddcc7d29d49308a2badd58961cc2b1a8f80c96d0823")
     add_versions("v1.3.2", "687148704f278c292962cffe1f440e5a4cc33f2a82f5e5a17b23aab88a282951")
 


### PR DESCRIPTION
New version of pyincpp detected (package version: nil, last github version: v1.4.1)