### PR TITLE
Auto-update geos to 3.12.2

### DIFF
--- a/packages/g/geos/xmake.lua
+++ b/packages/g/geos/xmake.lua
@@ -5,6 +5,7 @@ package("geos")
     set_license("LGPL-2.1")
 
     add_urls("https://github.com/libgeos/geos/archive/refs/tags/$(version).tar.gz")
+    add_versions("3.12.2", "a3f89e794307d62aa550416e9b6ef06509f53076730946f7cd369ed275f256d0")
     add_versions("3.12.1", "f6e2f3aaa417410d3fa4c78a9c5ef60d46097ef7ad0aee3bbbb77327350e1e01")
     add_versions("3.11.3", "3c517fcccdd3d562122d59c93e0982ef9bc10e775a177ad88882fca1d7d28d08")
     add_versions("3.9.1", "e9e20e83572645ac2af0af523b40a404627ce74b3ec99727754391cdf5b23645")


### PR DESCRIPTION
New version of geos detected (package version: 3.12.1, last github version: 3.12.2)