### PR TITLE
Auto-update catch2 to v3.5.4

### DIFF
--- a/packages/c/catch2/patches/3.5.4/windows_arm64.patch
+++ b/packages/c/catch2/patches/3.5.4/windows_arm64.patch
@@ -1,0 +1,24 @@
+diff --git a/src/catch2/internal/catch_random_integer_helpers.hpp b/src/catch2/internal/catch_random_integer_helpers.hpp
+index 10d82559..cb5e004f 100644
+--- a/src/catch2/internal/catch_random_integer_helpers.hpp
++++ b/src/catch2/internal/catch_random_integer_helpers.hpp
+@@ -21,7 +21,10 @@
+ //       it, and it provides an escape hatch to the users who need it.
+ #if defined( __SIZEOF_INT128__ )
+ #    define CATCH_CONFIG_INTERNAL_UINT128
+-#elif defined( _MSC_VER ) && ( defined( _WIN64 ) || defined( _M_ARM64 ) )
++// Unlike GCC, MSVC does not polyfill umul as mulh + mul pair on ARM machines.
++// Currently we do not bother doing this ourselves, but we could if it became
++// important for perf.
++#elif defined( _MSC_VER ) && defined( _M_X64 )
+ #    define CATCH_CONFIG_INTERNAL_MSVC_UMUL128
+ #endif
+ 
+@@ -36,7 +39,6 @@
+     !defined( CATCH_CONFIG_MSVC_UMUL128 )
+ #    define CATCH_CONFIG_MSVC_UMUL128
+ #    include <intrin.h>
+-#    pragma intrinsic( _umul128 )
+ #endif
+ 
+ 

--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -1,5 +1,4 @@
 package("catch2")
-
     set_homepage("https://github.com/catchorg/Catch2")
     set_description("Catch2 is a multi-paradigm test framework for C++. which also supports Objective-C (and maybe C). ")
     set_license("BSL-1.0")
@@ -24,6 +23,10 @@ package("catch2")
     add_versions("v2.13.6", "39d50f5d1819cdf2908066664d57c2cde4a4000c364ad3376ea099735c896ff4")
     add_versions("v2.13.5", "728679b056dc1248cc79b3a1999ff7453f76422c68417563fc47a0ac2aaeeaef")
     add_versions("v2.9.2", "dc486300de22b0d36ddba1705abb07b9e5780639d824ba172ddf7062b2a1bf8f")
+
+    if is_plat("windows") then
+        add_patches("v3.5.4", path.join(os.scriptdir(), "patches", "3.5.4", "windows_arm64.patch"), "36fa29bd38fc97d3d3563bc4e7fab0810e899f8a2d8f8418555e2a4c051ad947")
+    end
 
     add_configs("cxx17", {description = "Compiles Catch as a C++17 library (requires a C++17 compiler).", default = true, type = "boolean"})
 

--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -6,6 +6,7 @@ package("catch2")
 
     add_urls("https://github.com/catchorg/Catch2/archive/refs/tags/$(version).zip",
              "https://github.com/catchorg/Catch2.git")
+    add_versions("v3.5.4", "190a236fe0772ac4f5eebfdebfc18f92eeecfd270c55a1e5095ae4f10be2343f")
     add_versions("v3.5.3", "2de1868288b26a19c2aebfc3fe53a748ec3ec5fc32cc742dfccaf6c685a0dc07")
     add_versions("v3.5.2", "85fcc78d0c3387b15ad82f22a94017b29e4fe7c1cf0a05c3dd465b2746eef73f")
     add_versions("v3.5.1", "b422fcd526a95e6057839f93a18099261bdc8c595f932ed4b1a978b358b3f1ed")


### PR DESCRIPTION
New version of catch2 detected (package version: v3.5.3, last github version: v3.5.4)