### PR TITLE
Auto-update lightgbm to 4.5.0

### DIFF
--- a/packages/l/lightgbm/xmake.lua
+++ b/packages/l/lightgbm/xmake.lua
@@ -4,6 +4,7 @@ package("lightgbm")
     set_license("MIT")
 
     add_urls("https://github.com/microsoft/LightGBM/releases/download/v$(version)/lightgbm-$(version).tar.gz")
+
     add_versions("4.5.0", "e1cd7baf0318d4e308a26575a63a4635f08df866ad3622a9d8e3d71d9637a1ba")
     add_versions("4.4.0", "9e8a7640911481134e60987d5d1e1cd157f430c3b4b38de8d36fc55c302bc299")
     add_versions("4.3.0", "006f5784a9bcee43e5a7e943dc4f02de1ba2ee7a7af1ee5f190d383f3b6c9ebe")
@@ -14,6 +15,16 @@ package("lightgbm")
     add_configs("gpu", {description = "Enable GPU-accelerated training.", default = false, type = "boolean"})
 
     add_deps("cmake")
+
+    if on_check then
+        on_check("linux", function (package)
+            if package:version() and package:version():ge("4.5.0") then
+                if package:has_tool("cxx", "clang") and package:config("shared") then
+                    raise("package(lightgbm) unsupported clang + shared build")
+                end
+            end
+        end)
+    end
 
     on_load("windows|x64", "linux", function (package)
         if package:config("gpu") then
@@ -26,7 +37,7 @@ package("lightgbm")
     end)
 
     on_install("windows|x64", "linux", function (package)
-        if package:version():lt("4.2.0") then
+        if package:version() and package:version():lt("4.2.0") then
             os.cd("compile")
         end
 

--- a/packages/l/lightgbm/xmake.lua
+++ b/packages/l/lightgbm/xmake.lua
@@ -4,6 +4,7 @@ package("lightgbm")
     set_license("MIT")
 
     add_urls("https://github.com/microsoft/LightGBM/releases/download/v$(version)/lightgbm-$(version).tar.gz")
+    add_versions("4.5.0", "e1cd7baf0318d4e308a26575a63a4635f08df866ad3622a9d8e3d71d9637a1ba")
     add_versions("4.4.0", "9e8a7640911481134e60987d5d1e1cd157f430c3b4b38de8d36fc55c302bc299")
     add_versions("4.3.0", "006f5784a9bcee43e5a7e943dc4f02de1ba2ee7a7af1ee5f190d383f3b6c9ebe")
     add_versions("4.2.0", "8a4d051df2ab2218998a16f7712e843ee9e96d8b09ffbfcc18533da127e0da02")


### PR DESCRIPTION
New version of lightgbm detected (package version: 4.4.0, last github version: 4.5.0)