### PR TITLE
Auto-update aws-c-cal to v0.6.11

### DIFF
--- a/packages/a/aws-c-cal/xmake.lua
+++ b/packages/a/aws-c-cal/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-cal")
     add_urls("https://github.com/awslabs/aws-c-cal/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-cal.git")
 
+    add_versions("v0.6.11", "e1b0af88c14300e125e86ee010d4c731292851fff16cfb67eb6ba6036df2d648")
     add_versions("v0.6.2", "777feb1e88b261415e1ad607f7e420a743c3b432e21a66a5aaf9249149dc6fef")
 
     add_configs("openssl", {description = "Set this if you want to use your system's OpenSSL 1.0.2/1.1.1 compatible libcrypto", default = false, type = "boolean"})


### PR DESCRIPTION
New version of aws-c-cal detected (package version: nil, last github version: v0.6.11)