### PR TITLE
Auto-update xpack to v1.0.6

### DIFF
--- a/packages/x/xpack/xmake.lua
+++ b/packages/x/xpack/xmake.lua
@@ -7,6 +7,7 @@ package("xpack")
     add_urls("https://github.com/xyz347/xpack/archive/refs/tags/$(version).tar.gz",
              "https://github.com/xyz347/xpack.git")
 
+    add_versions("v1.0.6", "76ccd82b0f0ddaae93d2340b2fa49e3245c2eb15c147f4736e27e8b05616085d")
     add_versions("v1.0.5", "ea8693dd3a53d54e0c1e3c9e6e06f31ff7f593f7f8cf8fb4889f5c3354dbae8e")
 
     add_deps("rapidjson", "rapidxml")


### PR DESCRIPTION
New version of xpack detected (package version: v1.0.5, last github version: v1.0.6)