### PR TITLE
Auto-update toml11 to v4.0.2

### DIFF
--- a/packages/t/toml11/xmake.lua
+++ b/packages/t/toml11/xmake.lua
@@ -7,6 +7,7 @@ package("toml11")
     add_urls("https://github.com/ToruNiina/toml11/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ToruNiina/toml11.git")
 
+    add_versions("v4.0.2", "d1bec1970d562d328065f2667b23f9745a271bf3900ca78e92b71a324b126070")
     add_versions("v4.0.1", "96965cb00ca7757c611c169cd5a6fb15736eab1cd1c1a88aaa62ad9851d926aa")
     add_versions("v3.8.1", "6a3d20080ecca5ea42102c078d3415bef80920f6c4ea2258e87572876af77849")
     add_versions("v3.7.0", "a0b6bec77c0e418eea7d270a4437510884f2fe8f61e7ab121729624f04c4b58e")


### PR DESCRIPTION
New version of toml11 detected (package version: v4.0.1, last github version: v4.0.2)