### PR TITLE
Auto-update polyscope to v2.2.1

### DIFF
--- a/packages/p/polyscope/xmake.lua
+++ b/packages/p/polyscope/xmake.lua
@@ -6,6 +6,7 @@ package("polyscope")
 
     add_urls("https://github.com/nmwsharp/polyscope/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nmwsharp/polyscope.git")
+    add_versions("v2.2.1", "1952d20722cb37c5531e88d5b7f5db88c2827c55fd7ada481c2ac425f3bc4d25")
     add_versions("v2.1.0", "bdad2daab33a44b3b6424cec82b43cecb842b529769fd0df3bf7d8e616cea34c")
     add_versions("v1.3.0", "c0d3594b1c818c6e7efe2c2589d71f5e254db383d36a92555aa909a2114f12d4")
 


### PR DESCRIPTION
New version of polyscope detected (package version: nil, last github version: v2.2.1)