### PR TITLE
Auto-update joltphysics to v5.1.0

### DIFF
--- a/packages/j/joltphysics/xmake.lua
+++ b/packages/j/joltphysics/xmake.lua
@@ -77,6 +77,9 @@ package("joltphysics")
         if package:config("shared") then
             package:add("defines", "JPH_SHARED_LIBRARY")
         end
+        if not package:is_debug() then
+            package:add("defines", "JPH_NO_DEBUG")
+        end
         if package:is_arch("i386", "x86", "x64", "x86_64") then
             -- add instruction sets (from https://github.com/jrouwe/JoltPhysics/blob/4cd52055e09160affcafa557b39520331bf0d034/Jolt/Jolt.cmake#L602)
             if package:has_tool("cxx", "cl") then

--- a/packages/j/joltphysics/xmake.lua
+++ b/packages/j/joltphysics/xmake.lua
@@ -213,7 +213,7 @@ package("joltphysics")
                 	va_list list;
                 	va_start(list, fmt);
                 	char buffer[1024];
-                	vsnprintf(buffer, sizeof(buffer), inFMT, list);
+                	vsnprintf(buffer, sizeof(buffer), fmt, list);
                 	va_end(list);
                 };
                 JPH::PhysicsSystem physics_system;

--- a/packages/j/joltphysics/xmake.lua
+++ b/packages/j/joltphysics/xmake.lua
@@ -206,8 +206,16 @@ package("joltphysics")
 
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
+            #include <cstdarg>
             void test() {
                 JPH::RegisterDefaultAllocator();
+                JPH::Trace = [](const char* fmt, ...) {
+                	va_list list;
+                	va_start(list, inFMT);
+                	char buffer[1024];
+                	vsnprintf(buffer, sizeof(buffer), inFMT, list);
+                	va_end(list);
+                };
                 JPH::PhysicsSystem physics_system;
                 physics_system.OptimizeBroadPhase();
             }

--- a/packages/j/joltphysics/xmake.lua
+++ b/packages/j/joltphysics/xmake.lua
@@ -207,15 +207,16 @@ package("joltphysics")
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
             #include <cstdarg>
+            void trace_impl(const char* fmt, ...) {
+                va_list list;
+                va_start(list, fmt);
+                char buffer[1024];
+                vsnprintf(buffer, sizeof(buffer), fmt, list);
+                va_end(list);
+            };
             void test() {
                 JPH::RegisterDefaultAllocator();
-                JPH::Trace = [](const char* fmt, ...) {
-                	va_list list;
-                	va_start(list, fmt);
-                	char buffer[1024];
-                	vsnprintf(buffer, sizeof(buffer), fmt, list);
-                	va_end(list);
-                };
+                JPH::Trace = &trace_impl;
                 JPH::PhysicsSystem physics_system;
                 physics_system.OptimizeBroadPhase();
             }

--- a/packages/j/joltphysics/xmake.lua
+++ b/packages/j/joltphysics/xmake.lua
@@ -214,9 +214,15 @@ package("joltphysics")
                 vsnprintf(buffer, sizeof(buffer), fmt, list);
                 va_end(list);
             };
+            bool AssertFailedImpl(const char *inExpression, const char *inMessage, const char *inFile, JPH::uint inLine)
+            {
+            	// Breakpoint
+            	return true;
+            };
             void test() {
                 JPH::RegisterDefaultAllocator();
                 JPH::Trace = &trace_impl;
+                JPH::AssertFailed = &AssertFailedImpl;
                 JPH::PhysicsSystem physics_system;
                 physics_system.OptimizeBroadPhase();
             }

--- a/packages/j/joltphysics/xmake.lua
+++ b/packages/j/joltphysics/xmake.lua
@@ -211,7 +211,7 @@ package("joltphysics")
                 JPH::RegisterDefaultAllocator();
                 JPH::Trace = [](const char* fmt, ...) {
                 	va_list list;
-                	va_start(list, inFMT);
+                	va_start(list, fmt);
                 	char buffer[1024];
                 	vsnprintf(buffer, sizeof(buffer), inFMT, list);
                 	va_end(list);

--- a/packages/j/joltphysics/xmake.lua
+++ b/packages/j/joltphysics/xmake.lua
@@ -5,6 +5,7 @@ package("joltphysics")
 
     add_urls("https://github.com/jrouwe/JoltPhysics/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jrouwe/JoltPhysics.git")
+    add_versions("v5.1.0", "525c9d6fb79471b3995f9d621c9f843e71470aed286872c4d4065c1f7b7d049a")
     add_versions("v5.0.0", "5231953d1b1d5b9cb617facf86341a11337e1cd04456949af6911b917a1646cb")
     add_versions("v4.0.2", "046baf71d05e47de7a530ce5d58a587a93ea7e9ea1ef8bf3ff80238fb95650ae")
     add_versions("v4.0.1", "e0bb4fa07047ca9c38bd71262427ad2972a7f45f8dff74587f73457f3b60df82")

--- a/packages/j/joltphysics/xmake.lua
+++ b/packages/j/joltphysics/xmake.lua
@@ -225,7 +225,7 @@ package("joltphysics")
             void test() {
                 JPH::RegisterDefaultAllocator();
                 JPH::Trace = &trace_impl;
-                JPH::AssertFailed = &AssertFailedImpl;
+                JPH_IF_ENABLE_ASSERTS(JPH::AssertFailed = &AssertFailedImpl;)
                 JPH::PhysicsSystem physics_system;
                 physics_system.OptimizeBroadPhase();
             }


### PR DESCRIPTION
New version of joltphysics detected (package version: v5.0.0, last github version: v5.1.0)