### PR TITLE
feat: Update hdf5 version

### DIFF
--- a/packages/h/hdf5/xmake.lua
+++ b/packages/h/hdf5/xmake.lua
@@ -14,6 +14,8 @@ package("hdf5")
     add_versions("1.13.2", "01643fa5b37dba7be7c4db6bbf3c5d07adf5c1fa17dbfaaa632a279b1b2f06da")
     add_versions("1.13.3", "83c7c06671f975cee6944b0b217f95005faa55f79ea5532cf4ac268989866af4")
     add_versions("1.14.0", "a571cc83efda62e1a51a0a912dd916d01895801c5025af91669484a1575a6ef4")
+    add_versions("1.14.2", "1c342e634008284a8c2794c8e7608e2eaf26d01d445fb3dfd7f33cb2fb51ac53")
+    add_versions("1.14.3", "09cdb287aa7a89148c1638dd20891fdbae08102cf433ef128fd345338aa237c7")
 
     add_configs("cpplib", {description = "Build HDF5 C++ Library", default = false, type = "boolean"})
 


### PR DESCRIPTION
Update hdf5 version(1.14.2/1.14.3).

**1.14.3 CHANGELOG**

* Many parallel HDF5 bug fixes and improvements
* Improved read-only S3 VFD performance
* Many new Fortran API wrappers, including wrappers for async API calls
* A new H5Pset_actual_selection_io_mode() API call for determining if selection I/O was actually used in an I/O operation
* Improved cross-compiling support
* Better compiler support for Intel, AMD, and NVidia


**1.14.2 CHANGELOG**
* Updated HDF5 API tests CMake code to support VOL connectors
* Added support for selection I/O in the MPIO file driver
* Several bug and CVE fixes