### PR TITLE
Auto-update reflect-cpp to v0.13.0

### DIFF
--- a/packages/c/ctre/xmake.lua
+++ b/packages/c/ctre/xmake.lua
@@ -14,7 +14,9 @@ package("ctre")
     add_configs("header_only", {description = "Use header only version.", default = false, type = "boolean"})
 
     on_load(function (package)
-        if not package:config("header_only") then
+        if package:config("header_only") then
+            package:set("kind", "library", {headeronly = true})
+        else
             package:add("deps", "cmake")
         end
     end)

--- a/packages/c/ctre/xmake.lua
+++ b/packages/c/ctre/xmake.lua
@@ -1,33 +1,33 @@
 package("ctre")
-
+    set_kind("library", {headeronly = true})
     set_homepage("https://github.com/hanickadot/compile-time-regular-expressions/")
     set_description("ctre is a Compile time PCRE (almost) compatible regular expression matcher.")
+    set_license("Apache-2.0")
 
-    set_urls("https://github.com/hanickadot/compile-time-regular-expressions/archive/refs/tags/v$(version).zip")
-    add_versions("3.4.1", "099d6503cddd8e086b71247321ac64d91976136aa727d0de3ad5f9fd1897c5c7")
-    add_versions("3.5", "335180eaa44d60cec0fec445bafad78509f03c6e8a8bd9d24591d4d38333f78d")
-    add_versions("3.6", "f99f9c8bd3154d76305ef4fbde2c6622ed309c5a3401168732048fbc31e93f5d")
-    add_versions("3.7.2", "1dbcd96d279b5be27e9c90d2952533db10bc0e5d8ff6224a3c6d538fd94ab18f")
-    add_versions("3.8.1", "7c7a936145defe56e886bac7731ea16a52de65d73bda2b56702d0d0a61101c76")
-    add_versions("3.9.0", "8d0c061faf6b41c6913cac39af1d8cc8272e693b442c32f4fa762b505490fb36")
+    set_urls("https://github.com/hanickadot/compile-time-regular-expressions/archive/refs/tags/$(version).zip",
+             "https://github.com/hanickadot/compile-time-regular-expressions.git")
 
-    add_configs("header_only", {description = "Use header only version.", default = false, type = "boolean"})
+    add_versions("v3.4.1", "099d6503cddd8e086b71247321ac64d91976136aa727d0de3ad5f9fd1897c5c7")
+    add_versions("v3.5", "335180eaa44d60cec0fec445bafad78509f03c6e8a8bd9d24591d4d38333f78d")
+    add_versions("v3.6", "f99f9c8bd3154d76305ef4fbde2c6622ed309c5a3401168732048fbc31e93f5d")
+    add_versions("v3.7.2", "1dbcd96d279b5be27e9c90d2952533db10bc0e5d8ff6224a3c6d538fd94ab18f")
+    add_versions("v3.8.1", "7c7a936145defe56e886bac7731ea16a52de65d73bda2b56702d0d0a61101c76")
+    add_versions("v3.9.0", "8d0c061faf6b41c6913cac39af1d8cc8272e693b442c32f4fa762b505490fb36")
+
+    add_configs("cmake", {description = "Use cmake build system", default = false, type = "boolean"})
 
     on_load(function (package)
-        if package:config("header_only") then
-            package:set("kind", "library", {headeronly = true})
-        else
+        if package:config("cmake") then
             package:add("deps", "cmake")
         end
     end)
 
     on_install(function (package)
-        if package:config("header_only") then
-            os.cp("single-header", package:installdir("include"))
-            return
+        if package:config("cmake") then
+            import("package.tools.cmake").install(package, {"-DCTRE_BUILD_TESTS=OFF"})
+        else
+            os.cp("include", package:installdir())
         end
-        local configs = {"-DCTRE_BUILD_TESTS=OFF"}
-        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/r/reflect-cpp/xmake.lua
+++ b/packages/r/reflect-cpp/xmake.lua
@@ -7,6 +7,7 @@ package("reflect-cpp")
     add_urls("https://github.com/getml/reflect-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/getml/reflect-cpp.git")
 
+    add_versions("v0.13.0", "a7a31832fe8bbaa7f7299da46dfd4ccc8b99a13242e16a1d93f8669de1fca9c6")
     add_versions("v0.12.0", "13d448dd5eaee13ecb7ab5cb61cb263c7111ba75230503adc823a888f68e1eaa")
     add_versions("v0.11.1", "e45f112fb3f14507a4aa53b99ae2d4ab6a4e7b2d5f04dd06fec00bf7faa7bbdc")
     add_versions("v0.10.0", "d2c8876d993ddc8c57c5804e767786bdb46a2bdf1a6cd81f4b14f57b1552dfd7")


### PR DESCRIPTION
New version of reflect-cpp detected (package version: v0.12.0, last github version: v0.13.0)