### PR TITLE
Auto-update whisper.cpp to 1.6.2

### DIFF
--- a/packages/w/whisper.cpp/xmake.lua
+++ b/packages/w/whisper.cpp/xmake.lua
@@ -6,6 +6,7 @@ package("whisper.cpp")
     set_urls("https://github.com/ggerganov/whisper.cpp/archive/refs/tags/v$(version).tar.gz",
              "https://github.com/ggerganov/whisper.cpp.git")
 
+    add_versions("1.6.2", "da7988072022acc3cfa61b370b3c51baad017f1900c3dc4e68cb276499f66894")
     add_versions("1.6.0", "2729a83662edf909dad66115a3b616c27011cbe4c05335656034954c91ba0c92")
     add_versions("1.5.5", "27fa5c472657af2a6cee63de349a34b23d0f3781fa9b8ef301a940cf64964a79")
     add_versions("1.5.4", "06eed84de310fdf5408527e41e863ac3b80b8603576ba0521177464b1b341a3a")


### PR DESCRIPTION
New version of whisper.cpp detected (package version: 1.6.0, last github version: 1.6.2)