### PR TITLE
Auto-update aws-c-s3 to v0.6.0

### DIFF
--- a/packages/a/aws-c-s3/xmake.lua
+++ b/packages/a/aws-c-s3/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-s3")
     add_urls("https://github.com/awslabs/aws-c-s3/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-s3.git")
 
+    add_versions("v0.6.0", "0a29dbb13ea003de3fd0d08a61fa705b1c753db4b35de9c464641432000f13ec")
     add_versions("v0.5.9", "7a337195b295406658d163b6dac64ff81f7556291b8a8e79e58ebaa2d55178ee")
     add_versions("v0.5.7", "2f2eab9bf90a319030fd3525953dc7ac00c8dc8c0d33e3f0338f2a3b554d3b6a")
     add_versions("v0.3.17", "72fd93a2f9a7d9f205d66890da249944b86f9528216dc0321be153bf19b2ecd5")


### PR DESCRIPTION
New version of aws-c-s3 detected (package version: v0.5.9, last github version: v0.6.0)