### PR TITLE
Auto-update fastgltf to v0.8.0

### DIFF
--- a/packages/f/fastgltf/xmake.lua
+++ b/packages/f/fastgltf/xmake.lua
@@ -6,6 +6,7 @@ package("fastgltf")
     add_urls("https://github.com/spnda/fastgltf/archive/refs/tags/$(version).tar.gz",
              "https://github.com/spnda/fastgltf.git")
 
+    add_versions("v0.8.0", "0bc88a0858c88d94306443946a5a1606118b7d5e4960f1e6186a3632e9df38fb")
     add_versions("v0.7.2", "292fc9d0d5a6726c90db88c1aadf09e6d152ffc0ebffe6fb968736c47288511c")
     add_versions("v0.7.1", "44bcb025dd5cd480236a3bc7a3f8c9a708a801ed773b7859677440d22e0e1e7c")
 


### PR DESCRIPTION
New version of fastgltf detected (package version: v0.7.2, last github version: v0.8.0)