### PR TITLE
Auto-update kuba-zip to v0.3.2

### DIFF
--- a/packages/k/kuba-zip/xmake.lua
+++ b/packages/k/kuba-zip/xmake.lua
@@ -6,6 +6,7 @@ package("kuba-zip")
     add_urls("https://github.com/kuba--/zip/archive/refs/tags/$(version).tar.gz",
              "https://github.com/kuba--/zip.git")
 
+    add_versions("v0.3.2", "0c33740aec7a3913bca07df360420c19cac5e794e0f602f14f798cb2e6f710e5")
     add_versions("v0.3.1", "775b8a44b53e72a55c13839bf507219c2cf30b26f62e70f1a20bb727db54438f")
     add_versions("v0.2.2", "f278b1da5e5382c7a1a1db1502cfa1f6df6b1e05e36253d661344d30277f9895")
     add_versions("v0.2.5", "e052f6cbe6713f69f8caec61214fda4e5ae5150d1fcba02c9e79f1a05d939305")


### PR DESCRIPTION
New version of kuba-zip detected (package version: nil, last github version: v0.3.2)