### PR TITLE
Auto-update libimagequant to 4.3.1

### DIFF
--- a/packages/l/libimagequant/xmake.lua
+++ b/packages/l/libimagequant/xmake.lua
@@ -6,6 +6,7 @@ package("libimagequant")
 
     add_urls("https://github.com/ImageOptim/libimagequant/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ImageOptim/libimagequant.git")
+    add_versions("4.3.1", "75020204491f14a8cdf4b857f6c5bab08b6b5f1736345412b296a253bc632bf6")
     add_versions("2.15.1", "3a9548f99be8c3b20a5d9407d0ca95bae8b0fb424a2735a87cb6cf3fdd028225")
 
     add_configs("sse", {description = "Use SSE.", default = true, type = "boolean"})


### PR DESCRIPTION
New version of libimagequant detected (package version: nil, last github version: 4.3.1)