### PR TITLE
Auto-update efsw to 1.4.0

### DIFF
--- a/packages/e/efsw/xmake.lua
+++ b/packages/e/efsw/xmake.lua
@@ -5,6 +5,7 @@ package("efsw")
 
     set_urls("https://github.com/SpartanJ/efsw/archive/refs/tags/$(version).tar.gz",
              "https://github.com/SpartanJ/efsw.git")
+    add_versions("1.4.0", "9eed5fc8471767faa44134f5379d4de02825e3756007dafa482fd1656e42bc4a")
     add_versions("1.3.1", "3c0efe023258712d25644977227f07cf7edf7e5dc00ffa8d88733f424fa6af86")
     add_versions("1.3.0", "e190b72f23d92c42e1a0dab9bb6354a56f75c7535fd1f3e3a10b1c317e05f8f6")
     add_versions("1.2.0", "66d8631deeb2af50511e84cae7e745134e6a22811c93246e39e7001af887a7db")


### PR DESCRIPTION
New version of efsw detected (package version: 1.3.1, last github version: 1.4.0)