### PR TITLE
(Check if Dataframe 3.1.0 can pass ci)

### DIFF
--- a/packages/d/dataframe/xmake.lua
+++ b/packages/d/dataframe/xmake.lua
@@ -6,6 +6,7 @@ package("dataframe")
     add_urls("https://github.com/hosseinmoein/DataFrame/archive/refs/tags/$(version).tar.gz",
              "https://github.com/hosseinmoein/DataFrame.git")
 
+    add_versions("3.1.0", "09280a81f17d87d171062210c904c1acd94b1cdcf4c040eaa16cc9d224d526d4")
     add_versions("3.0.0", "9266fb85c518a251a5440e490c81615601791f2de2fad8755aa09f13a0c541f9")
     add_versions("1.21.0", "a6b07eaaf628225a34e4402c1a6e311430e8431455669ac03691d92f44081172")
     add_versions("1.22.0", "4b244241cd56893fccb22f7c874588f0d86b444912382ed6e9a4cf95e55ffda2")


### PR DESCRIPTION
view::zip has been implemented in gcc13 and msvc-cl now

