### PR TITLE
Auto-update csvparser to 2.2.1

### DIFF
--- a/packages/c/csvparser/xmake.lua
+++ b/packages/c/csvparser/xmake.lua
@@ -4,6 +4,7 @@ package("csvparser")
     set_description("A modern C++ library for reading, writing, and analyzing CSV (and similar) files (by vincentlaucsb)")
 
     add_urls("https://github.com/vincentlaucsb/csv-parser/archive/refs/tags/$(version).zip")
+    add_versions("2.2.1", "96fd6a468f56fc157a11fcbc5cece6da952b06190837c46465d091eff674a813")
     add_versions("2.2.0", "b7744b28f3ac5f92c17379f323733cb8872ea48ef2347842604dc54285d60640")
     add_versions("2.1.1", "5fb6fc1c32196fb8cda144f192964b5bbedf61da9015d6c0edb8cb39b0dacff8")
 


### PR DESCRIPTION
New version of csvparser detected (package version: 2.2.0, last github version: 2.2.1)