### PR TITLE
Auto-update pyincpp to v2.1.0

### DIFF
--- a/packages/p/pyincpp/xmake.lua
+++ b/packages/p/pyincpp/xmake.lua
@@ -26,5 +26,5 @@ package("pyincpp")
                 assert(map.keys() == Set<String>({"first", "second", "third"}));
                 assert(map["third"][-1].factorial() == 120);
             }
-        ]]}, {configs = {languages = "c++17"}, includes = "pyincpp/pyincpp.hpp"}))
+        ]]}, {configs = {languages = "c++20"}, includes = "pyincpp/pyincpp.hpp"}))
     end)

--- a/packages/p/pyincpp/xmake.lua
+++ b/packages/p/pyincpp/xmake.lua
@@ -6,6 +6,7 @@ package("pyincpp")
     add_urls("https://github.com/chen-qingyu/pyincpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/chen-qingyu/pyincpp.git")
 
+    add_versions("v2.1.0", "437105ce0ced67c078c90aeb78627df6d42d7aaa80b3d35e0cf3c8a8dc8fc545")
     add_versions("v1.6.0", "1e8e4bfde447c439974180e206087b309f50ac0e24aeddf39d21d73fd7067368")
     add_versions("v1.4.1", "f3de3b5044a5c640811e87782264acbaf14697cd8c35bb21ddcd4de5664a60d0")
     add_versions("v1.3.3", "2689349de9faa35d8bbefddcc7d29d49308a2badd58961cc2b1a8f80c96d0823")

--- a/packages/p/pyincpp/xmake.lua
+++ b/packages/p/pyincpp/xmake.lua
@@ -21,10 +21,12 @@ package("pyincpp")
             #include <cassert>
             using namespace pyincpp;
             void test() {
-                Map<String, List<Integer>> map = {{"first", {123, 456}}, {"second", {789}}, {"second", {0}}, {"third", {"12345678987654321", 5}}};
-                assert(map.size() == 3);
-                assert(map.keys() == Set<String>({"first", "second", "third"}));
-                assert(map["third"][-1].factorial() == 120);
+                Dict<Str, List<Int>> dict = {{"first", {"123", "456"}}, {"second", {"789"}}, {"third", {"12345678987654321", "5"}}};
+                std::ostringstream oss;
+                oss << dict;
+                assert(oss.str() == "{\"first\": [123, 456], \"second\": [789], \"third\": [12345678987654321, 5]}");
+                assert(dict.keys() == Set<Str>{"first", "second", "third"});
+                assert(dict["third"][-1].factorial() == 120);
             }
         ]]}, {configs = {languages = "c++20"}, includes = "pyincpp/pyincpp.hpp"}))
     end)


### PR DESCRIPTION
New version of pyincpp detected (package version: v1.6.0, last github version: v2.1.0)