### PR TITLE
Auto-update pdfhummus to v4.6.4

### DIFF
--- a/packages/p/pdfhummus/xmake.lua
+++ b/packages/p/pdfhummus/xmake.lua
@@ -6,6 +6,7 @@ package("pdfhummus")
     add_urls("https://github.com/galkahana/PDF-Writer/archive/refs/tags/$(version).tar.gz",
              "https://github.com/galkahana/PDF-Writer/archive/refs/tags/v$(version).tar.gz",
              "https://github.com/galkahana/PDF-Writer.git")
+    add_versions("v4.6.4", "93b5f1dc88fd67fdebde409e927e828dfbae02efa44936e89728622411c6a047")
     add_versions("v4.6.3", "3b5d9ba4b49d0380678e8172f27cdb8eda196ea448e7f1cdd79620066d082ab9")
     add_versions("v4.6.2", "0a36815ccc9d207028567f90039785c824b211169ba5da68de84d0c15455ab62")
     add_versions("v4.6.1", "6e95fcb26ec679fa12ce6638d35a591e80960b35956a142d9a80b9a8c80ca824")


### PR DESCRIPTION
New version of pdfhummus detected (package version: v4.6.3, last github version: v4.6.4)