### PR TITLE
Auto-update sentry-native to 0.7.6

### DIFF
--- a/packages/s/sentry-native/xmake.lua
+++ b/packages/s/sentry-native/xmake.lua
@@ -5,6 +5,7 @@ package("sentry-native")
     set_urls("https://github.com/getsentry/sentry-native/releases/download/$(version)/sentry-native.zip",
              "https://github.com/getsentry/sentry-native.git")
 
+    add_versions("0.7.6", "42180ad933a3a2bd86a1649ed0f1a41df20e783ce17c5cb1f86775f7caf06bc1")
     add_versions("0.7.5", "d9f1b44753fae3e9462aa1e6fd3021cb0ff2f51c1a1fa02b34510e3bc311f429")
     add_versions("0.7.2", "afb44d5cc4e0ec5f2e8068132c68256959188f6bf015e1837e7cc687014b9c70")
     add_versions("0.7.1", "c450a064b0dbb1883a355455db2b6469abef59c04686a53719384bbc7ff507d3")


### PR DESCRIPTION
New version of sentry-native detected (package version: 0.7.5, last github version: 0.7.6)