### PR TITLE
Auto-update duckdb to v0.10.3

### DIFF
--- a/packages/d/duckdb/xmake.lua
+++ b/packages/d/duckdb/xmake.lua
@@ -5,6 +5,7 @@ package("duckdb")
 
     add_urls("https://github.com/duckdb/duckdb/releases/download/$(version)/libduckdb-src.zip",
              "https://github.com/duckdb/duckdb.git")
+    add_versions("v0.10.3", "f22ed5058188c81886dfdda80c6c46b7df2ed0a623a348c78ac8372451c84497")
     add_versions("v0.10.0", "385e27aa67712813e4a07389465c4c5c45c431d97cddd35713b8a306d2a86f2d")
     add_versions("v0.10.1", "70ec6ffefd9a04bf9fcdc1a4949611f9633f10f0e3b9cead1425b926a54d0f89")
     add_versions("v0.10.2", "6bab203dc2e10432edbefda7be7043f73f17c8898ba81ce3aa2319e7e2d5af10")


### PR DESCRIPTION
New version of duckdb detected (package version: v0.10.2, last github version: v0.10.3)