### PR TITLE
yoga: Add missing include <cstdint>

### DIFF
--- a/packages/y/yoga/xmake.lua
+++ b/packages/y/yoga/xmake.lua
@@ -21,6 +21,7 @@ package("yoga")
         on_check(function (package)
             assert(package:check_cxxsnippets({test = [[
                 #include <bit>
+                #include <cstdint>
                 void test() {
                     constexpr double f64v = 19880124.0; 
                     constexpr auto u64v = std::bit_cast<std::uint64_t>(f64v);


### PR DESCRIPTION
AFAIK, you technically need `#include <cstdint>` for `std::uint64_t`, and at least my compiler really needs that to compile the snippet. Otherwise only a `package(yoga) Require at least C++20.` error message appears