### PR TITLE
Auto-update etl to 20.38.17

### DIFF
--- a/packages/e/etl/xmake.lua
+++ b/packages/e/etl/xmake.lua
@@ -7,6 +7,7 @@ package("etl")
     add_urls("https://github.com/ETLCPP/etl/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ETLCPP/etl.git")
 
+    add_versions("20.38.17", "5b490aca3faad3796a48bf0980e74f2a67953967fad3c051a6d4981051cb0b9a")
     add_versions("20.38.16", "6d05e33d6e7eb2c8d4654c77dcd083adc70da29aba808f471ba7c6e2b8fcbf03")
     add_versions("20.38.13", "e606083e189a8fe6211c30c8c579b60c29658a531b5cafbb511daab1a2861a69")
     add_versions("20.38.11", "c73b6b076ab59e02398a9f90a66198a9f8bf0cfa91af7be2eebefb3bb264ba83")


### PR DESCRIPTION
New version of etl detected (package version: 20.38.16, last github version: 20.38.17)