### PR TITLE
improve folly

### DIFF
--- a/packages/f/folly/xmake.lua
+++ b/packages/f/folly/xmake.lua
@@ -21,6 +21,8 @@ package("folly")
     add_versions("2024.04.01", "f09e522c76a5f102c40c54726f6f255b0dc127c78f9c8c9ac117fc0f7ac284bb")
     add_versions("2024.06.10", "27d7f825a9a3469b59a4f0a5ba2edac733407ea8dcc036e7ca9279d803ece1e9")
 
+    add_patches("<=2022.08.29", path.join(os.scriptdir(), "patches", "2021.06.28", "reorder.patch"), "9a6bf283881580474040cfc7a8e89d461d68b89bae5583d89fff0a3198739980")
+    add_patches("<=2022.08.29", path.join(os.scriptdir(), "patches", "2021.06.28", "regex.patch"), "6a77ade9f48dd9966d3f7154e66ca8a5c030ae2b6d335cbe3315784aefd8f495")
     add_patches("<=2024.04.01", path.join(os.scriptdir(), "patches", "2023.11.20", "pkgconfig.patch"), "6838623d453418569853f62ad97c729e802a120c13d804aabba6d6455997e674")
     add_patches("<=2024.04.01", path.join(os.scriptdir(), "patches", "2023.11.20", "msvc.patch"), "1ee01c75528bd42736541022af461e44af3031c01d62c9342006f0abc0f44f2d")
 


### PR DESCRIPTION
- Keeping the outdated version here is somewhat pointless due to folly's rolling release development approach.
- The latest version has been included.
- Enable libaio and liburing features on Linux.
- Packages relying on folly will be updated in the upcoming PRs.