### PR TITLE
add wigxjpf

### DIFF
--- a/packages/w/wigxjpf/xmake.lua
+++ b/packages/w/wigxjpf/xmake.lua
@@ -12,18 +12,13 @@ package("wigxjpf")
         os.cp("inc/*.h", package:installdir("include"))
         os.cp("lib/*.a", package:installdir("lib"))
         os.cp("bin/*", package:installdir("bin"))
+        if package:config("shared") then
+            table.insert(configs, "shared")
+            import("package.tools.make").build(package, configs)
+            os.cp("lib/*.so", package:installdir("lib"))
+        end
     end)
 
     on_test(function (package)
-        assert(package:check_csnippets({test = [[
-            #include "wigxjpf.h"
-            void test() {
-                double val6j;
-                wig_table_init(2 * 100, 9);
-                wig_temp_init(2 * 100);
-                val6j = wig6jj(2 * 2, 2 * 2, 2 * 1, 2 * 2, 2 * 1, 2 * 1);
-                wig_temp_free();
-                wig_table_free();
-            }
-        ]]}))
+        assert(package:has_cfuncs("wig3jj", {includes = "wigxjpf.h"}))
     end)

--- a/packages/w/wigxjpf/xmake.lua
+++ b/packages/w/wigxjpf/xmake.lua
@@ -13,9 +13,11 @@ package("wigxjpf")
         end
         import("package.tools.make").build(package, configs)
         os.cp("inc/*.h", package:installdir("include"))
-        os.cp("bin/*", package:installdir("bin"))
-        os.trycp("lib/*.so", package:installdir("lib"))
-        os.trycp("lib/*.a", package:installdir("lib"))
+        if package:config("shared") then
+            os.cp("lib/*.so", package:installdir("lib"))
+        else
+            os.cp("lib/*.a", package:installdir("lib"))
+        end
     end)
 
     on_test(function (package)

--- a/packages/w/wigxjpf/xmake.lua
+++ b/packages/w/wigxjpf/xmake.lua
@@ -10,12 +10,13 @@ package("wigxjpf")
         local configs = {}
         import("package.tools.make").build(package, configs)
         os.cp("inc/*.h", package:installdir("include"))
-        os.cp("lib/*.a", package:installdir("lib"))
         os.cp("bin/*", package:installdir("bin"))
         if package:config("shared") then
             table.insert(configs, "shared")
             import("package.tools.make").build(package, configs)
             os.cp("lib/*.so", package:installdir("lib"))
+        else
+            os.cp("lib/*.a", package:installdir("lib"))
         end
     end)
 

--- a/packages/w/wigxjpf/xmake.lua
+++ b/packages/w/wigxjpf/xmake.lua
@@ -8,16 +8,14 @@ package("wigxjpf")
 
     on_install("linux", "macosx", function (package)
         local configs = {}
+        if package:config("shared") then
+            table.insert(configs, "shared")
+        end
         import("package.tools.make").build(package, configs)
         os.cp("inc/*.h", package:installdir("include"))
         os.cp("bin/*", package:installdir("bin"))
-        if package:config("shared") then
-            table.insert(configs, "shared")
-            import("package.tools.make").build(package, configs)
-            os.cp("lib/*.so", package:installdir("lib"))
-        else
-            os.cp("lib/*.a", package:installdir("lib"))
-        end
+        os.trycp("lib/*.so", package:installdir("lib"))
+        os.trycp("lib/*.a", package:installdir("lib"))
     end)
 
     on_test(function (package)

--- a/packages/w/wigxjpf/xmake.lua
+++ b/packages/w/wigxjpf/xmake.lua
@@ -1,0 +1,31 @@
+package("wigxjpf")
+    set_homepage("https://fy.chalmers.se/subatom/wigxjpf/")
+    set_description("WIGXJPF evaluates Wigner 3j, 6j and 9j symbols accurately using prime factorisation and multi-word integer arithmetic.")
+    set_license("GPL-3.0", "LGPL-3.0")
+
+    set_urls("https://fy.chalmers.se/subatom/wigxjpf/wigxjpf-$(version).tar.gz")
+    add_versions("1.13", "90ab9bfd495978ad1fdcbb436e274d6f4586184ae290b99920e5c978d64b3e6a")
+
+    on_install("linux", "macosx", function (package)
+        os.vrun("make")
+        os.cp("inc/*.h", package:installdir("include"))
+        os.cp("lib/*.a", package:installdir("lib"))
+        os.cp("bin/*", package:installdir("bin"))
+    end)
+
+    on_test(function (package)
+        assert(package:check_csnippets({test = [[
+            #include "wigxjpf.h"
+            int test()
+            {
+                double val6j;
+                wig_table_init(2*100, 9);
+                wig_temp_init(2*100);
+                val6j = wig6jj(2*  2 , 2*  2 , 2*  1 ,
+                                2*  2 , 2*  1 , 2*  1 );
+                wig_temp_free();
+                wig_table_free();
+                return 0;
+            }
+        ]]}))
+    end)

--- a/packages/w/wigxjpf/xmake.lua
+++ b/packages/w/wigxjpf/xmake.lua
@@ -7,7 +7,8 @@ package("wigxjpf")
     add_versions("1.13", "90ab9bfd495978ad1fdcbb436e274d6f4586184ae290b99920e5c978d64b3e6a")
 
     on_install("linux", "macosx", function (package)
-        os.vrun("make")
+        local configs = {}
+        import("package.tools.make").build(package, configs)
         os.cp("inc/*.h", package:installdir("include"))
         os.cp("lib/*.a", package:installdir("lib"))
         os.cp("bin/*", package:installdir("bin"))

--- a/packages/w/wigxjpf/xmake.lua
+++ b/packages/w/wigxjpf/xmake.lua
@@ -16,16 +16,13 @@ package("wigxjpf")
     on_test(function (package)
         assert(package:check_csnippets({test = [[
             #include "wigxjpf.h"
-            int test()
-            {
+            void test() {
                 double val6j;
-                wig_table_init(2*100, 9);
-                wig_temp_init(2*100);
-                val6j = wig6jj(2*  2 , 2*  2 , 2*  1 ,
-                                2*  2 , 2*  1 , 2*  1 );
+                wig_table_init(2 * 100, 9);
+                wig_temp_init(2 * 100);
+                val6j = wig6jj(2 * 2, 2 * 2, 2 * 1, 2 * 2, 2 * 1, 2 * 1);
                 wig_temp_free();
                 wig_table_free();
-                return 0;
             }
         ]]}))
     end)


### PR DESCRIPTION
The wigxjpf library is used for evaluating Wigner symbols, which is very useful for angular momentum coupling. The GNU-GSL library offers `gsl_sf_coupling_?j` functions, but they are inaccurate for very large angular momentum. This library use big integer techniques to give accurate result.