### PR TITLE
Auto-update zmqpb to 0.6

### DIFF
--- a/packages/z/zmqpb/xmake.lua
+++ b/packages/z/zmqpb/xmake.lua
@@ -5,6 +5,7 @@ package("zmqpb")
 
     set_urls("https://github.com/SFGrenade/ZmqPb/archive/refs/tags/v$(version).tar.gz",
              "https://github.com/SFGrenade/ZmqPb.git")
+    add_versions("0.6", "f8c37950ba318d5b6383f082d439139548d9e2d5c29a767fd0ac7d6dbbe020b7")
     add_versions("0.1", "4a34ec92faa381306356e84e2a2000093d8f76cfa037db1f4cd0adb0205faebb")
     add_versions("0.2", "5dfa4d4cebb10cb7ae03943e18e8d48c8ff215e80371f24c5ade212be7f20721")
     add_versions("0.3", "343c57c9f72facca47082422a259ec8c531f5c6e332a3828835080c4a96b9064")


### PR DESCRIPTION
New version of zmqpb detected (package version: nil, last github version: 0.6)