### PR TITLE
Added support of Fortran in OpenMP package

### DIFF
--- a/packages/o/openmp/xmake.lua
+++ b/packages/o/openmp/xmake.lua
@@ -8,7 +8,7 @@ package("openmp")
 
     on_load(function (package)
         if package.has_tool then
-            for _, toolkind in ipairs({"cc", "cxx"}) do
+            for _, toolkind in ipairs({"cc", "cxx", "fc"}) do
                 if package:config("runtime") == "default" then
                     if package:has_tool(toolkind, "clang", "clangxx") then
                         package:add("deps", "libomp")
@@ -26,8 +26,14 @@ package("openmp")
         end
         local result = {}
         if package.has_tool then
-            for _, toolkind in ipairs({"cc", "cxx"}) do
-                local flagname = toolkind == "cxx" and "cxxflags" or "cflags"
+            for _, toolkind in ipairs({"cc", "cxx", "fc"}) do
+                if toolkind == "cxx" then
+                    flagname = "cxxflags"
+                elseif toolkind == "fc" then
+                    flagname = "fcflags"
+                else
+                    flagname = "cflags"
+                end
                 if package:has_tool(toolkind, "cl", "clang_cl") then
                     if package:config("feature") == "default" then
                         result[flagname] = "/openmp"
@@ -43,9 +49,9 @@ package("openmp")
                     else
                         result[flagname] = "-fopenmp"
                     end
-                elseif package:has_tool(toolkind, "gcc", "gxx") then
+                elseif package:has_tool(toolkind, "gcc", "gxx", "gfortran") then
                     result[flagname] = "-fopenmp"
-                elseif package:has_tool(toolkind, "icc", "icpc") then
+                elseif package:has_tool(toolkind, "icc", "icpc", "ifort") then
                     result[flagname] = "-qopenmp"
                 elseif package:has_tool(toolkind, "icl") then
                     result[flagname] = "-Qopenmp"
@@ -55,7 +61,7 @@ package("openmp")
                         if not package:is_plat("macosx") then
                             result.ldflags = "-fopenmp"
                         end
-                    elseif package:has_tool(toolkind, "gcc", "gxx") then
+                    elseif package:has_tool(toolkind, "gcc", "gxx", "gfortran") then
                         result.ldflags = "-fopenmp"
                     elseif package:has_tool(toolkind, "icc", "icpc") then
                         result.ldflags = "-qopenmp"
@@ -72,7 +78,7 @@ package("openmp")
         else
             raise("This package(openmp) requires xmake version 2.6.1 or newer.")
         end
-        return (result.cflags or result.cxxflags) and result
+        return (result.cflags or result.cxxflags or result.fcflags) and result
     end)
 
     on_install("linux", "macosx", "windows", "mingw@msys", function (package)


### PR DESCRIPTION
The PR addresses request #4065.
The modifications are as follows:

* Added support for Fortran compilers ("fc")
* Added support of GFortran and Intel Fortran (classic)

Tested on Mac OS X (Apple, arm64, GFortran) and Linux (AMD, x86_64, GFortran).

Small example to test the package (`hello_mp.F90`)
```
program hello_mp

#ifdef _OPENMP
    integer, external :: omp_get_num_threads, omp_get_thread_num
#endif

#ifdef _OPENMP
!$omp parallel
write(*, '(a,i0,a,i0)') 'Hello, ', omp_get_num_threads(), &
    ' threads are running and this thread ', omp_get_thread_num()
!$omp end parallel
#else
write(*,'(a)') 'Hello, this is a serial program'
#endif

end program hello_mp
```

Note that with GFortran, the extension needs to be in upper case (F90 instead of f90) to automatically enable C preprocssing, deactivated otherwise in GFortran.