### PR TITLE
Auto-update kokkos-kernels to 4.3.00

### DIFF
--- a/packages/k/kokkos-kernels/xmake.lua
+++ b/packages/k/kokkos-kernels/xmake.lua
@@ -6,6 +6,7 @@ package("kokkos-kernels")
 
     add_urls("https://github.com/kokkos/kokkos-kernels/archive/refs/tags/$(version).tar.gz",
              "https://github.com/kokkos/kokkos-kernels.git")
+    add_versions("4.3.00", "03c3226ee97dbca4fa56fe69bc4eefa0673e23c37f2741943d9362424a63950e")
     add_versions("4.2.01", "058052b3a40f5d4e447b7ded5c480f1b0d4aa78373b0bc7e43804d0447c34ca8")
     add_versions("4.0.01", "3f493fcb0244b26858ceb911be64092fbf7785616ad62c81abde0ea1ce86688a")
 

--- a/packages/k/kokkos-kernels/xmake.lua
+++ b/packages/k/kokkos-kernels/xmake.lua
@@ -25,7 +25,7 @@ package("kokkos-kernels")
         end
     end)
 
-    on_install("windows|x64", "macosx", "linux", function (package)
+    on_install("windows|x64", "macosx|x86_64", "linux", function (package)
         if package:is_plat("windows") then
             local vs = import("core.tool.toolchain").load("msvc"):config("vs")
             if tonumber(vs) < 2022 then

--- a/packages/k/kokkos-kernels/xmake.lua
+++ b/packages/k/kokkos-kernels/xmake.lua
@@ -1,11 +1,11 @@
 package("kokkos-kernels")
-
     set_homepage("https://github.com/kokkos/kokkos-kernels")
     set_description("Kokkos C++ Performance Portability Programming EcoSystem: Math Kernels")
     set_license("Apache-2.0")
 
     add_urls("https://github.com/kokkos/kokkos-kernels/archive/refs/tags/$(version).tar.gz",
              "https://github.com/kokkos/kokkos-kernels.git")
+
     add_versions("4.3.00", "03c3226ee97dbca4fa56fe69bc4eefa0673e23c37f2741943d9362424a63950e")
     add_versions("4.2.01", "058052b3a40f5d4e447b7ded5c480f1b0d4aa78373b0bc7e43804d0447c34ca8")
     add_versions("4.0.01", "3f493fcb0244b26858ceb911be64092fbf7785616ad62c81abde0ea1ce86688a")
@@ -16,7 +16,7 @@ package("kokkos-kernels")
     add_configs("cuda", {description = "Enable CUDA support.", default = false, type = "boolean"})
 
     add_deps("cmake")
-    on_load("windows|x64", "macosx", "linux", function (package)
+    on_load("windows|x64", "macosx|x86_64", "linux", function (package)
         if package:config("cuda") then
             package:add("deps", "cuda")
             package:add("deps", "kokkos", {configs = {cuda = true}})

--- a/packages/k/kokkos/xmake.lua
+++ b/packages/k/kokkos/xmake.lua
@@ -1,11 +1,12 @@
 package("kokkos")
-
     set_homepage("https://kokkos.github.io/")
     set_description("Kokkos C++ Performance Portability Programming EcoSystem: The Programming Model")
     set_license("Apache-2.0")
 
     add_urls("https://github.com/kokkos/kokkos/archive/refs/tags/$(version).tar.gz",
              "https://github.com/kokkos/kokkos.git")
+
+    add_versions("4.3.00", "53cf30d3b44dade51d48efefdaee7a6cf109a091b702a443a2eda63992e5fe0d")
     add_versions("4.2.01", "cbabbabba021d00923fb357d2e1b905dda3838bd03c885a6752062fe03c67964")
     add_versions("4.2.00", "ac08765848a0a6ac584a0a46cd12803f66dd2a2c2db99bb17c06ffc589bf5be8")
     add_versions("4.0.01", "bb942de8afdd519fd6d5d3974706bfc22b6585a62dd565c12e53bdb82cd154f0")


### PR DESCRIPTION
New version of kokkos-kernels detected (package version: nil, last github version: 4.3.00)