### PR TITLE
Auto-update uwebsockets to v20.65.0

### DIFF
--- a/packages/u/uwebsockets/xmake.lua
+++ b/packages/u/uwebsockets/xmake.lua
@@ -7,6 +7,7 @@ package("uwebsockets")
     add_urls("https://github.com/uNetworking/uWebSockets/archive/refs/tags/$(version).tar.gz",
              "https://github.com/uNetworking/uWebSockets.git")
 
+    add_versions("v20.65.0", "e261f7c124b3b9e217fc766d6e51d4fdc4b227aa52c7a0ca5952a9e65cea4213")
     add_versions("v20.64.0", "bb81fa773dcbd6bc738904ad496554fd131a33269570e0e86fa09213d82ba9ef")
     add_versions("v20.62.0", "03dfc8037cf43856a41e64bbc7fc5a7cf5e6369c9158682753074ecbbe09eed1")
     add_versions("v20.61.0", "94778209571f832740fe1a4f19dbc059990b6acc34b8789f39cda6a158178d1f")


### PR DESCRIPTION
New version of uwebsockets detected (package version: v20.64.0, last github version: v20.65.0)