### PR TITLE
Auto-update cppcheck to 2.14.2

### DIFF
--- a/packages/c/cppcheck/xmake.lua
+++ b/packages/c/cppcheck/xmake.lua
@@ -4,6 +4,7 @@ package("cppcheck")
     set_description("A static analysis tool for C/C++ code")
 
     add_urls("https://github.com/danmar/cppcheck/archive/refs/tags/$(version).tar.gz")
+    add_versions("2.14.2", "9c3acea5f489336bd83a8ea33917a9a04a80c56d874bf270287e7de27acf2d00")
     add_versions("2.14.1", "22d1403fbc3158f35b5216d7b0a50bbaf0c80bf6663933a71f65cc4fc307ff3d")
     add_versions("2.13.4", "d6ea064ebab76c6aa000795440479767d8d814dd29405918df4c1bbfcd6cb86c")
     add_versions("2.13.0", "8229afe1dddc3ed893248b8a723b428dc221ea014fbc76e6289840857c03d450")


### PR DESCRIPTION
New version of cppcheck detected (package version: 2.14.1, last github version: 2.14.2)