### PR TITLE
Auto-update ck to 0.7.2

### DIFF
--- a/packages/c/ck/xmake.lua
+++ b/packages/c/ck/xmake.lua
@@ -4,6 +4,7 @@ package("ck")
 
     add_urls("https://github.com/concurrencykit/ck/archive/refs/tags/$(version).tar.gz",
              "https://github.com/concurrencykit/ck.git")
+    add_versions("0.7.2", "568ebe0bc1988a23843fce6426602e555b7840bf6714edcdf0ed530214977f1b")
     add_versions("0.7.1", "97d2a21d5326ef79b4668be2e6eda6284ee77a64c0981b35fd9695c736c3d4ac")
 
     on_install("macosx", "linux", function (package)


### PR DESCRIPTION
New version of ck detected (package version: nil, last github version: 0.7.2)