### PR TITLE
Auto-update nsync to 1.29.2

### DIFF
--- a/packages/n/nsync/xmake.lua
+++ b/packages/n/nsync/xmake.lua
@@ -6,6 +6,7 @@ package("nsync")
     add_urls("https://github.com/google/nsync/archive/refs/tags/$(version).tar.gz",
              "https://github.com/google/nsync.git")
 
+    add_versions("1.29.2", "1d63e967973733d2c97e841e3c05fac4d3fa299f01d14c86f2695594c7a4a2ec")
     add_versions("1.29.1", "3045a8922171430426b695edf794053182d245f6a382ddcc59ef4a6190848e98")
     add_versions("1.28.1", "0011fc00820088793b6a9ba97536173a25cffd3df2dc62616fb3a2824b3c43f5")
 


### PR DESCRIPTION
New version of nsync detected (package version: 1.29.1, last github version: 1.29.2)