### PR TITLE
Auto-update libenvpp to v1.4.1

### DIFF
--- a/packages/l/libenvpp/xmake.lua
+++ b/packages/l/libenvpp/xmake.lua
@@ -6,6 +6,7 @@ package("libenvpp")
     add_urls("https://github.com/ph3at/libenvpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ph3at/libenvpp.git")
 
+    add_versions("v1.4.1", "1bcd0a1eb4eef32a53cbb410ae38d708ea662e491cc5536cb9b15d54cc8b5707")
     add_versions("v1.4.0", "3f9a4a4b62abc06522de76e3a999cc3cd6b60299dc26b28ccc2183aa614f10cd")
     add_versions("v1.1.0", "c373a6867ed915ffdacbbebfa017e03c0797dc4c2eb173659f607024e9cfbac9")
 


### PR DESCRIPTION
New version of libenvpp detected (package version: nil, last github version: v1.4.1)