### PR TITLE
Auto-update msgpack-c to 6.0.2

### DIFF
--- a/packages/m/msgpack-c/xmake.lua
+++ b/packages/m/msgpack-c/xmake.lua
@@ -5,6 +5,7 @@ package("msgpack-c")
     set_license("BSL-1.0")
 
     add_urls("https://github.com/msgpack/msgpack-c/releases/download/c-$(version)/msgpack-c-$(version).tar.gz")
+    add_versions("6.0.2", "5e90943f6f5b6ff6f4bda9146ada46e7e455af3a77568f6d503f35618c1b2a12")
     add_versions("6.0.1", "a349cd9af28add2334c7009e331335af4a5b97d8558b2e9804d05f3b33d97925")
     add_versions("4.0.0", "420fe35e7572f2a168d17e660ef981a589c9cbe77faa25eb34a520e1fcc032c8")
 


### PR DESCRIPTION
New version of msgpack-c detected (package version: 6.0.1, last github version: 6.0.2)