### PR TITLE
Auto-update daw_json_link to v3.26.0

### DIFF
--- a/packages/d/daw_json_link/xmake.lua
+++ b/packages/d/daw_json_link/xmake.lua
@@ -15,14 +15,16 @@ package("daw_json_link")
 
     add_deps("cmake")
 
-    on_install("windows", "linux", "macosx", "bsd", "mingw", "msys", "android@linux,macosx", "iphoneos", "cross", function (package)
-        if package:is_plat("android") then
-            import("core.tool.toolchain")
-            local ndk = toolchain.load("ndk", {plat = package:plat(), arch = package:arch()})
+    if on_check then
+        on_check("android", function (package)
+            local ndk = package:toolchain("ndk")
             local ndk_sdkver = ndk:config("ndk_sdkver")
             assert(ndk_sdkver and tonumber(ndk_sdkver) > 21, "package(daw_json_link): need ndk api level > 21 for android")
-        end
-        import("package.tools.cmake").install(package, configs)
+        end)
+    end
+
+    on_install("windows", "linux", "macosx", "bsd", "mingw", "msys", "android@linux,macosx", "iphoneos", "cross", function (package)
+        import("package.tools.cmake").install(package)
     end)
 
     on_test(function (package)

--- a/packages/d/daw_json_link/xmake.lua
+++ b/packages/d/daw_json_link/xmake.lua
@@ -7,6 +7,7 @@ package("daw_json_link")
     add_urls("https://github.com/beached/daw_json_link/archive/refs/tags/$(version).tar.gz",
              "https://github.com/beached/daw_json_link.git")
 
+    add_versions("v3.26.0", "c3eb3e37eba2eb919a908ef0be4c0f1c02460a677248a1b4298bfbe1bb2d9239")
     add_versions("v3.24.1", "439b4678377950f165e3d49d472c0676f0ef2fae3c5e6e7febddd5633f6e4f39")
     add_versions("v3.24.0", "7cecb2acde88028043e343ed4da7cde84c565a38125d3edb90db90daf881240a")
     add_versions("v3.23.2", "fd1234a14c126c79076e0b6e6eceae42afd465c419dc7a7393c69c28aa7f53d4")


### PR DESCRIPTION
New version of daw_json_link detected (package version: v3.24.1, last github version: v3.26.0)