### PR TITLE
Auto-update c4core to 0.2.2

### DIFF
--- a/packages/c/c4core/xmake.lua
+++ b/packages/c/c4core/xmake.lua
@@ -6,6 +6,7 @@ package("c4core")
     add_urls("https://github.com/biojppm/c4core/releases/download/v$(version)/c4core-$(version)-src.zip",
              "https://github.com/biojppm/c4core.git")
 
+    add_versions("0.2.2", "5a9508385daa5b2608ed007784d76586af21c5367411efe9ae26d5b4aea03305")
     add_versions("0.2.1", "81ff1c0d15e24da6d76fdd1b6fdd903fa23d0df7c82e564f993147a4dac88773")
 
     add_configs("fast_float", {description = "use fastfloat to parse floats", default = false, type = "boolean"})

--- a/packages/c/c4core/xmake.lua
+++ b/packages/c/c4core/xmake.lua
@@ -27,7 +27,7 @@ package("c4core")
         end
 
         if package:config("fast_float") or package:config("debugbreak") then
-            package:add("patches", "0.2.1", "patches/0.2.1/cmake-deps.patch", "92c0c6510cc3b8cbd10b575b5b9d0defa2a19d19f24c1618a73d4f4636da4c9b")
+            package:add("patches", ">=0.2.1", "patches/0.2.1/cmake-deps.patch", "92c0c6510cc3b8cbd10b575b5b9d0defa2a19d19f24c1618a73d4f4636da4c9b")
         end
     end)
 


### PR DESCRIPTION
New version of c4core detected (package version: 0.2.1, last github version: 0.2.2)