### PR TITLE
Auto-update libwfkafka to v0.11.5

### DIFF
--- a/packages/l/libwfkafka/xmake.lua
+++ b/packages/l/libwfkafka/xmake.lua
@@ -6,6 +6,7 @@ package("libwfkafka")
     add_urls("https://github.com/sogou/workflow/archive/refs/tags/$(version).tar.gz",
              "https://github.com/sogou/workflow.git")
 
+    add_versions("v0.11.5", "e37ba93c59da1fbeadb4f1ca413e6d26a3d8979aa00a806c0129f84e92b7925a")
     add_versions("v0.10.6", "5701ef31518a7927e61b26cd6cc1d699cb43393bf1ffc77fa61e73e64d2dd28e")
     add_versions("v0.10.7", "aa9806983f32174597549db4a129e2ee8a3d1f005923fcbb924906bc70c0e123")
     add_versions("v0.10.8", "bb5654e8011822d4251a7a433cbe4c5ecfd2c65c8f997a8196685742d24bcaf0")


### PR DESCRIPTION
New version of libwfkafka detected (package version: v0.11.4, last github version: v0.11.5)