### PR TITLE
Auto-update harfbuzz to 8.5.0

### DIFF
--- a/packages/h/harfbuzz/xmake.lua
+++ b/packages/h/harfbuzz/xmake.lua
@@ -6,6 +6,7 @@ package("harfbuzz")
 
     add_urls("https://github.com/harfbuzz/harfbuzz/archive/refs/tags/$(version).tar.gz", {excludes = "README"})
     add_urls("https://github.com/harfbuzz/harfbuzz.git")
+    add_versions("8.5.0", "7ad8e4e23ce776efb6a322f653978b3eb763128fd56a90252775edb9fd327956")
     add_versions("8.4.0", "9f1ca089813b05944ad1ce8c7e018213026d35dc9bab480a21eb876838396556")
     add_versions("2.8.1", "b3f17394c5bccee456172b2b30ddec0bb87e9c5df38b4559a973d14ccd04509d")
     add_versions("2.9.0", "bf5d5bad69ee44ff1dd08800c58cb433e9b3bf4dad5d7c6f1dec5d1cf0249d04")


### PR DESCRIPTION
New version of harfbuzz detected (package version: 8.4.0, last github version: 8.5.0)