### PR TITLE
Auto-update zziplib to v0.13.77

### DIFF
--- a/packages/z/zziplib/xmake.lua
+++ b/packages/z/zziplib/xmake.lua
@@ -6,6 +6,7 @@ package("zziplib")
 
     add_urls("https://github.com/gdraheim/zziplib/archive/refs/tags/$(version).tar.gz",
              "https://github.com/gdraheim/zziplib.git")
+    add_versions("v0.13.77", "50e166e6a879c2bd723e60e482a91ec793a7362fa2d9c5fe556fb0e025810477")
     add_versions("v0.13.76", "08b0e300126329c928a41b6d68e397379fad02469e34a0855d361929968ea4c0")
     add_versions("v0.13.74", "319093aa98d39453f3ea2486a86d8a2fab2d5632f6633a2665318723a908eecf")
     add_versions("v0.13.72", "93ef44bf1f1ea24fc66080426a469df82fa631d13ca3b2e4abaeab89538518dc")


### PR DESCRIPTION
New version of zziplib detected (package version: v0.13.76, last github version: v0.13.77)