### PR TITLE
Auto-update zziplib to v0.13.74

### DIFF
--- a/packages/z/zziplib/xmake.lua
+++ b/packages/z/zziplib/xmake.lua
@@ -6,6 +6,7 @@ package("zziplib")
 
     add_urls("https://github.com/gdraheim/zziplib/archive/refs/tags/$(version).tar.gz",
              "https://github.com/gdraheim/zziplib.git")
+    add_versions("v0.13.74", "319093aa98d39453f3ea2486a86d8a2fab2d5632f6633a2665318723a908eecf")
     add_versions("v0.13.72", "93ef44bf1f1ea24fc66080426a469df82fa631d13ca3b2e4abaeab89538518dc")
     add_versions("v0.13.73", "2aa9d317f70060101064863e4e8fe698c32301e2d293d2b4964608cf2d5b2d8b")
 


### PR DESCRIPTION
New version of zziplib detected (package version: nil, last github version: v0.13.74)