### PR TITLE
OpenEXR: fixed wrong includepaths

### DIFF
--- a/packages/o/openexr/xmake.lua
+++ b/packages/o/openexr/xmake.lua
@@ -23,6 +23,8 @@ package("openexr")
 
     add_configs("build_both", {description = "Build both static library and shared library. (deprecated)", default = false, type = "boolean"})
 
+    add_includedirs("include/OpenEXR", "include")
+
     on_load("windows", "macosx", "linux", "mingw@windows", "mingw@msys", function (package)
         local ver = package:version()
         local suffix = format("-%d_%d", ver:major(), ver:minor())
@@ -39,10 +41,9 @@ package("openexr")
         if package:is_plat("windows") and package:config("shared") then
             package:add("defines", "OPENEXR_DLL")
         end
-        package:add("includedirs", {"include/OpenEXR", "include"})
     end)
 
-    on_install("macosx", "linux", "windows", "mingw@windows", "mingw@msys", function (package)
+    on_install("macosx", "linux", "windows|x64", "windows|x86", "mingw@windows", "mingw@msys", function (package)
         local configs = {"-DBUILD_TESTING=OFF", "-DINSTALL_OPENEXR_EXAMPLES=OFF", "-DINSTALL_OPENEXR_DOCS=OFF", "-DOPENEXR_BUILD_UTILS=ON"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         if package:version():ge("3.0") then

--- a/packages/o/openexr/xmake.lua
+++ b/packages/o/openexr/xmake.lua
@@ -39,6 +39,7 @@ package("openexr")
         if package:is_plat("windows") and package:config("shared") then
             package:add("defines", "OPENEXR_DLL")
         end
+        package:add("includedirs", {"include/OpenEXR", "include"})
     end)
 
     on_install("macosx", "linux", "windows", "mingw@windows", "mingw@msys", function (package)


### PR DESCRIPTION
Some of OpenEXR headers use global include notation and contain only file name, without the nested "OpenEXR" subdirectory. That approach require additional include directory to be added on the user side in order to get proper paths for such headers.

This pull request fixes the problem by adding nested "include/OpenEXR" include directory that will guarantee that these headers can be included properly.