### PR TITLE
libcpuid: support exclusively x86 archs on Windows

### DIFF
--- a/packages/l/libcpuid/xmake.lua
+++ b/packages/l/libcpuid/xmake.lua
@@ -11,7 +11,7 @@ package("libcpuid")
 
     add_deps("cmake")
 
-    on_install("windows|native", "macosx", "linux", "mingw", function (package)
+    on_install("windows|x86", "windows|x64", "macosx", "linux", "mingw", function (package)
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))


### PR DESCRIPTION
`native` would fail if we build on Windows ARM

