### PR TITLE
Auto-update c-ares to 1.28.1

### DIFF
--- a/packages/c/c-ares/xmake.lua
+++ b/packages/c/c-ares/xmake.lua
@@ -7,6 +7,7 @@ package("c-ares")
     add_urls("https://github.com/c-ares/c-ares/releases/download/cares-$(version).tar.gz", {version = function (version)
         return version:gsub("%.", "_") .. "/c-ares-" .. version
     end})
+    add_versions("1.28.1", "675a69fc54ddbf42e6830bc671eeb6cd89eeca43828eb413243fd2c0a760809d")
     add_versions("1.27.0", "0a72be66959955c43e2af2fbd03418e82a2bd5464604ec9a62147e37aceb420b")
     add_versions("1.16.1", "d08312d0ecc3bd48eee0a4cc0d2137c9f194e0a28de2028928c0f6cae85f86ce")
     add_versions("1.17.0", "1cecd5dbe21306c7263f8649aa6e9a37aecb985995a3489f487d98df2b40757d")


### PR DESCRIPTION
New version of c-ares detected (package version: nil, last github version: 1.28.1)