### PR TITLE
Add `on_load` function to volk package script to fix installing error on latest xmake version.

### DIFF
--- a/packages/v/volk/xmake.lua
+++ b/packages/v/volk/xmake.lua
@@ -65,6 +65,12 @@ package("volk")
         import("package.tools.xmake").install(package)
     end)
 
+    on_load(function (package)
+        if package:config("header_only") then
+            package:set("kind", "library", {headeronly = true})
+        end
+    end)
+
     on_test(function (package)
         local defines
         if package:config("header_only") then 


### PR DESCRIPTION
The package script file for `volk` library does not include a linkage specification, which will fail the linkage validation on latest xmake version:

```
error: package(volk): links not found!
  => install volk 1.3.283+0 .. failed
error: install failed!
```

See https://github.com/JX-Master/LunaSDK/actions/runs/9902626221/job/27356844358 for full log.

This pull request fixes this bug by adding a `on_load` callback function to explicitly specify the library as header-only, so that the linkage validation will not cause installation failure.