### PR TITLE
Auto-update daw_json_link to v3.24.1

### DIFF
--- a/packages/d/daw_json_link/xmake.lua
+++ b/packages/d/daw_json_link/xmake.lua
@@ -7,6 +7,7 @@ package("daw_json_link")
     add_urls("https://github.com/beached/daw_json_link/archive/refs/tags/$(version).tar.gz",
              "https://github.com/beached/daw_json_link.git")
 
+    add_versions("v3.24.1", "439b4678377950f165e3d49d472c0676f0ef2fae3c5e6e7febddd5633f6e4f39")
     add_versions("v3.24.0", "7cecb2acde88028043e343ed4da7cde84c565a38125d3edb90db90daf881240a")
     add_versions("v3.23.2", "fd1234a14c126c79076e0b6e6eceae42afd465c419dc7a7393c69c28aa7f53d4")
     add_versions("v3.20.1", "046638bc4437d138cc8bdc882027d318ca3e267f33d1b419c5bdecb45b595a47")


### PR DESCRIPTION
New version of daw_json_link detected (package version: v3.24.0, last github version: v3.24.1)