### PR TITLE
Auto-update tinygltf to v2.8.22

### DIFF
--- a/packages/t/tinygltf/xmake.lua
+++ b/packages/t/tinygltf/xmake.lua
@@ -6,6 +6,7 @@ package("tinygltf")
 
     add_urls("https://github.com/syoyo/tinygltf/archive/refs/tags/$(version).tar.gz",
              "https://github.com/syoyo/tinygltf.git")
+    add_versions("v2.8.22", "97c3eb1080c1657cd749d0b49af189c6a867d5af30689c48d5e19521e7b5a070")
     add_versions("v2.8.21", "e567257d7addde58b0a483832cbaa5dd8f15e5bcaee6f023831e215d1a2c0502")
     add_versions("v2.5.0", "5d85bd556b60b1b69527189293cfa4902957d67fabb8582b6532f23a5ef27ec1")
     add_versions("v2.6.3", "f61e4a501baa7fbf31b18ea0f6815a59204ad0de281f7b04f0168f6bbd17c340")


### PR DESCRIPTION
New version of tinygltf detected (package version: v2.8.21, last github version: v2.8.22)