### PR TITLE
Auto-update vcglib to 2023.12

### DIFF
--- a/packages/v/vcglib/xmake.lua
+++ b/packages/v/vcglib/xmake.lua
@@ -7,6 +7,7 @@ package("vcglib")
 
     add_urls("https://github.com/cnr-isti-vclab/vcglib/archive/refs/tags/$(version).tar.gz",
              "https://github.com/cnr-isti-vclab/vcglib.git")
+    add_versions("2023.12", "5a84db6d596be1cb4abdc450d130dc8e2224a4c7b4198b60cd9ac55f45ac5c7b")
     add_versions("2020.12", "731c57435e39c4b958a1d766cadd9865d9db35e36410708f2da7818e9fa5f786")
     add_versions("2021.07", "384bb4bb86b4114391cbc0fb8990f218473a656d06f2214bcc3725dac193db1c")
     add_versions("2021.10", "a443a4a63c0f6691229c80aa22a15f17ab7d9da2b0b6a5111cf39aee86632d5a")


### PR DESCRIPTION
New version of vcglib detected (package version: nil, last github version: 2023.12)