### PR TITLE
Auto-update lvgl to v9.1.0

### DIFF
--- a/packages/l/lvgl/xmake.lua
+++ b/packages/l/lvgl/xmake.lua
@@ -6,6 +6,7 @@ package("lvgl")
 
     add_urls("https://github.com/lvgl/lvgl/archive/refs/tags/$(version).tar.gz",
              "https://github.com/lvgl/lvgl.git")
+    add_versions("v9.1.0", "6930f1605d305fcd43f31d5f470ecf4a013c4ce0980e78ee4c33b96a589bf433")
     add_versions("v9.0.0", "73ae6ef7b44b434b41f25755ce4f6f5d23c49c1c254c4b7774b5a9cf83a46b7f")
     add_versions("v8.0.2", "7136edd6c968b60f0554130c6903f16870fa26cda11a2290bc86d09d7138a6b4")
     add_versions("v8.2.0", "dd1cb1955ded3789c99e2dee7ac367393e87b5870cbce6b88930e378c3e91829")


### PR DESCRIPTION
New version of lvgl detected (package version: nil, last github version: v9.1.0)