### PR TITLE
Auto-update vulkan-utility-libraries to v1.3.288

### DIFF
--- a/packages/v/vulkan-utility-libraries/xmake.lua
+++ b/packages/v/vulkan-utility-libraries/xmake.lua
@@ -12,6 +12,7 @@ package("vulkan-utility-libraries")
         return version:startswith("v") and version or prefix .. version:gsub("%+", ".")
     end})
 
+    add_versions("v1.3.288", "9192bd1352162d524b80d1d5edb5752eb3c9ba15c053a0f2b51b63e461a6c0a5")
     add_versions("v1.3.283", "a446616dede2b0168726f4e1b51777ba5c20ec46c475b378e2c07fd4ab4375ee")
     add_versions("v1.3.280", "075e13f2fdeeca3bb6fb39155c8cc345cf216ab93661549b1a33368aa28a9dea")
     add_versions("v1.3.275", "96d3ec7bda7b6e9fabbb471c570104a7b1cb56928d097dd0441c96129468b888")


### PR DESCRIPTION
New version of vulkan-utility-libraries detected (package version: v1.3.283, last github version: v1.3.288)