### PR TITLE
Auto-update vvenc to v1.11.1

### DIFF
--- a/packages/v/vvenc/xmake.lua
+++ b/packages/v/vvenc/xmake.lua
@@ -16,7 +16,7 @@ package("vvenc")
     add_deps("cmake")
 
     on_install("windows|x86", "windows|x64", "linux", "macosx", "bsd", "mingw", "msys", "android", "iphoneos", function (package)
-        local configs = {}
+        local configs = {"-DVVENC_OVERRIDE_COMPILER_CHECK=ON"}
         if package:is_debug() then
             table.insert(configs, "-DCMAKE_BUILD_TYPE=Debug")
             table.insert(configs, "-DVVENC_ENABLE_TRACING=ON")

--- a/packages/v/vvenc/xmake.lua
+++ b/packages/v/vvenc/xmake.lua
@@ -6,6 +6,7 @@ package("vvenc")
     add_urls("https://github.com/fraunhoferhhi/vvenc/archive/refs/tags/$(version).tar.gz",
              "https://github.com/fraunhoferhhi/vvenc.git")
 
+    add_versions("v1.11.1", "4f0c8ac3f03eb970bee7a0cacc57a886ac511d58f081bb08ba4bce6f547d92fa")
     add_versions("v1.9.0", "4ddb365dfc21bbbb7ed54655c7630ae3e8e977af31f22b28195e720215b1072d")
 
     add_configs("postfix", {description = "set build type postfix for apps and libs", default = false, type = "boolean"})


### PR DESCRIPTION
New version of vvenc detected (package version: nil, last github version: v1.11.1)