### PR TITLE
fix cppp-reiconv static link error in windows

### DIFF
--- a/packages/c/cppp-reiconv/xmake.lua
+++ b/packages/c/cppp-reiconv/xmake.lua
@@ -16,8 +16,26 @@ package("cppp-reiconv")
         table.insert(configs, "-DENABLE_EXTRA=ON")
         table.insert(configs, "-DENABLE_TEST=OFF")
         import("package.tools.cmake").install(package, configs)
-        if not package:config("shared") and package:is_plat("windows") then
-            os.rm(path.translate(package:installdir("lib") .. "cppp-reiconv.lib"))
+        if package:is_plat("windows") then
+            if package:config("shared") then
+                os.rm(path.translate(package:installdir("lib") .. "/cppp-reiconv.static.lib"))
+            else
+                os.rm(path.translate(package:installdir("lib") .. "/cppp-reiconv.lib"))
+            end
+        elseif package:is_plat("macos") then
+            if package:config("shared") then
+                os.rm(path.translate(package:installdir("lib") .. "/libcppp-reiconv.static.a"))
+            else
+                os.rm(path.translate(package:installdir("lib") .. "/libcppp-reiconv.dylib"))
+                os.rm(path.translate(package:installdir("lib") .. "/libcppp-reiconv.2.1.0.dylib"))
+            end
+        else
+            if package:config("shared") then
+                os.rm(path.translate(package:installdir("lib") .. "/libcppp-reiconv.static.a"))
+            else
+                os.rm(path.translate(package:installdir("lib") .. "/libcppp-reiconv.so"))
+                os.rm(path.translate(package:installdir("lib") .. "/libcppp-reiconv.so.2.1.0"))
+            end
         end
     end)
 

--- a/packages/c/cppp-reiconv/xmake.lua
+++ b/packages/c/cppp-reiconv/xmake.lua
@@ -16,6 +16,9 @@ package("cppp-reiconv")
         table.insert(configs, "-DENABLE_EXTRA=ON")
         table.insert(configs, "-DENABLE_TEST=OFF")
         import("package.tools.cmake").install(package, configs)
+        if not package:config("shared") and package:is_plat("windows") then
+            os.rm(path.translate(package:installdir("lib") .. "cppp-reiconv.lib"))
+        end
     end)
 
     on_test(function (package)


### PR DESCRIPTION
默认是把动态库和静态库都编译出来了，用静态库的时候需要把动态库删掉，否则设置使用静态库无效