### PR TITLE
Auto-update whisper.cpp to 1.5.5

### DIFF
--- a/packages/w/whisper.cpp/xmake.lua
+++ b/packages/w/whisper.cpp/xmake.lua
@@ -6,6 +6,7 @@ package("whisper.cpp")
     set_urls("https://github.com/ggerganov/whisper.cpp/archive/refs/tags/v$(version).tar.gz",
              "https://github.com/ggerganov/whisper.cpp.git")
 
+    add_versions("1.5.5", "27fa5c472657af2a6cee63de349a34b23d0f3781fa9b8ef301a940cf64964a79")
     add_versions("1.5.4", "06eed84de310fdf5408527e41e863ac3b80b8603576ba0521177464b1b341a3a")
     add_versions("1.4.2", "1b988dcc77fca55f188dbc4e472f971a80854c1d44309cf3eaab9d5677f175e1")
 


### PR DESCRIPTION
New version of whisper.cpp detected (package version: nil, last github version: 1.5.5)