### PR TITLE
Auto-update nghttp2 to 1.61.0

### DIFF
--- a/packages/n/nghttp2/xmake.lua
+++ b/packages/n/nghttp2/xmake.lua
@@ -4,6 +4,7 @@ package("nghttp2")
     set_license("MIT")
 
     add_urls("https://github.com/nghttp2/nghttp2/releases/download/v$(version)/nghttp2-$(version).tar.gz")
+    add_versions("1.61.0", "aa7594c846e56a22fbf3d6e260e472268808d3b49d5e0ed339f589e9cc9d484c")
     add_versions("1.60.0", "ca2333c13d1af451af68de3bd13462de7e9a0868f0273dea3da5bc53ad70b379")
     add_versions("1.59.0", "90fd27685120404544e96a60ed40398a3457102840c38e7215dc6dec8684470f")
     add_versions("1.58.0", "9ebdfbfbca164ef72bdf5fd2a94a4e6dfb54ec39d2ef249aeb750a91ae361dfb")


### PR DESCRIPTION
New version of nghttp2 detected (package version: nil, last github version: 1.61.0)