### PR TITLE
Update fast_io to version 2024.03.31

### DIFF
--- a/packages/f/fast_io/xmake.lua
+++ b/packages/f/fast_io/xmake.lua
@@ -9,15 +9,24 @@ package("fast_io")
     add_urls("https://gitee.com/qabeowjbtkwb/fast_io.git")
 
     add_versions("2023.1.28", "b99b32ab429eb6256fd8de1e17fe38e4c54eb49c")
+    add_versions("2024.3.31", "a13c3ed1cd6da64b381322f3466f3b4fc9a80ff2")
 
     on_install("windows", "linux", "macosx", "msys", "mingw", function (package)
         os.cp("include", package:installdir())
     end)
 
     on_test(function (package)
-        assert(package:check_cxxsnippets({test = [[
-            void test() {
-                print("Hello, fast_io world!\n");
-            }
-        ]]}, {configs = {languages = "c++20"}, includes = {"fast_io.h"}}))
+        if package:version() == "2023.1.28" then
+            assert(package:check_cxxsnippets({test = [[
+                void test() {
+                    print("Hello, fast_io world!\n");
+                }
+            ]]}, {configs = {languages = "c++20"}, includes = {"fast_io.h"}}))
+        else 
+            assert(package:check_cxxsnippets({test = [[
+                void test() {
+                    fast_io::io::print("Hello, fast_io world!\n");
+                }
+            ]]}, {configs = {languages = "c++20"}, includes = {"fast_io.h"}}))
+        end
     end)


### PR DESCRIPTION
Update Fast_io to version 2024.03.31

fast_io 在新版本修复了部分Bug，并且添加了fast_io::io命名空间避免命名冲突。
因此在添加了新版本后，额外修改了on_test部分的测试逻辑
