### PR TITLE
Auto-update gyp-next to v0.18.1

### DIFF
--- a/packages/g/gyp-next/xmake.lua
+++ b/packages/g/gyp-next/xmake.lua
@@ -7,6 +7,7 @@ package("gyp-next")
 
     add_urls("https://github.com/nodejs/gyp-next/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nodejs/gyp-next.git")
+    add_versions("v0.18.1", "f9be5e64a992688b651d64c6f269a8a701b843e089c048fae0733e9eb01dd48e")
     add_versions("v0.18.0", "2c0e002843da6a854d937a93d6fad5993954a457b3ffc2031d8af2dcff42caba")
     add_versions("v0.16.2", "145d5719a88112ae2631a88556361da3b8780f4179a928c823ba3d18ab796464")
     add_versions("v0.16.1", "892fecef9ca3fa1eff8bd18b7bcec54c6e8a2203788c048d26bccb53d9fcf737")


### PR DESCRIPTION
New version of gyp-next detected (package version: v0.18.0, last github version: v0.18.1)