### PR TITLE
glslang: Update binary name when testing

### DIFF
--- a/packages/g/glslang/xmake.lua
+++ b/packages/g/glslang/xmake.lua
@@ -82,7 +82,7 @@ package("glslang")
 
     on_test(function (package)
         if not package:is_cross() then
-            os.vrun("glslangValidator --version")
+            os.vrun("glslang --version")
         end
         if not package:config("binaryonly") then
             assert(package:has_cxxfuncs("ShInitialize", {configs = {languages = "c++11"}, includes = "glslang/Public/ShaderLang.h"}))


### PR DESCRIPTION
glslang compiler binary has been renamed in https://github.com/KhronosGroup/glslang/releases/tag/12.3.0, a symlink exists but doesn't seem to work well on Windows