### PR TITLE
Auto-update yomm2 to v1.5.0

### DIFF
--- a/packages/y/yomm2/xmake.lua
+++ b/packages/y/yomm2/xmake.lua
@@ -6,6 +6,7 @@ package("yomm2")
     add_urls("https://github.com/jll63/yomm2/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jll63/yomm2.git")
 
+    add_versions("v1.5.0", "daebc9bc56e3f67f1513c40b4b185cf435d8e16fe9936f3e5ed6fbb337a39030")
     add_versions("v1.4.0", "3f1f3a2b6fa5250405986b6cc4dff82299f866e2c6c2db75c7c3f38ecb91360f")
 
     add_deps("cmake", "boost")

--- a/packages/y/yomm2/xmake.lua
+++ b/packages/y/yomm2/xmake.lua
@@ -18,6 +18,8 @@ package("yomm2")
     end)
 
     on_install("windows", "linux", "macosx", "bsd", "mingw", "cross", function (package)
+        io.replace("CMakeLists.txt", "add_subdirectory(docs.in)", "", {plain = true})
+
         local configs =
         {
             "-DYOMM2_ENABLE_TESTS=OFF",


### PR DESCRIPTION
New version of yomm2 detected (package version: nil, last github version: v1.5.0)