### PR TITLE
Auto-update ade to v0.1.2

### DIFF
--- a/packages/a/ade/patches/0.1.2/cmake-mingw.patch
+++ b/packages/a/ade/patches/0.1.2/cmake-mingw.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index af78061..8aba951 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,13 +39,15 @@ function(add_security_flags target)
+             target_compile_options( ${target} PRIVATE -fstack-protector-strong)
+         endif()
+     elseif(WIN32)
+-        target_compile_options( ${target} PRIVATE /GS /DynamicBase)
+-        if(BUILD_WITH_STATIC_CRT)
+-            target_compile_options( ${target} PRIVATE "/MT")
+-        endif()
+-        if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
+-            # These options for 32 bit builds only
+-            target_compile_options( ${target} PRIVATE /SAFESEH /NXCOMPAT )
++        if (MSVC)
++            target_compile_options( ${target} PRIVATE /GS /DynamicBase)
++            if(BUILD_WITH_STATIC_CRT)
++                target_compile_options( ${target} PRIVATE "/MT")
++            endif()
++            if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
++                # These options for 32 bit builds only
++                target_compile_options( ${target} PRIVATE /SAFESEH /NXCOMPAT )
++            endif()
+         endif()
+     endif()
+ endfunction()

--- a/packages/a/ade/xmake.lua
+++ b/packages/a/ade/xmake.lua
@@ -6,8 +6,10 @@ package("ade")
     add_urls("https://github.com/opencv/ade/archive/refs/tags/$(version).tar.gz",
              "https://github.com/opencv/ade.git")
 
-    add_versions("v0.1.2", "ac2e6a4acbe6e0b0942418687ec37c6cd55dcaec5112c7ca09abefe6ee539499")
     add_versions("v0.1.2d", "edefba61a33d6cd4b78a9976cb3309c95212610a81ba6dade09882d1794198ff")
+    add_versions("v0.1.2", "ac2e6a4acbe6e0b0942418687ec37c6cd55dcaec5112c7ca09abefe6ee539499")
+
+    add_patches("0.1.2", "patches/0.1.2/cmake-mingw.patch", "59ac0ed938b82090e97de6dee358ba683b371908c3063b4d10146999a30eaaaa")
 
     add_deps("cmake")
 
@@ -20,5 +22,9 @@ package("ade")
     end)
 
     on_test(function (package)
-        assert(package:has_cxxtypes("ade::Graph", {configs = {languages = "c++11"}, includes = "ade/graph.hpp"}))
+        assert(package:check_cxxsnippets({test = [[
+            void test() {
+                ade::Graph x;
+            }
+        ]]}, {configs = {languages = "c++11"}, includes = "ade/graph.hpp"}))
     end)

--- a/packages/a/ade/xmake.lua
+++ b/packages/a/ade/xmake.lua
@@ -6,6 +6,7 @@ package("ade")
     add_urls("https://github.com/opencv/ade/archive/refs/tags/$(version).tar.gz",
              "https://github.com/opencv/ade.git")
 
+    add_versions("v0.1.2", "ac2e6a4acbe6e0b0942418687ec37c6cd55dcaec5112c7ca09abefe6ee539499")
     add_versions("v0.1.2d", "edefba61a33d6cd4b78a9976cb3309c95212610a81ba6dade09882d1794198ff")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of ade detected (package version: v0.1.2d, last github version: v0.1.2)