### PR TITLE
fix opengl dependency for Qt6

### DIFF
--- a/packages/q/qt6gui/xmake.lua
+++ b/packages/q/qt6gui/xmake.lua
@@ -8,6 +8,7 @@ package("qt6gui")
 
         if package:is_plat("linux") then 
             package:add("deps", "freetype", "fontconfig", "libxkbcommon")
+            add_extsources("apt::libgl1-mesa-dev", "pacman::mesa")
         elseif package:is_plat("android") then
             package:data_set("syslinks", "GLESv2")
         elseif package:is_plat("iphoneos") then


### PR DESCRIPTION
I found that Qt6 xrepo package missing `libgl1-mesa-dev` dependency for Linux. It's occurred when I tried to build Qt project on GitHub Actions (most likely due to missing GUI environment on such CI distros):
```log
checking for platform ... linux
checking for architecture ... x86_64
updating repositories .. ok
  => download https://github.com/xmake-mirror/xmake-cacert/archive/refs/tags/20240207.zip .. ok
  => install ca-certificates 20240207 .. ok
  => download https://www.python.org/ftp/python/3.12.3/Python-3.12.3.tgz .. ok
  => download https://downloads.sourceforge.net/project/freetype/freetype2/2.13.1/freetype-2.13.1.tar.gz .. ok
  => download https://ftpmirror.gnu.org/gnu/gperf/gperf-3.1.tar.gz .. ok
  => install gperf 3.1 .. ok
  => install freetype 2.13.1 .. ok
  => install python 3.12.3 .. ok
  => download https://github.com/ninja-build/ninja/archive/refs/tags/v1.11.1.tar.gz .. ok
  => download https://github.com/mesonbuild/meson/releases/download/1.4.2/meson-1.4.2.tar.gz .. ok
  => install meson 1.4.2 .. ok
  => install aqt latest .. ok
  => install qt6base 6.6.0 .. ok
  => install qt6core 6.6.0 .. ok
  => install qt6network 6.6.0 .. ok
  => install ninja 1.11.1 .. ok
  => download https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.23.0/downloads/wayland-1.23.0.tar.xz .. ok
  => download https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.14.2.tar.gz .. ok
  => install wayland 1.23.0 .. ok
  => download https://github.com/xkbcommon/libxkbcommon/archive/xkbcommon-1.0.3.tar.gz .. ok
  => install fontconfig 2.14.2 .. ok
  => install libxkbcommon 1.0.3 .. ok
  => install qt6gui 6.6.0 .. ok
  => install qt6widgets 6.6.0 .. ok
[ 28%]: compiling.qt.moc main_window.hpp
create ok!
compile_commands.json updated!
error: In file included from /home/runner/.xmake/packages/q/qt6base/6.6.0/c9e1ef6b685d43d6b38c1427[18](https://github.com/yh-sb/qt6-example/actions/runs/10100838578/job/27933095931#step:8:19)1ac297/include/QtGui/QtGui:60,
                 from /home/runner/.xmake/packages/q/qt6base/6.6.0/c9e1ef6b685d43d6b38c1427181ac297/include/QtWidgets/QtWidgetsDepends:4,
                 from /home/runner/.xmake/packages/q/qt6base/6.6.0/c9e1ef6b685d43d6b38c14[27](https://github.com/yh-sb/qt6-example/actions/runs/10100838578/job/27933095931#step:8:28)181ac297/include/QtWidgets/QtWidgets:3,
                 from build/.gens/qt-app/linux/x86_64/debug/../../../../../../main_window.hpp:4,
                 from build/.gens/qt-app/linux/x86_64/debug/moc_main_window.cpp:9:
/home/runner/.xmake/packages/q/qt6base/6.6.0/c9e1ef6b685d43d6b38c1427181ac[29](https://github.com/yh-sb/qt6-example/actions/runs/10100838578/job/27933095931#step:8:30)7/include/QtGui/qopengl.h:105:13: fatal error: GL/gl.h: No such file or directory
  105 | #   include <GL/gl.h>
      |             ^~~~~~~~~
compilation terminated.
```
After installing `libgl1-mesa-dev`, the error no longer occurs.