### PR TITLE
Auto-update yoga to v3.0.4

### DIFF
--- a/packages/y/yoga/xmake.lua
+++ b/packages/y/yoga/xmake.lua
@@ -6,6 +6,7 @@ package("yoga")
     add_urls("https://github.com/facebook/yoga/archive/refs/tags/$(version).tar.gz",
              "https://github.com/facebook/yoga.git")
 
+    add_versions("v3.0.4", "ef3ce5106eed03ab2e40dcfe5b868936a647c5f02b7ffd89ffaa5882dca3ef7f")
     add_versions("v3.0.3", "0ae44f7d30f8130cdf63e91293e11e34803afbfd12482fe4ef786435fc7fa8e7")
     add_versions("v3.0.2", "73a81c51d9ceb5b95cd3abcafeb4c840041801d59f5048dacce91fbaab0cc6f9")
     add_versions("v3.0.0", "da4739061315fd5b6442e0658c2541db24ded359f41525359d5e61edb2f45297")


### PR DESCRIPTION
New version of yoga detected (package version: nil, last github version: v3.0.4)