### PR TITLE
Auto-update simdjson to v3.9.2

### DIFF
--- a/packages/s/simdjson/xmake.lua
+++ b/packages/s/simdjson/xmake.lua
@@ -6,6 +6,7 @@ package("simdjson")
 
     add_urls("https://github.com/simdjson/simdjson/archive/refs/tags/$(version).tar.gz",
              "https://github.com/simdjson/simdjson.git")
+    add_versions("v3.9.2", "79fbe700f4ac3dd69c4f08275af58399daabd612bca0c0465aea959c60256651")
     add_versions("v3.9.1", "a4b6e7cd83176e0ccb107ce38521da40a8df41c2d3c90566f2a0af05b0cd05c4")
     add_versions("v3.8.0", "e28e3f46f0012d405b67de6c0a75e8d8c9a612b0548cb59687822337d73ca78b")
     add_versions("v0.9.5", "db69582fc5e4ece8c0a6a64894efeef475fe22fe466bd67195422de11b08b4d2")


### PR DESCRIPTION
New version of simdjson detected (package version: v3.9.1, last github version: v3.9.2)