### PR TITLE
Auto-update libbpf to v1.4.1

### DIFF
--- a/packages/l/libbpf/xmake.lua
+++ b/packages/l/libbpf/xmake.lua
@@ -5,6 +5,7 @@ package("libbpf")
 
     add_urls("https://github.com/libbpf/libbpf/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libbpf/libbpf.git")
+    add_versions("v1.4.1", "cc01a3a05d25e5978c20be7656f14eb8b6fcb120bb1c7e8041e497814fc273cb")
     add_versions("v0.3", "c168d84a75b541f753ceb49015d9eb886e3fb5cca87cdd9aabce7e10ad3a1efc")
 
     add_deps("libelf", "zlib")


### PR DESCRIPTION
New version of libbpf detected (package version: nil, last github version: v1.4.1)