### PR TITLE
Auto-update rocksdb to v9.1.1

### DIFF
--- a/packages/r/rocksdb/xmake.lua
+++ b/packages/r/rocksdb/xmake.lua
@@ -4,6 +4,7 @@ package("rocksdb")
 
     add_urls("https://github.com/facebook/rocksdb/archive/refs/tags/$(version).tar.gz",
              "https://github.com/facebook/rocksdb.git")
+    add_versions("v9.1.1", "54ca90dd782a988cd3ebc3e0e9ba9b4efd563d7eb78c5e690c2403f1b7d4a87a")
     add_versions("v9.0.0", "013aac178aa12837cbfa3b1e20e9e91ff87962ab7fdd044fd820e859f8964f9b")
     add_versions("v7.10.2", "4619ae7308cd3d11cdd36f0bfad3fb03a1ad399ca333f192b77b6b95b08e2f78")
 


### PR DESCRIPTION
New version of rocksdb detected (package version: nil, last github version: v9.1.1)