### PR TITLE
Auto-update drogon to v1.9.5

### DIFF
--- a/packages/d/drogon/xmake.lua
+++ b/packages/d/drogon/xmake.lua
@@ -6,6 +6,7 @@ package("drogon")
 
     add_urls("https://github.com/an-tao/drogon/archive/refs/tags/$(version).tar.gz",
              "https://github.com/an-tao/drogon.git")
+    add_versions("v1.9.5", "ec17882835abeb0672db29cb36ab0c5523f144d5d8ff177861b8f5865803eaae")
     add_versions("v1.9.4", "b23d9d01d36fb1221298fcdbedcf7fd3e1b8b8821bf6fb8ed073c8b0c290d11d")
     add_versions("v1.9.3", "fb4ef351b3e4c06ed850cfbbf50c571502decb1738fb7d62a9d7d70077c9fc23")
     add_versions("v1.4.1", "ad794d7744b600240178348c15e216c919fe7a2bc196cf1239f129aee2af19c7")


### PR DESCRIPTION
New version of drogon detected (package version: v1.9.4, last github version: v1.9.5)