### PR TITLE
Add macosx platform support to directxmath

### DIFF
--- a/packages/d/directxmath/xmake.lua
+++ b/packages/d/directxmath/xmake.lua
@@ -14,7 +14,7 @@ package("directxmath")
     add_versions("2022.12", "2ed0ae7d7fe5d11ad11f6d3d9b31ce686024a551cf82ade723de86aa7b4b57e1")
     add_versions("2024.02", "214d71420107249dfb4bbc37a573f288b0951cc9ffe323dbf662101f3df4d766")
 
-    if is_plat("linux") then
+    if is_plat("linux", "macosx") then
         add_resources(">=2022.12", "headers", "https://raw.githubusercontent.com/dotnet/runtime/2201016c1e13bdb9abf49e2e38cadf4ee0568df2/src/coreclr/pal/inc/rt/sal.h", "7dae281adc3a09a691291fb90526f05e4f9ef8b16d7f33d716ba690f7241a492")
     end
 

--- a/packages/d/directxmath/xmake.lua
+++ b/packages/d/directxmath/xmake.lua
@@ -21,7 +21,7 @@ package("directxmath")
     add_deps("cmake")
     add_includedirs("include/directxmath")
 
-    on_install("windows", "mingw", "linux", "macosx", function (package)
+    on_install("windows", "mingw|x86_64", "linux", "macosx", function (package)
         if package:is_plat("linux", "macosx") then
             os.cp("../resources/headers/sal.h", package:installdir("include", "directxmath"))
         end

--- a/packages/d/directxmath/xmake.lua
+++ b/packages/d/directxmath/xmake.lua
@@ -21,8 +21,8 @@ package("directxmath")
     add_deps("cmake")
     add_includedirs("include/directxmath")
 
-    on_install("windows", "mingw", "linux", function (package)
-        if package:is_plat("linux") then
+    on_install("windows", "mingw", "linux", "macosx", function (package)
+        if package:is_plat("linux", "macosx") then
             os.cp("../resources/headers/sal.h", package:installdir("include", "directxmath"))
         end
         import("package.tools.cmake").install(package, {"-DBUILD_TESTING=OFF"})


### PR DESCRIPTION
DirectXMath can supports compilation on macosx. Made changes to the `xmake.lua` to allow compilation on macosx.

To test compilation on mac, I copied over this package and renamed it to `dxmath` 
![image](https://github.com/user-attachments/assets/cc684788-f67a-4763-80f7-9c156abee2f4)

