### PR TITLE
Auto-update reflect-cpp to v0.11.1

### DIFF
--- a/packages/r/reflect-cpp/xmake.lua
+++ b/packages/r/reflect-cpp/xmake.lua
@@ -7,6 +7,7 @@ package("reflect-cpp")
     add_urls("https://github.com/getml/reflect-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/getml/reflect-cpp.git")
 
+    add_versions("v0.11.1", "e45f112fb3f14507a4aa53b99ae2d4ab6a4e7b2d5f04dd06fec00bf7faa7bbdc")
     add_versions("v0.10.0", "d2c8876d993ddc8c57c5804e767786bdb46a2bdf1a6cd81f4b14f57b1552dfd7")
 
     add_patches("0.10.0", "patches/0.10.0/cmake.patch", "b8929c0a13bd4045cbdeea0127e08a784e2dc8c43209ca9f056fff4a3ab5c4d3")


### PR DESCRIPTION
New version of reflect-cpp detected (package version: v0.10.0, last github version: v0.11.1)