### PR TITLE
Auto-update vc-ltl5 to 5.1.1

### DIFF
--- a/packages/v/vc-ltl5/xmake.lua
+++ b/packages/v/vc-ltl5/xmake.lua
@@ -4,6 +4,7 @@ package("vc-ltl5")
     set_license("EPL-2.0")
 
     add_urls("https://github.com/Chuyu-Team/VC-LTL5/releases/download/v$(version)/VC-LTL-$(version)-Binary.7z")
+    add_versions("5.1.1", "71eb81ad7d5270cb2a247d6b1c5c01b8efb8f2c869d2e5222be8aafab2fc07de")
     add_versions("5.0.6", "e406f829f75d59c34ee1e34cb6e994eb7db0810123ae7196499f26df88bc0a6f")
     add_versions("5.0.7", "08555aca30b2f77a484534be0799cfed05bfdeb1d1e461d91576264d7123e687")
     add_versions("5.0.9", "71a3099978ff3dc83fe8e2ebddf104e2f916d13cd10fb01fe02317ebc7fb02d9")


### PR DESCRIPTION
New version of vc-ltl5 detected (package version: 5.0.9, last github version: 5.1.1)