### PR TITLE
Auto-update node-api-headers to v1.2.0

### DIFF
--- a/packages/n/node-api-headers/xmake.lua
+++ b/packages/n/node-api-headers/xmake.lua
@@ -6,6 +6,7 @@ package("node-api-headers")
 
     set_urls("https://github.com/nodejs/node-api-headers/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nodejs/node-api-headers.git")
+    add_versions("v1.2.0", "deda1c8536ebae8b0a35c26d8547e23061c7d3cffd05ea70046be1c7c0efc2d0")
     add_versions("v1.1.0", "70608bc1e6dddce280285f3462f18a106f687c0720a4b90893e1ecd86e5a8bbf")
 
     on_install(function(package)


### PR DESCRIPTION
New version of node-api-headers detected (package version: v1.1.0, last github version: v1.2.0)