### PR TITLE
Auto-update thorvg to v0.14.3

### DIFF
--- a/packages/t/thorvg/xmake.lua
+++ b/packages/t/thorvg/xmake.lua
@@ -6,6 +6,7 @@ package("thorvg")
     add_urls("https://github.com/thorvg/thorvg/archive/refs/tags/$(version).tar.gz",
              "https://github.com/thorvg/thorvg.git")
 
+    add_versions("v0.14.3", "302e7bb2082a5c4528b6ec9b95d500b2c0f54f4333870a709cc122b5b393dcfe")
     add_versions("v0.14.2", "04202e8f5e17b427c3b16ae3b3d4be5d3f3cdac96d5c64ed3efd7b6db3ad731f")
     add_versions("v0.14.1", "9c0346fda8b62a3b13a764dda5784e0465c8cab54fb5342d0240c7fb40e415bd")
     add_versions("v0.13.8", "ce49929a94d1686d4f1436da6ef5fa7a8439901c22b5fa0879d7d5879b8ba2bd")


### PR DESCRIPTION
New version of thorvg detected (package version: v0.14.2, last github version: v0.14.3)