### PR TITLE
Auto-update cgraph to v2.6.0

### DIFF
--- a/packages/c/cgraph/xmake.lua
+++ b/packages/c/cgraph/xmake.lua
@@ -7,6 +7,7 @@ package("cgraph")
     add_urls("https://github.com/ChunelFeng/CGraph/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ChunelFeng/CGraph.git")
 
+    add_versions("v2.6.0", "1b055ee86f0340f2c35b4ed40c4a3b4cc05081b115b0fb634d778671018648f2")
     add_versions("v2.5.4", "fd5a53dc0d7e3fc11050ccc13fac987196ad42184a4e244b9d5e5d698b1cb101")
 
     if is_plat("windows") then


### PR DESCRIPTION
New version of cgraph detected (package version: v2.5.4, last github version: v2.6.0)