### PR TITLE
Add header only package `matchit`

### DIFF
--- a/packages/m/matchit/xmake.lua
+++ b/packages/m/matchit/xmake.lua
@@ -1,31 +1,30 @@
 package("matchit")
-  set_kind("library", {headeronly = true})
-  set_homepage("https://bowenfu.github.io/matchit.cpp/")
-  set_description("A lightweight single-header pattern-matching library for C++17 with macro-free APIs.")
-  set_license("Apache-2.0")
+    set_kind("library", {headeronly = true})
+    set_homepage("https://bowenfu.github.io/matchit.cpp/")
+    set_description("A lightweight single-header pattern-matching library for C++17 with macro-free APIs.")
+    set_license("Apache-2.0")
 
-  add_urls("https://github.com/BowenFu/matchit.cpp/archive/refs/tags/$(version).tar.gz",
+    add_urls("https://github.com/BowenFu/matchit.cpp/archive/refs/tags/$(version).tar.gz",
            "https://github.com/BowenFu/matchit.cpp.git")
-  add_versions("v1.0.1", "52112e323eb3a1e63485334764c345d3e908a244")
-  add_versions("2022.11.22", "62c85a91413c61880ededee1a265ecfc87eb8ecd")
+    add_versions("v1.0.1", "52112e323eb3a1e63485334764c345d3e908a244")
+    add_versions("2022.11.22", "62c85a91413c61880ededee1a265ecfc87eb8ecd")
 
-  on_install(function (package)
-    os.cp("include", package:installdir())
-  end)
+    on_install(function (package)
+        os.cp("include", package:installdir())
+    end)
 
-  on_test(function (package) 
-    assert(package:check_cxxsnippets({test = [[
-      #include "matchit.h"
-      constexpr int32_t gcd(int32_t a, int32_t b) {
-        using namespace matchit;
-        return match(a, b)(
-          pattern | ds(_, 0) = [&] { return a >= 0 ? a : -a; },
-          pattern | _        = [&] { return gcd(b, a%b); }
-        );
-      }
-      void test() {
-        static_assert(gcd(12, 6) == 6);
-      }
-    ]]}, {configs = {languages = "c++17"}}))
-  end)
-package_end()
+    on_test(function (package) 
+        assert(package:check_cxxsnippets({test = [[
+            #include "matchit.h"
+            constexpr int32_t gcd(int32_t a, int32_t b) {
+                using namespace matchit;
+                return match(a, b)(
+                    pattern | ds(_, 0) = [&] { return a >= 0 ? a : -a; },
+                    pattern | _        = [&] { return gcd(b, a%b); }
+                );
+            }
+            void test() {
+                static_assert(gcd(12, 6) == 6);
+            }
+        ]]}, {configs = {languages = "c++17"}}))
+    end)

--- a/packages/m/matchit/xmake.lua
+++ b/packages/m/matchit/xmake.lua
@@ -1,0 +1,31 @@
+package("matchit")
+  set_kind("library", {headeronly = true})
+  set_homepage("https://bowenfu.github.io/matchit.cpp/")
+  set_description("A lightweight single-header pattern-matching library for C++17 with macro-free APIs.")
+  set_license("Apache-2.0")
+
+  add_urls("https://github.com/BowenFu/matchit.cpp/archive/refs/tags/$(version).tar.gz",
+           "https://github.com/BowenFu/matchit.cpp.git")
+  add_versions("v1.0.1", "52112e323eb3a1e63485334764c345d3e908a244")
+  add_versions("2022.11.22", "62c85a91413c61880ededee1a265ecfc87eb8ecd")
+
+  on_install(function (package)
+    os.cp("include", package:installdir())
+  end)
+
+  on_test(function (package) 
+    assert(package:check_cxxsnippets({test = [[
+      #include "matchit.h"
+      constexpr int32_t gcd(int32_t a, int32_t b) {
+        using namespace matchit;
+        return match(a, b)(
+          pattern | ds(_, 0) = [&] { return a >= 0 ? a : -a; },
+          pattern | _        = [&] { return gcd(b, a%b); }
+        );
+      }
+      void test() {
+        static_assert(gcd(12, 6) == 6);
+      }
+    ]]}, {configs = {languages = "c++17"}}))
+  end)
+package_end()

--- a/packages/m/matchit/xmake.lua
+++ b/packages/m/matchit/xmake.lua
@@ -6,17 +6,17 @@ package("matchit")
 
     add_urls("https://github.com/BowenFu/matchit.cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/BowenFu/matchit.cpp.git")
+
     add_versions("v1.0.1", "2860cb85febf37220f75cef5b499148bafc9f5541fe1298e11b0c169bb3f31ac")
 
     add_deps("cmake")
 
     on_install(function (package)
-        import("package.tools.cmake").install(package)
+        import("package.tools.cmake").install(package, {"-DBUILD_TESTING=OFF"})
     end)
 
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
-            #include "matchit.h"
             constexpr int32_t gcd(int32_t a, int32_t b) {
                 using namespace matchit;
                 return match(a, b)(
@@ -27,5 +27,5 @@ package("matchit")
             void test() {
                 static_assert(gcd(12, 6) == 6);
             }
-        ]]}, {configs = {languages = "c++17"}}))
+        ]]}, {configs = {languages = "c++17"}, includes = "matchit.h"}))
     end)

--- a/packages/m/matchit/xmake.lua
+++ b/packages/m/matchit/xmake.lua
@@ -14,7 +14,7 @@ package("matchit")
         os.cp("include", package:installdir())
     end)
 
-    on_test(function (package) 
+    on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
             #include "matchit.h"
             constexpr int32_t gcd(int32_t a, int32_t b) {

--- a/packages/m/matchit/xmake.lua
+++ b/packages/m/matchit/xmake.lua
@@ -5,13 +5,13 @@ package("matchit")
     set_license("Apache-2.0")
 
     add_urls("https://github.com/BowenFu/matchit.cpp/archive/refs/tags/$(version).tar.gz",
-             "https://github.com/BowenFu/matchit.cpp.git", {alias = "release"})
-    add_urls("https://github.com/BowenFu/matchit.cpp.git", {alias = "trunk"})
-    add_versions("release:v1.0.1", "2860cb85febf37220f75cef5b499148bafc9f5541fe1298e11b0c169bb3f31ac")
-    add_versions("trunk:2022.11.22", "62c85a91413c61880ededee1a265ecfc87eb8ecd")
+             "https://github.com/BowenFu/matchit.cpp.git")
+    add_versions("v1.0.1", "2860cb85febf37220f75cef5b499148bafc9f5541fe1298e11b0c169bb3f31ac")
+
+    add_deps("cmake")
 
     on_install(function (package)
-        os.cp("include", package:installdir())
+        import("package.tools.cmake").install(package)
     end)
 
     on_test(function (package)

--- a/packages/m/matchit/xmake.lua
+++ b/packages/m/matchit/xmake.lua
@@ -5,9 +5,10 @@ package("matchit")
     set_license("Apache-2.0")
 
     add_urls("https://github.com/BowenFu/matchit.cpp/archive/refs/tags/$(version).tar.gz",
-           "https://github.com/BowenFu/matchit.cpp.git")
-    add_versions("v1.0.1", "52112e323eb3a1e63485334764c345d3e908a244")
-    add_versions("2022.11.22", "62c85a91413c61880ededee1a265ecfc87eb8ecd")
+             "https://github.com/BowenFu/matchit.cpp.git", {alias = "release"})
+    add_urls("https://github.com/BowenFu/matchit.cpp.git", {alias = "trunk"})
+    add_versions("release:v1.0.1", "2860cb85febf37220f75cef5b499148bafc9f5541fe1298e11b0c169bb3f31ac")
+    add_versions("trunk:2022.11.22", "62c85a91413c61880ededee1a265ecfc87eb8ecd")
 
     on_install(function (package)
         os.cp("include", package:installdir())


### PR DESCRIPTION
Detailed meta info see added `xmake.lua`.

- author: BowenFu
- home page: https://bowenfu.github.io/matchit.cpp/
- github repo: https://github.com/BowenFu/matchit.cpp.git
- description: A lightweight single-header pattern-matching library for C++17 with macro-free APIs.