### PR TITLE
Auto-update rapidfuzz to v3.0.4

### DIFF
--- a/packages/r/rapidfuzz/xmake.lua
+++ b/packages/r/rapidfuzz/xmake.lua
@@ -7,6 +7,7 @@ package("rapidfuzz")
     add_urls("https://github.com/rapidfuzz/rapidfuzz-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/rapidfuzz/rapidfuzz-cpp.git")
 
+    add_versions("v3.0.4", "18d1c41575ceddd6308587da8befc98c85d3b5bc2179d418daffed6d46b8cb0a")
     add_versions("v3.0.2", "4fddce5c0368e78bd604c6b820e6be248d669754715e39b4a8a281bda4c06de1")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of rapidfuzz detected (package version: v3.0.2, last github version: v3.0.4)