### PR TITLE
Auto-update libvips to v8.15.3

### DIFF
--- a/packages/l/libvips/patches/8.15.3/msvc-ssize_t.patch
+++ b/packages/l/libvips/patches/8.15.3/msvc-ssize_t.patch
@@ -1,0 +1,32 @@
+diff --git a/libvips/iofuncs/generate.c b/libvips/iofuncs/generate.c
+index bb3d1b2d7..8be7ad675 100644
+--- a/libvips/iofuncs/generate.c
++++ b/libvips/iofuncs/generate.c
+@@ -92,6 +92,11 @@
+ #endif /*HAVE_CONFIG_H*/
+ #include <glib/gi18n-lib.h>
+ 
++#if defined(_MSC_VER)
++#include <BaseTsd.h>
++typedef SSIZE_T ssize_t;
++#endif
++
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stdarg.h>
+diff --git a/libvips/iofuncs/util.c b/libvips/iofuncs/util.c
+index 047516084..c2049c107 100644
+--- a/libvips/iofuncs/util.c
++++ b/libvips/iofuncs/util.c
+@@ -37,6 +37,11 @@
+ #endif /*HAVE_CONFIG_H*/
+ #include <glib/gi18n-lib.h>
+ 
++#if defined(_MSC_VER)
++#include <BaseTsd.h>
++typedef SSIZE_T ssize_t;
++#endif
++
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>

--- a/packages/l/libvips/xmake.lua
+++ b/packages/l/libvips/xmake.lua
@@ -6,6 +6,7 @@ package("libvips")
     add_urls("https://github.com/libvips/libvips/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libvips/libvips.git")
 
+    add_versions("v8.15.3", "c23a820443241c35e62f1f1f0a1f6c199b37e07d98e3268a7fa9db43309fd67d")
     add_versions("v8.15.2", "8c3ece7be367636fd676573a8ff22170c07e95e81fd94f2d1eb9966800522e1f")
     add_versions("v8.15.1", "5701445a076465a3402a135d13c0660d909beb8efc4f00fbbe82392e243497f2")
 

--- a/packages/l/libvips/xmake.lua
+++ b/packages/l/libvips/xmake.lua
@@ -10,6 +10,8 @@ package("libvips")
     add_versions("v8.15.2", "8c3ece7be367636fd676573a8ff22170c07e95e81fd94f2d1eb9966800522e1f")
     add_versions("v8.15.1", "5701445a076465a3402a135d13c0660d909beb8efc4f00fbbe82392e243497f2")
 
+    add_patches("8.15.3", "patches/8.15.3/msvc-ssize_t.patch", "d056a86735c4e05e164ca6fb27999bd98871e3b4de2fce0b792bf936d67ea658")
+
     add_configs("c++", { description = "Build C++ API", default = true, type = "boolean" })
     add_configs("deprecated", { description = "Build deprecated components", default = false, type = "boolean" })
     add_configs("dynamic_modules", { description = "Build dynamic modules", default = false, type = "boolean" })

--- a/packages/l/libvips/xmake.lua
+++ b/packages/l/libvips/xmake.lua
@@ -41,14 +41,14 @@ package("libvips")
         "libtiff",
         "libwebp",
         "zlib",
+        "cgif",
+        "nifti",
+        "highway",
     }
 
     local unsupported_deps = {
-        "cgif",
         "exif",
-        "nifti",
         "openslide",
-        "highway",
         "orc",
         "pangocairo",
         "pdfium",


### PR DESCRIPTION
New version of libvips detected (package version: v8.15.2, last github version: v8.15.3)