### PR TITLE
Auto-update simde to 0.8.2

### DIFF
--- a/packages/s/simde/xmake.lua
+++ b/packages/s/simde/xmake.lua
@@ -9,7 +9,7 @@ package("simde")
     add_versions("0.8.2", "59068edc3420e75c5ff85ecfd80a77196fb3a151227a666cc20abb313a5360bf")
     add_versions("0.7.2", "544c8aac764f0e24e444b1a7842d0314fa0231802d3b1b2020a03677b5be6142")
 
-    on_install(function (package)
+    on_install("windows|x86", "windows|x64", "macosx", "linux", "mingw", "iphoneos", "bsd", "wasm", function (package)
         os.cp("*", package:installdir("include"))
     end)
 

--- a/packages/s/simde/xmake.lua
+++ b/packages/s/simde/xmake.lua
@@ -6,6 +6,7 @@ package("simde")
 
     set_urls("https://github.com/simd-everywhere/simde/releases/download/v$(version)/simde-amalgamated-$(version).tar.xz")
 
+    add_versions("0.8.2", "59068edc3420e75c5ff85ecfd80a77196fb3a151227a666cc20abb313a5360bf")
     add_versions("0.7.2", "544c8aac764f0e24e444b1a7842d0314fa0231802d3b1b2020a03677b5be6142")
 
     on_install(function (package)


### PR DESCRIPTION
New version of simde detected (package version: nil, last github version: 0.8.2)

- close: #3791 
- close: #3481