### PR TITLE
Auto-update libpqxx to 7.9.2

### DIFF
--- a/packages/l/libpqxx/xmake.lua
+++ b/packages/l/libpqxx/xmake.lua
@@ -4,6 +4,7 @@ package("libpqxx")
 
     add_urls("https://github.com/jtv/libpqxx/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jtv/libpqxx.git")
+    add_versions("7.9.2", "e37d5774c39f6c802e32d7f418e88b8e530404fb54758516e884fc0ebdee6da4")
     add_versions("7.7.0", "2d99de960aa3016915bc69326b369fcee04425e57fbe9dad48dd3fa6203879fb")
 
     add_deps("cmake", "python 3.x")


### PR DESCRIPTION
New version of libpqxx detected (package version: 7.7.0, last github version: 7.9.2)