### PR TITLE
Auto-update glog to v0.7.0

### DIFF
--- a/packages/g/glog/xmake.lua
+++ b/packages/g/glog/xmake.lua
@@ -50,9 +50,9 @@ package("glog")
             table.insert(configs, "-DWITH_" .. config:upper() .. "=" .. (package:config(config) and "ON" or "OFF"))
         end
 
-        if (is_host("macosx") and package:is_plat("mingw")) or package:is_plat("msys") then
+        if package:is_plat("mingw") then
             -- fix cmake try run
-            table.insert(configs, "-DWITH_SYMBOLIZE=OFF")
+            table.insert(configs, "-DHAVE_SYMBOLIZE_EXITCODE=ON")
         end
         import("package.tools.cmake").install(package, configs)
     end)

--- a/packages/g/glog/xmake.lua
+++ b/packages/g/glog/xmake.lua
@@ -49,6 +49,11 @@ package("glog")
         for config, dep in pairs(configdeps) do
             table.insert(configs, "-DWITH_" .. config:upper() .. "=" .. (package:config(config) and "ON" or "OFF"))
         end
+
+        if is_host("macosx") and package:is_plat("mingw") then
+            -- fix cmake try run
+            table.insert(configs, "-DWITH_SYMBOLIZE=OFF")
+        end
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/g/glog/xmake.lua
+++ b/packages/g/glog/xmake.lua
@@ -53,5 +53,9 @@ package("glog")
     end)
 
     on_test(function (package)
-        assert(package:has_cxxfuncs("google::InitGoogleLogging(\"glog\")", {includes = "glog/logging.h"}))
+        local languages
+        if package:version():ge("0.7.0") then
+            languages = "c++14"
+        end
+        assert(package:has_cxxfuncs("google::InitGoogleLogging(\"glog\")", {includes = "glog/logging.h", configs = {languages = languages}}))
     end)

--- a/packages/g/glog/xmake.lua
+++ b/packages/g/glog/xmake.lua
@@ -50,7 +50,7 @@ package("glog")
             table.insert(configs, "-DWITH_" .. config:upper() .. "=" .. (package:config(config) and "ON" or "OFF"))
         end
 
-        if is_host("macosx") and package:is_plat("mingw") then
+        if (is_host("macosx") and package:is_plat("mingw")) or package:is_plat("msys") then
             -- fix cmake try run
             table.insert(configs, "-DWITH_SYMBOLIZE=OFF")
         end

--- a/packages/g/glog/xmake.lua
+++ b/packages/g/glog/xmake.lua
@@ -1,11 +1,11 @@
 package("glog")
-
     set_homepage("https://github.com/google/glog/")
     set_description("C++ implementation of the Google logging module")
     set_license("BSD-3-Clause")
 
     add_urls("https://github.com/google/glog/archive/refs/tags/$(version).tar.gz",
              "https://github.com/google/glog.git")
+
     add_versions("v0.7.0", "375106b5976231b92e66879c1a92ce062923b9ae573c42b56ba28b112ee4cc11")
     add_versions("v0.4.0", "f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c")
     add_versions("v0.5.0", "eede71f28371bf39aa69b45de23b329d37214016e2055269b3b5e7cfd40b59f5")
@@ -20,9 +20,11 @@ package("glog")
 
     if is_plat("linux") then
         add_syslinks("pthread")
+    elseif is_plat("windows") then
+        add_syslinks("dbghelp")
     end
 
-    on_load("windows", "linux", "macosx", "android", "iphoneos", "cross", function (package)
+    on_load(function (package)
         if package:is_plat("windows") then
             if package:version():le("0.4") and not package:config("shared") then
                 package:add("defines", "GOOGLE_GLOG_DLL_DECL=")
@@ -34,9 +36,13 @@ package("glog")
                 package:add("deps", dep)
             end
         end
+
+        if package:version():ge("0.7.0") then
+            package:add("defines", "GLOG_USE_GLOG_EXPORT")
+        end
     end)
 
-    on_install("windows", "linux", "macosx", "android", "iphoneos", "cross", function (package)
+    on_install(function (package)
         local configs = {"-DBUILD_TESTING=OFF", "-DCMAKE_INSTALL_LIBDIR=lib"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))

--- a/packages/g/glog/xmake.lua
+++ b/packages/g/glog/xmake.lua
@@ -6,6 +6,7 @@ package("glog")
 
     add_urls("https://github.com/google/glog/archive/refs/tags/$(version).tar.gz",
              "https://github.com/google/glog.git")
+    add_versions("v0.7.0", "375106b5976231b92e66879c1a92ce062923b9ae573c42b56ba28b112ee4cc11")
     add_versions("v0.4.0", "f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c")
     add_versions("v0.5.0", "eede71f28371bf39aa69b45de23b329d37214016e2055269b3b5e7cfd40b59f5")
     add_versions("v0.6.0", "8a83bf982f37bb70825df71a9709fa90ea9f4447fb3c099e1d720a439d88bad6")


### PR DESCRIPTION
New version of glog detected (package version: v0.6.0, last github version: v0.7.0)