### PR TITLE
Auto-update glaze to v2.5.3

### DIFF
--- a/packages/g/glaze/xmake.lua
+++ b/packages/g/glaze/xmake.lua
@@ -6,6 +6,7 @@ package("glaze")
     add_urls("https://github.com/stephenberry/glaze/archive/refs/tags/$(version).tar.gz",
              "https://github.com/stephenberry/glaze.git")
 
+    add_versions("v2.5.3", "f4c5eb83c80f1caa0feaa831715e9982203908ea140242cb061aead161e2b09b")
     add_versions("v2.4.4", "98ef6af4209e0b98d449d6d414b7e0d69b7a79f78d1c9efeb9dfeca011c0600c")
     add_versions("v2.4.2", "2593617e874d6afc33158a68843c74d875e8e443b430aef826d69662459b280e")
     add_versions("v1.3.5", "de5d59cb7f31193d45f67f25d8ced1499df50c0d926a1461432b87f2b2368817")


### PR DESCRIPTION
New version of glaze detected (package version: nil, last github version: v2.5.3)