### PR TITLE
ffmpeg: Fix script with xmake dev

### DIFF
--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -256,7 +256,7 @@ package("ffmpeg")
             else
                 -- rename files from libxx.a to xx.lib
                 for _, libfile in ipairs(os.files(package:installdir("lib", "*.a"))) do
-                    os.vmv(libfile, libfile:gsub("^(.+[\\/])lib(.+)%.a$", "%1%2.lib"))
+                    os.vmv(libfile, (libfile:gsub("^(.+[\\/])lib(.+)%.a$", "%1%2.lib")))
                 end
             end
         elseif package:is_plat("android") then


### PR DESCRIPTION
fixes this:
```
> move C:\Users\lynix\AppData\Local\.xmake\packages\f\ffmpeg\7.0\11eee8174e3342b5b90ed61ac467badc\lib\libavcodec.a to C:\Users\lynix\AppData\Local\.xmake\packages\f\ffmpeg\7.0\11eee8174e3342b5b90ed61ac467badc\lib\avcodec.lib
error: @programdir\core\base\os.lua:132: attempt to index a number value (local 'opt')
stack traceback:
    [@programdir\core\base\os.lua:132]:
    [@programdir\core\sandbox\modules\os.lua:109]:
    [...make\repositories\xmake-repo\packages\f\ffmpeg\xmake.lua:259]: in function 'script'
    [...dir\modules\private\action\require\impl\utils\filter.lua:114]: in function 'call'
    [...\modules\private\action\require\impl\actions\install.lua:404]:

  => install ffmpeg 7.0 .. failed
```