### PR TITLE
Auto-update libbpf to v1.4.3

### DIFF
--- a/packages/l/libbpf/xmake.lua
+++ b/packages/l/libbpf/xmake.lua
@@ -5,6 +5,7 @@ package("libbpf")
 
     add_urls("https://github.com/libbpf/libbpf/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libbpf/libbpf.git")
+    add_versions("v1.4.3", "d8be49641dd4c5caa27986a8291907176e3b6fd6fe650e4fee5b45f8093fc935")
     add_versions("v0.3", "c168d84a75b541f753ceb49015d9eb886e3fb5cca87cdd9aabce7e10ad3a1efc")
 
     add_deps("libelf", "zlib")


### PR DESCRIPTION
New version of libbpf detected (package version: v0.3, last github version: v1.4.3)