### PR TITLE
Auto-update libsais to v2.8.4

### DIFF
--- a/packages/l/libsais/xmake.lua
+++ b/packages/l/libsais/xmake.lua
@@ -5,6 +5,7 @@ package("libsais")
 
     add_urls("https://github.com/IlyaGrebnov/libsais/archive/refs/tags/$(version).tar.gz",
              "https://github.com/IlyaGrebnov/libsais.git")
+    add_versions("v2.8.4", "6de93b078a89ea85ee03916a7a9cfb1003a9946dee9d1e780a97c84d80b49476")
     add_versions("v2.8.3", "9f407265f7c958da74ee8413ee1d18143e3040c453c1c829b10daaf5d37f7cda")
     add_versions("v2.8.2", "a17918936d6231cf6b019629d65ad7170f889bab5eb46c09b775dede7d890502")
     add_versions("v2.8.1", "01852e93305fe197d8f2ffdc32a856e78d6796aa3f40708325084c55b450747a")


### PR DESCRIPTION
New version of libsais detected (package version: v2.8.3, last github version: v2.8.4)