### PR TITLE
Update tbb 2021.12.0

### DIFF
--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -76,8 +76,9 @@ package("tbb")
                 --  for r26c,r26b: ndkver is 26 and ndk_sdkver:="29" 
                 --  for the above ndk versions ,we have to a workaround
                 -- 
-                local exflags = {"-Wl", "--undefined-version"}
+                local exflags = {"-Wl,--undefined-version"}
                 if ndkver == 26 and ndk_sdkver == "29" then
+                    print("At this time point we have to add -Wl,--undefined-version to ldflags ")
                     import("package.tools.cmake").install(package, configs, {shflags = exflags, ldflags = exflags})
                 else
                     import("package.tools.cmake").install(package, configs)

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -67,14 +67,17 @@ package("tbb")
                 table.insert(configs, "-DCMAKE_SYSTEM_PROCESSOR=" .. (package:is_arch("x86_64") and "AMD64" or "i686"))
             end
             if package:is_plat("android") then
-                
                 local ndk = toolchain.load("ndk")
                 local ndk_sdkver = ndk:config("ndk_sdkver")
+                local exflags = {"-Wl", "--undefined-version"}
                 if ndk_sdkver and tonumber(ndk_sdkver) == 26 then
-                    table.insert(configs, "EXTRA_LDFLAGS=--undefined-version")
+                    import("package.tools.cmake").install(package, configs, {shflags = exflags, ldflags = exflags})
+                else
+                    import("package.tools.cmake").install(package, configs)
                 end
+            else
+                import("package.tools.cmake").install(package, configs)
             end
-            import("package.tools.cmake").install(package, configs)
             if package:is_plat("mingw") then
                 local ext = package:config("shared") and ".dll.a" or ".a"
                 local libfiles = os.files(path.join(package:installdir("lib"), "libtbb*" .. ext))

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -67,7 +67,8 @@ package("tbb")
                 table.insert(configs, "-DCMAKE_SYSTEM_PROCESSOR=" .. (package:is_arch("x86_64") and "AMD64" or "i686"))
             end
             if package:is_plat("android") then
-                local ndk = toolchain.load("ndk")
+                import("core.tool.toolchain")
+                local ndk = toolchain.load("ndk", {plat = package:plat(), arch = package:arch()})
                 local ndk_sdkver = ndk:config("ndk_sdkver")
                 local exflags = {"-Wl", "--undefined-version"}
                 if ndk_sdkver and tonumber(ndk_sdkver) == 26 then

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -74,7 +74,7 @@ package("tbb")
                     table.insert(exldflags, "-Wl")
                     table.insert(exldflags, "--undefined-version")
                 end
-                if #ldflags > 0 then
+                if #exldflags > 0 then
                     table.insert(configs, "EXTRA_LDFLAGS=" .. table.concat(exldflags, " "))
                 end
             end

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -70,14 +70,14 @@ package("tbb")
                 import("core.tool.toolchain")
                 local ndk = toolchain.load("ndk", {plat = package:plat(), arch = package:arch()})
                 local ndkver = ndk:config("ndkver")
-                local ndk_sdkver = tonumber(ndk:config("ndk_sdkver") )
+                -- local ndk_sdkver = tonumber(ndk:config("ndk_sdkver") )
                 
                 --  20240524:
-                --  for r26c,r26b: ndkver is 26 and ndk_sdkver:="29" 
+                --  for r26c,r26b: ndkver is 26 
                 --  for the above ndk versions ,we have to a workaround
                 -- 
                 local exflags = {"-Wl,--undefined-version"}
-                if ndkver == 26 and ndk_sdkver == 29 then
+                if ndkver == 26  then
                     print("At this time point we have to add -Wl,--undefined-version to ldflags ")
                     import("package.tools.cmake").install(package, configs, {shflags = exflags, ldflags = exflags})
                 else

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -67,15 +67,11 @@ package("tbb")
                 table.insert(configs, "-DCMAKE_SYSTEM_PROCESSOR=" .. (package:is_arch("x86_64") and "AMD64" or "i686"))
             end
             if target:is_plat("android") then
-                local exldflags = {}
+                
                 local ndk = toolchain.load("ndk")
                 local ndk_sdkver = ndk:config("ndk_sdkver")
                 if ndk_sdkver and tonumber(ndk_sdkver) == 26 then
-                    table.insert(exldflags, "-Wl")
-                    table.insert(exldflags, "--undefined-version")
-                end
-                if #exldflags > 0 then
-                    table.insert(configs, "EXTRA_LDFLAGS=" .. table.concat(exldflags, " "))
+                    table.insert(configs, "EXTRA_LDFLAGS=--undefined-version")
                 end
             end
             import("package.tools.cmake").install(package, configs)

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -66,7 +66,7 @@ package("tbb")
                 io.replace("cmake/compilers/GNU.cmake", "-Wl,-z,relro,-z,now,-z,noexecstack", "", {plain = true})
                 table.insert(configs, "-DCMAKE_SYSTEM_PROCESSOR=" .. (package:is_arch("x86_64") and "AMD64" or "i686"))
             end
-            if target:is_plat("android") then
+            if package:is_plat("android") then
                 
                 local ndk = toolchain.load("ndk")
                 local ndk_sdkver = ndk:config("ndk_sdkver")

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -77,7 +77,7 @@ package("tbb")
                 --  for the above ndk versions ,we have to a workaround
                 -- 
                 local exflags = {"-Wl,--undefined-version"}
-                if ndkver == 26 and ndk_sdkver == "29" then
+                if ndkver == 26 and ndk_sdkver == 29 then
                     print("At this time point we have to add -Wl,--undefined-version to ldflags ")
                     import("package.tools.cmake").install(package, configs, {shflags = exflags, ldflags = exflags})
                 else

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -69,12 +69,15 @@ package("tbb")
             if package:is_plat("android") then
                 import("core.tool.toolchain")
                 local ndk = toolchain.load("ndk", {plat = package:plat(), arch = package:arch()})
-                local ndk_sdkver = ndk:config("ndk_sdkver")
-                print("NDK= ", ndk)
-                print("NDK_SDKVER= ", ndk_sdkver)
-                print("TONUMBER_NDK_SDKVER= ", tonumber(ndk_sdkver))
+                local ndkver = ndk:config("ndkver")
+                local ndk_sdkver = tonumber(ndk:config("ndk_sdkver") )
+                
+                --  20240524:
+                --  for r26c,r26b: ndkver is 26 and ndk_sdkver:="29" 
+                --  for the above ndk versions ,we have to a workaround
+                -- 
                 local exflags = {"-Wl", "--undefined-version"}
-                if ndk_sdkver and tonumber(ndk_sdkver) == 26 then
+                if ndkver == 26 and ndk_sdkver == "29" then
                     import("package.tools.cmake").install(package, configs, {shflags = exflags, ldflags = exflags})
                 else
                     import("package.tools.cmake").install(package, configs)

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -70,6 +70,9 @@ package("tbb")
                 import("core.tool.toolchain")
                 local ndk = toolchain.load("ndk", {plat = package:plat(), arch = package:arch()})
                 local ndk_sdkver = ndk:config("ndk_sdkver")
+                print("NDK= ", ndk)
+                print("NDK_SDKVER= ", ndk_sdkver)
+                print("TONUMBER_NDK_SDKVER= ", tonumber(ndk_sdkver))
                 local exflags = {"-Wl", "--undefined-version"}
                 if ndk_sdkver and tonumber(ndk_sdkver) == 26 then
                     import("package.tools.cmake").install(package, configs, {shflags = exflags, ldflags = exflags})

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -70,7 +70,7 @@ package("tbb")
                 local exldflags = {}
                 local ndk = toolchain.load("ndk")
                 local ndk_sdkver = ndk:config("ndk_sdkver")
-                if ndk_sdkver and tonumber(ndk_sdkver) == 26
+                if ndk_sdkver and tonumber(ndk_sdkver) == 26 then
                     table.insert(exldflags, "-Wl")
                     table.insert(exldflags, "--undefined-version")
                 end

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -66,26 +66,18 @@ package("tbb")
                 io.replace("cmake/compilers/GNU.cmake", "-Wl,-z,relro,-z,now,-z,noexecstack", "", {plain = true})
                 table.insert(configs, "-DCMAKE_SYSTEM_PROCESSOR=" .. (package:is_arch("x86_64") and "AMD64" or "i686"))
             end
+
+            local exflags
             if package:is_plat("android") then
                 import("core.tool.toolchain")
+
                 local ndk = toolchain.load("ndk", {plat = package:plat(), arch = package:arch()})
                 local ndkver = ndk:config("ndkver")
-                -- local ndk_sdkver = tonumber(ndk:config("ndk_sdkver") )
-                
-                --  20240524:
-                --  for r26c,r26b: ndkver is 26 
-                --  for the above ndk versions ,we have to a workaround
-                -- 
-                local exflags = {"-Wl,--undefined-version"}
-                if ndkver == 26  then
-                    print("At this time point we have to add -Wl,--undefined-version to ldflags ")
-                    import("package.tools.cmake").install(package, configs, {shflags = exflags, ldflags = exflags})
-                else
-                    import("package.tools.cmake").install(package, configs)
+                if ndkver == 26 then
+                    exflags = {"-Wl,--undefined-version"}
                 end
-            else
-                import("package.tools.cmake").install(package, configs)
             end
+            import("package.tools.cmake").install(package, configs, {shflags = exflags, ldflags = exflags})
             if package:is_plat("mingw") then
                 local ext = package:config("shared") and ".dll.a" or ".a"
                 local libfiles = os.files(path.join(package:installdir("lib"), "libtbb*" .. ext))

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -19,6 +19,7 @@ package("tbb")
         add_versions("2021.7.0", "2cae2a80cda7d45dc7c072e4295c675fff5ad8316691f26f40539f7e7e54c0cc")
         add_versions("2021.10.0", "487023a955e5a3cc6d3a0d5f89179f9b6c0ae7222613a7185b0227ba0c83700b")
         add_versions("2021.11.0", "782ce0cab62df9ea125cdea253a50534862b563f1d85d4cda7ad4e77550ac363")
+        add_versions("2021.12.0", "c7bb7aa69c254d91b8f0041a71c5bcc3936acb64408a1719aec0b2b7639dd84f")
     else
         add_urls("https://github.com/oneapi-src/oneTBB/archive/v$(version).tar.gz")
         add_versions("2020.3", "ebc4f6aa47972daed1f7bf71d100ae5bf6931c2e3144cf299c8cc7d041dca2f3")
@@ -29,7 +30,8 @@ package("tbb")
         add_versions("2021.7.0", "2cae2a80cda7d45dc7c072e4295c675fff5ad8316691f26f40539f7e7e54c0cc")
         add_versions("2021.10.0", "487023a955e5a3cc6d3a0d5f89179f9b6c0ae7222613a7185b0227ba0c83700b")
         add_versions("2021.11.0", "782ce0cab62df9ea125cdea253a50534862b563f1d85d4cda7ad4e77550ac363")
-
+        add_versions("2021.12.0", "c7bb7aa69c254d91b8f0041a71c5bcc3936acb64408a1719aec0b2b7639dd84f")
+    
         add_patches("2021.2.0", path.join(os.scriptdir(), "patches", "2021.2.0", "gcc11.patch"), "181511cf4878460cb48ac0531d3ce8d1c57626d698e9001a0951c728fab176fb")
         add_patches("2021.5.0", path.join(os.scriptdir(), "patches", "2021.5.0", "i386.patch"), "1a1c11724839cf98b1b8f4d415c0283ec7719c330b11503c578739eb02889ec0")
 

--- a/packages/t/tbb/xmake.lua
+++ b/packages/t/tbb/xmake.lua
@@ -66,6 +66,18 @@ package("tbb")
                 io.replace("cmake/compilers/GNU.cmake", "-Wl,-z,relro,-z,now,-z,noexecstack", "", {plain = true})
                 table.insert(configs, "-DCMAKE_SYSTEM_PROCESSOR=" .. (package:is_arch("x86_64") and "AMD64" or "i686"))
             end
+            if target:is_plat("android") then
+                local exldflags = {}
+                local ndk = toolchain.load("ndk")
+                local ndk_sdkver = ndk:config("ndk_sdkver")
+                if ndk_sdkver and tonumber(ndk_sdkver) == 26
+                    table.insert(exldflags, "-Wl")
+                    table.insert(exldflags, "--undefined-version")
+                end
+                if #ldflags > 0 then
+                    table.insert(configs, "EXTRA_LDFLAGS=" .. table.concat(exldflags, " "))
+                end
+            end
             import("package.tools.cmake").install(package, configs)
             if package:is_plat("mingw") then
                 local ext = package:config("shared") and ".dll.a" or ".a"


### PR DESCRIPTION
Fixed parallel_for_each algorithm behavior for iterators defining iterator_concept trait instead of iterator_category.
Fixed the redefinition issue for std::min and std::max on Windows* OS (https://github.com/oneapi-src/oneTBB/issues/832).
Fixed the incorrect binary search order in TBBConfig.cmake.


https://github.com/oneapi-src/oneTBB/releases