### PR TITLE
Auto-update libfabric to 1.22.0

### DIFF
--- a/packages/l/libfabric/xmake.lua
+++ b/packages/l/libfabric/xmake.lua
@@ -5,6 +5,7 @@ package("libfabric")
     set_license("BSD-2-Clause")
 
     add_urls("https://github.com/ofiwg/libfabric/releases/download/v$(version)/libfabric-$(version).tar.bz2")
+    add_versions("1.22.0", "485e6cafa66c9e4f6aa688d2c9526e274c47fda3a783cf1dd8f7c69a07e2d5fe")
     add_versions("1.20.2", "75b89252a0b8b3eae8e60f7098af1598445a99a99e8fc1ff458e2fd5d4ef8cde")
     add_versions("1.20.1", "fd88d65c3139865d42a6eded24e121aadabd6373239cef42b76f28630d6eed76")
     add_versions("1.13.0", "0c68264ae18de5c31857724c754023351614330bd61a50b40cef2b5e8f63ab28")


### PR DESCRIPTION
New version of libfabric detected (package version: 1.20.2, last github version: 1.22.0)