### PR TITLE
Auto-update cargs to v1.2.0

### DIFF
--- a/packages/c/cargs/xmake.lua
+++ b/packages/c/cargs/xmake.lua
@@ -5,6 +5,7 @@ package("cargs")
 
     add_urls("https://github.com/likle/cargs/archive/refs/tags/$(version).tar.gz",
              "https://github.com/likle/cargs.git")
+    add_versions("v1.2.0", "0b33379e3d3c8cb3e22f33d3e1a260adcd366970868bc9b7c47237f24188ff25")
     add_versions("v1.1.0", "87e7da5b539f574d48529870cb0620ef5a244a5ee2eac73cc7559dedc04128ca")
     add_versions("v1.0.3", "ddba25bd35e9c6c75bc706c126001b8ce8e084d40ef37050e6aa6963e836eb8b")
 


### PR DESCRIPTION
New version of cargs detected (package version: v1.1.0, last github version: v1.2.0)