### PR TITLE
Auto-update cglm to v0.9.4

### DIFF
--- a/packages/c/cglm/xmake.lua
+++ b/packages/c/cglm/xmake.lua
@@ -5,6 +5,7 @@ package("cglm")
 
     add_urls("https://github.com/recp/cglm/archive/refs/tags/$(version).tar.gz",
              "https://github.com/recp/cglm.git")
+    add_versions("v0.9.4", "101376d9f5db7139a54db35ccc439e40b679bc2efb756d3469d39ee38e69c41b")
     add_versions("v0.9.2", "5c0639fe125c00ffaa73be5eeecd6be999839401e76cf4ee05ac2883447a5b4d")
     add_versions("v0.9.0", "9b688bc52915cdd4ad8b7d4080ef59cc92674d526856d8f16bb3a114db1dd794")
 


### PR DESCRIPTION
New version of cglm detected (package version: v0.9.2, last github version: v0.9.4)