### PR TITLE
Auto-update hpx to v1.10.0

### DIFF
--- a/packages/h/hpx/xmake.lua
+++ b/packages/h/hpx/xmake.lua
@@ -6,6 +6,7 @@ package("hpx")
     add_urls("https://github.com/STEllAR-GROUP/hpx/archive/refs/tags/$(version).tar.gz",
              "https://github.com/STEllAR-GROUP/hpx.git")
 
+    add_versions("v1.10.0", "5720ed7d2460fa0b57bd8cb74fa4f70593fe8675463897678160340526ec3c19")
     add_versions("v1.9.1", "1adae9d408388a723277290ddb33c699aa9ea72defadf3f12d4acc913a0ff22d")
 
     add_configs("malloc", {description = "Use a custom allocator", default = "system", values = {"system", "tcmalloc", "jemalloc", "mimalloc"}})


### PR DESCRIPTION
New version of hpx detected (package version: v1.9.1, last github version: v1.10.0)