### PR TITLE
Auto-update numactl to 2.0.18

### DIFF
--- a/packages/n/numactl/xmake.lua
+++ b/packages/n/numactl/xmake.lua
@@ -5,6 +5,7 @@ package("numactl")
     set_license("LGPL-2.1")
 
     add_urls("https://github.com/numactl/numactl/releases/download/v$(version)/numactl-$(version).tar.gz")
+    add_versions("2.0.18", "b4fc0956317680579992d7815bc43d0538960dc73aa1dd8ca7e3806e30bc1274")
     add_versions("2.0.14", "826bd148c1b6231e1284e42a4db510207747484b112aee25ed6b1078756bcff6")
 
     on_install("linux", function (package)


### PR DESCRIPTION
New version of numactl detected (package version: nil, last github version: 2.0.18)