### PR TITLE
make `/utf-8` from `fmt` public

### DIFF
--- a/packages/f/fmt/xmake.lua
+++ b/packages/f/fmt/xmake.lua
@@ -52,7 +52,7 @@ package("fmt")
             end
         end
         if package:is_plat("windows") and package:config("unicode") then
-            package:add("cxxflags", "/utf-8")
+            package:add("cxxflags", "/utf-8", {public = true})
         end
     end)
 


### PR DESCRIPTION
probably a good idea, since otherwise the flag would be lost on targets dependent on targets that have fmt
