### PR TITLE
remove void test return 0 statement

### DIFF
--- a/packages/b/boost/xmake.lua
+++ b/packages/b/boost/xmake.lua
@@ -444,7 +444,6 @@ package("boost")
                     static void test() {
                         boost::iostreams::filtering_ostream out;
                         out.push(boost::iostreams::zstd_compressor());
-                        return 0;
                     }
                 ]]}, {configs = {languages = "c++14"}}))
             end
@@ -455,7 +454,6 @@ package("boost")
                     static void test() {
                         boost::iostreams::filtering_ostream out;
                         out.push(boost::iostreams::lzma_compressor());
-                        return 0;
                     }
                  ]]}, {configs = {languages = "c++14"}}))
             end


### PR DESCRIPTION
for boost lzma zstd 
测试函数从 int main() 改成 void test() 之后 忘记删除 return 0
删除多余的 return 0；


