### PR TITLE
Auto-update aws-c-auth to v0.7.18

### DIFF
--- a/packages/a/aws-c-auth/xmake.lua
+++ b/packages/a/aws-c-auth/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-auth")
     add_urls("https://github.com/awslabs/aws-c-auth/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-auth.git")
 
+    add_versions("v0.7.18", "c705199655066f1f874bc3758683f32e288024196a22f28360d336231e45406f")
     add_versions("v0.7.17", "8fe380255a71a2d5c9acd4979c135f9842135ce6385010ea562bc0b532bf5b84")
     add_versions("v0.7.3", "22e334508b76f1beddefbf877f200c8a5ace4e3956c6be6545b7572762afe8c5")
 


### PR DESCRIPTION
New version of aws-c-auth detected (package version: nil, last github version: v0.7.18)