### PR TITLE
Auto-update fribidi to 1.0.15

### DIFF
--- a/packages/f/fribidi/xmake.lua
+++ b/packages/f/fribidi/xmake.lua
@@ -5,6 +5,7 @@ package("fribidi")
     set_license("LGPL-2.1")
 
     add_urls("https://github.com/fribidi/fribidi/releases/download/v$(version)/fribidi-$(version).tar.xz")
+    add_versions("1.0.15", "0bbc7ff633bfa208ae32d7e369cf5a7d20d5d2557a0b067c9aa98bcbf9967587")
     add_versions("1.0.14", "76ae204a7027652ac3981b9fa5817c083ba23114340284c58e756b259cd2259a")
     add_versions("1.0.10", "7f1c687c7831499bcacae5e8675945a39bacbad16ecaa945e9454a32df653c01")
     add_versions("1.0.11", "30f93e9c63ee627d1a2cedcf59ac34d45bf30240982f99e44c6e015466b4e73d")


### PR DESCRIPTION
New version of fribidi detected (package version: 1.0.14, last github version: 1.0.15)