### PR TITLE
fix test checks

### DIFF
--- a/scripts/test.lua
+++ b/scripts/test.lua
@@ -42,7 +42,7 @@ local options =
 
 -- check package is supported?
 function _check_package_is_supported()
-    for _, names in pairs(core_package.apis()) do
+    for _, names in pairs(core_package.apis) do
         for _, name in ipairs(names) do
             if type(name) == "string" and name == "package.on_check" then
                 return true


### PR DESCRIPTION
fix `error: field 'apis' is not callable (a nil value)` in scripts/test.lua

Resolved #4061 