### PR TITLE
Auto-update functionalplus to v0.2.24

### DIFF
--- a/packages/f/functionalplus/xmake.lua
+++ b/packages/f/functionalplus/xmake.lua
@@ -6,6 +6,7 @@ package("functionalplus")
     add_urls("https://github.com/Dobiasd/FunctionalPlus/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Dobiasd/FunctionalPlus.git")
 
+    add_versions("v0.2.24", "446c63ac3f2045e7587f694501882a3d7c7b962b70bcc08deacf5777bdaaff8c")
     add_versions("v0.2.23", "5c2d28d2ba7d0cdeab9e31bbf2e7f8a9d6f2ff6111a54bfc11d1b05422096f19")
     add_versions("v0.2.22", "79378668dff6ffa8abc1abde2c2fe37dc6fe1ac040c55d5ee7886924fa6a1376")
 


### PR DESCRIPTION
New version of functionalplus detected (package version: nil, last github version: v0.2.24)