### PR TITLE
Add missed headeronly option for rapidcsv

### DIFF
--- a/packages/r/rapidcsv/xmake.lua
+++ b/packages/r/rapidcsv/xmake.lua
@@ -1,5 +1,6 @@
 package("rapidcsv")
 
+    set_kind("library", {headeronly = true})
     set_homepage("https://github.com/d99kris/rapidcsv")
     set_description("C++ header-only library for CSV parsing (by d99kris)")
 


### PR DESCRIPTION
Due to https://github.com/xmake-io/xmake/issues/5357 we have to mark such libraries explicitly. 