### PR TITLE
Use glog <0.7.0 for folly

### DIFF
--- a/packages/f/folly/xmake.lua
+++ b/packages/f/folly/xmake.lua
@@ -32,7 +32,7 @@ package("folly")
     add_deps("cmake")
     add_deps("boost", {configs = {date_time = true, iostreams = true, context = true, filesystem = true, program_options = true, regex = true, system = true, thread = true}})
     add_deps("libevent", {configs = {openssl = true}})
-    add_deps("double-conversion", "gflags", "glog", "zlib", "fmt")
+    add_deps("double-conversion", "gflags", "glog <0.7.0", "zlib", "fmt")
     add_deps("bzip2", "lz4", "zstd", {optional = true})
     if is_plat("linux") then
         add_syslinks("pthread")


### PR DESCRIPTION
Folly do not support glog 0.7.0 yet:
https://github.com/facebook/folly/issues/2171
