### PR TITLE
Auto-update h5cpp to v0.6.0

### DIFF
--- a/packages/h/h5cpp/xmake.lua
+++ b/packages/h/h5cpp/xmake.lua
@@ -5,10 +5,11 @@ package("h5cpp")
 
     add_urls("https://github.com/ess-dmsc/h5cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ess-dmsc/h5cpp.git")
+
     add_versions("v0.6.0", "72b459c92670628d730b3386fe6f4ac61218885afa904f234a181c2022a9f56f")
     add_versions("v0.5.1", "8fcab57ffbc2d799fe315875cd8fcf67e8b059cccc441ea45a001c03f6a9fd25")
 
-    add_patches("v0.5.1", path.join(os.scriptdir(), "patches", "fix-find-hdf5.patch"), "25f26ec6994d387571d7c068ba0405a34db45480a9c17fe3ea6402042e7de87c")
+    add_patches(">=0.5.1", path.join(os.scriptdir(), "patches", "fix-find-hdf5.patch"), "25f26ec6994d387571d7c068ba0405a34db45480a9c17fe3ea6402042e7de87c")
 
     add_deps("cmake")
     add_deps("zlib")

--- a/packages/h/h5cpp/xmake.lua
+++ b/packages/h/h5cpp/xmake.lua
@@ -5,6 +5,7 @@ package("h5cpp")
 
     add_urls("https://github.com/ess-dmsc/h5cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ess-dmsc/h5cpp.git")
+    add_versions("v0.6.0", "72b459c92670628d730b3386fe6f4ac61218885afa904f234a181c2022a9f56f")
     add_versions("v0.5.1", "8fcab57ffbc2d799fe315875cd8fcf67e8b059cccc441ea45a001c03f6a9fd25")
 
     add_patches("v0.5.1", path.join(os.scriptdir(), "patches", "fix-find-hdf5.patch"), "25f26ec6994d387571d7c068ba0405a34db45480a9c17fe3ea6402042e7de87c")


### PR DESCRIPTION
New version of h5cpp detected (package version: nil, last github version: v0.6.0)