### PR TITLE
Auto-update raylib-cpp to v5.0.2

### DIFF
--- a/packages/r/raylib-cpp/xmake.lua
+++ b/packages/r/raylib-cpp/xmake.lua
@@ -7,6 +7,7 @@ package("raylib-cpp")
     add_urls("https://github.com/RobLoach/raylib-cpp/archive/refs/tags/$(version).tar.gz", 
              "https://github.com/RobLoach/raylib-cpp.git")
 
+    add_versions("v5.0.2", "d3a718170882bc873c973a19a824d7fa4bfd9d0087b4778057231409a240920d")
     add_versions("v5.0.1", "6d10469019700fd5993db9a18bdd0ed025105b1bf7dd8916e353eef8bfac6355")
 
 	add_deps("raylib 5.x")


### PR DESCRIPTION
New version of raylib-cpp detected (package version: v5.0.1, last github version: v5.0.2)