### PR TITLE
Auto-update simdjson to v3.9.4

### DIFF
--- a/packages/s/simdjson/xmake.lua
+++ b/packages/s/simdjson/xmake.lua
@@ -6,6 +6,7 @@ package("simdjson")
 
     add_urls("https://github.com/simdjson/simdjson/archive/refs/tags/$(version).tar.gz",
              "https://github.com/simdjson/simdjson.git")
+    add_versions("v3.9.4", "9bf13be00fa1e1c5891a90dbc39b983e09972f0972a8956c20a9974cedfcca2f")
     add_versions("v3.9.3", "2e3d10abcde543d3dd8eba9297522cafdcebdd1db4f51b28f3bc95bf1d6ad23c")
     add_versions("v3.9.2", "79fbe700f4ac3dd69c4f08275af58399daabd612bca0c0465aea959c60256651")
     add_versions("v3.9.1", "a4b6e7cd83176e0ccb107ce38521da40a8df41c2d3c90566f2a0af05b0cd05c4")


### PR DESCRIPTION
New version of simdjson detected (package version: v3.9.3, last github version: v3.9.4)