### PR TITLE
Auto-update toml11 to v4.0.0

### DIFF
--- a/packages/t/toml11/xmake.lua
+++ b/packages/t/toml11/xmake.lua
@@ -7,6 +7,7 @@ package("toml11")
     add_urls("https://github.com/ToruNiina/toml11/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ToruNiina/toml11.git")
 
+    add_versions("v4.0.0", "f3dc3095f22e38745a5d448ac629f69b7ee76d2b3e6d653e4ce021deb7f7266e")
     add_versions("v3.8.1", "6a3d20080ecca5ea42102c078d3415bef80920f6c4ea2258e87572876af77849")
     add_versions("v3.7.0", "a0b6bec77c0e418eea7d270a4437510884f2fe8f61e7ab121729624f04c4b58e")
 


### PR DESCRIPTION
New version of toml11 detected (package version: v3.8.1, last github version: v4.0.0)