### PR TITLE
Auto-update trompeloeil to v48

### DIFF
--- a/packages/t/trompeloeil/xmake.lua
+++ b/packages/t/trompeloeil/xmake.lua
@@ -6,6 +6,7 @@ package("trompeloeil")
     set_license("BSL-1.0")
 
     add_urls("https://github.com/rollbear/trompeloeil/archive/refs/tags/$(version).tar.gz")
+    add_versions("v48", "eebd18456975251ea3450b815e241cccfefba5b883e4a36bd309f9cf629bdec6")
     add_versions("v47", "4a1d79260c1e49e065efe0817c8b9646098ba27eed1802b0c3ba7d959e4e5e84")
     add_versions("v43", "86a0afa2e97347202a0a883ab43da78c1d4bfff0d6cb93205cfc433d0d9eb9eb")
 


### PR DESCRIPTION
New version of trompeloeil detected (package version: v47, last github version: v48)