### PR TITLE
Auto-update liboai to 4.0.1

### DIFF
--- a/packages/l/liboai/xmake.lua
+++ b/packages/l/liboai/xmake.lua
@@ -6,6 +6,7 @@ package("liboai")
     set_urls("https://github.com/D7EAD/liboai/archive/refs/tags/v$(version).tar.gz",
              "https://github.com/D7EAD/liboai.git")
 
+    add_versions("4.0.1", "abe127ae1cd3049f19976e31d8414e8130a73d7978552e863b767fe04b20697f")
     add_versions("3.2.1", "9058bcc1485967061c9c33b2e7a109a254cdf71638b1448f21cfefd7ffd9c4fa")
     add_versions("3.1.0", "4b3564740f7dbf099c785d5720327a4e7acaca2535d329f487d877ce17524a73")
 


### PR DESCRIPTION
New version of liboai detected (package version: 3.2.1, last github version: 4.0.1)