### PR TITLE
Auto-update cmark to 0.31.1

### DIFF
--- a/packages/c/cmark/xmake.lua
+++ b/packages/c/cmark/xmake.lua
@@ -5,6 +5,7 @@ package("cmark")
     add_urls("https://github.com/commonmark/cmark/archive/refs/tags/$(version).tar.gz",
              "https://github.com/commonmark/cmark.git")
 
+    add_versions("0.31.1", "3da93db5469c30588cfeb283d9d62edfc6ded9eb0edc10a4f5bbfb7d722ea802")
     add_versions("0.31.0", "bbcb8f8c03b5af33fcfcf11a74e9499f20a9043200b8552f78a6e8ba76e04d11")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of cmark detected (package version: 0.31.0, last github version: 0.31.1)