### PR TITLE
Auto-update cgltf to v1.14

### DIFF
--- a/packages/c/cgltf/xmake.lua
+++ b/packages/c/cgltf/xmake.lua
@@ -6,6 +6,7 @@ package("cgltf")
 
     add_urls("https://github.com/jkuhlmann/cgltf/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jkuhlmann/cgltf.git")
+    add_versions("v1.14", "2f3c97a6b989943f50e7d7f228688f6558fe37b1411c13a350e3560d061707d8")
     add_versions("v1.13", "053d5320097334767486c6e33d01dd1b1c6224eac82aac2d720f4ec456d8c50b")
 
     on_install(function (package)


### PR DESCRIPTION
New version of cgltf detected (package version: v1.13, last github version: v1.14)