### PR TITLE
Auto-update lunasvg to v2.4.0

### DIFF
--- a/packages/l/lunasvg/xmake.lua
+++ b/packages/l/lunasvg/xmake.lua
@@ -5,6 +5,7 @@ package("lunasvg")
 
     add_urls("https://github.com/sammycage/lunasvg/archive/refs/tags/$(version).tar.gz",
              "https://github.com/sammycage/lunasvg.git")
+    add_versions("v2.4.0", "0682c60501c91d75f4261d9c1a5cd44c2c9da8dba76f8402eab628448c9a4591")
     add_versions("v2.3.9", "088bc9fd1191a004552c65bdcc260989b83da441b0bdaa965e79d984feba88fa")
     add_versions("v2.3.5", "350ff56aa1acdedefe2ad8a4241a9fb8f9b232868adc7bd36dfb3dbdd57e2e93")
 


### PR DESCRIPTION
New version of lunasvg detected (package version: v2.3.9, last github version: v2.4.0)