### PR TITLE
Auto-update aws-crt-cpp to v0.27.4

### DIFF
--- a/packages/a/aws-crt-cpp/xmake.lua
+++ b/packages/a/aws-crt-cpp/xmake.lua
@@ -6,6 +6,7 @@ package("aws-crt-cpp")
     add_urls("https://github.com/awslabs/aws-crt-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-crt-cpp.git")
 
+    add_versions("v0.27.4", "0554776a4cbbea016075f4a28698ff22818c5b948296171e1f76d0a787576f83")
     add_versions("v0.27.2", "e17c82d7cc3b5e6e4300bc7e4794306e292b5281d212ead536000a8b5f5f1be4")
     add_versions("v0.27.0", "e7601c8c5e6391013b6ad164d2dd7b970bf5dbb3693b9cc80c424bd6f42b79c8")
     add_versions("v0.26.11", "23acb2b14019182dd73fe6779ec266ee4d8937f19a99803da6407937fa22db7d")


### PR DESCRIPTION
New version of aws-crt-cpp detected (package version: v0.27.2, last github version: v0.27.4)