### PR TITLE
Auto-update lz4 to v1.10.0

### DIFF
--- a/packages/l/lz4/xmake.lua
+++ b/packages/l/lz4/xmake.lua
@@ -5,6 +5,7 @@ package("lz4")
 
     set_urls("https://github.com/lz4/lz4/archive/$(version).tar.gz",
              "https://github.com/lz4/lz4.git")
+    add_versions("v1.10.0", "537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b")
     add_versions("v1.9.4", "0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b")
     add_versions("v1.9.3", "030644df4611007ff7dc962d981f390361e6c97a34e5cbc393ddfbe019ffe2c1")
 


### PR DESCRIPTION
New version of lz4 detected (package version: v1.9.4, last github version: v1.10.0)