### PR TITLE
Add support for rgb/grb config for FreeImage

### DIFF
--- a/packages/f/freeimage/patches/3.18.0/pluginbmp.patch
+++ b/packages/f/freeimage/patches/3.18.0/pluginbmp.patch
@@ -1,0 +1,31 @@
+diff --git a/Source/FreeImage/PluginBMP.cpp b/Source/FreeImage/PluginBMP.cpp
+index 76149cf..ae1f6fa 100644
+--- a/Source/FreeImage/PluginBMP.cpp
++++ b/Source/FreeImage/PluginBMP.cpp
+@@ -1419,7 +1419,7 @@ Save(FreeImageIO *io, FIBITMAP *dib, fi_handle handle, int page, int flags, void
+ 
+ 			free(buffer);
+ #ifdef FREEIMAGE_BIGENDIAN
+-		} else if (bpp == 16) {
++		} else if (dst_bpp == 16) {
+ 			int padding = dst_pitch - dst_width * sizeof(WORD);
+ 			WORD pad = 0;
+ 			WORD pixel;
+@@ -1440,7 +1440,7 @@ Save(FreeImageIO *io, FIBITMAP *dib, fi_handle handle, int page, int flags, void
+ 			}
+ #endif
+ #if FREEIMAGE_COLORORDER == FREEIMAGE_COLORORDER_RGB
+-		} else if (bpp == 24) {
++		} else if (dst_bpp == 24) {
+ 			int padding = dst_pitch - dst_width * sizeof(FILE_BGR);
+ 			DWORD pad = 0;
+ 			FILE_BGR bgr;
+@@ -1461,7 +1461,7 @@ Save(FreeImageIO *io, FIBITMAP *dib, fi_handle handle, int page, int flags, void
+ 					}
+ 				}
+ 			}
+-		} else if (bpp == 32) {
++		} else if (dst_bpp == 32) {
+ 			FILE_BGRA bgra;
+ 			for(unsigned y = 0; y < dst_height; y++) {
+ 				BYTE *line = FreeImage_GetScanLine(dib, y);

--- a/packages/f/freeimage/xmake.lua
+++ b/packages/f/freeimage/xmake.lua
@@ -14,6 +14,9 @@ package("freeimage")
 
     add_configs("rgb", {description = "Use RGB instead of BGR.", default = false})
 
+    if is_plat("macosx") then
+        add_deps("libpng")
+    end
     on_load("windows", function (package)
         if not package:config("shared") then
             package:add("defines", "FREEIMAGE_LIB")
@@ -35,9 +38,15 @@ package("freeimage")
         io.writefile("xmake.lua", format([[
             add_rules("mode.debug", "mode.release")
             includes("check_cincludes.lua")
+            if is_plat("macosx") then
+                add_requires("libpng")
+            end
             target("freeimage")
                 set_kind("$(kind)")
                 set_languages("c++11")
+                if is_plat("macosx") then
+                    add_packages("libpng")
+                end
                 add_files({"%s"})
                 add_headerfiles("Source/FreeImage.h", "Source/FreeImageIO.h")
                 set_symbols("hidden")

--- a/packages/f/freeimage/xmake.lua
+++ b/packages/f/freeimage/xmake.lua
@@ -10,6 +10,9 @@ package("freeimage")
 
     add_patches("3.18.0", path.join(os.scriptdir(), "patches", "3.18.0", "libjxr.patch"), "fddbb9fa736da383f54352dc0ab848d083d9279b66cc6ac53910236144ad75ab")
 	add_patches("3.18.0", path.join(os.scriptdir(), "patches", "3.18.0", "openexr.patch"), "051940ec58fd5ae85b65c67b83fd46eda807c9039f0f5207769ac871350af830")
+	add_patches("3.18.0", path.join(os.scriptdir(), "patches", "3.18.0", "pluginbmp.patch"), "2029f95478c8ce77f83671fe8e1889c11caa04eef2584abf0cd0a9f6a7047db0")
+
+    add_configs("rgb", {description = "Use RGB instead of BGR.", default = false})
 
     on_load("windows", function (package)
         if not package:config("shared") then
@@ -28,6 +31,7 @@ package("freeimage")
         local content = io.readfile("Makefile.srcs")
         sources = content:match("SRCS = (.-)\n"):split(" ")
         includes = content:match("INCLUDE = (.-)\n"):gsub("%-I", ""):split(" ")
+        local rgb_type = package:config("rgb") and "FREEIMAGE_COLORORDER=1" or "FREEIMAGE_COLORORDER=0"
         io.writefile("xmake.lua", format([[
             add_rules("mode.debug", "mode.release")
             includes("check_cincludes.lua")
@@ -39,7 +43,7 @@ package("freeimage")
                 set_symbols("hidden")
                 add_includedirs({"%s"})
                 check_cincludes("Z_HAVE_UNISTD_H", "unistd.h")
-                add_defines("OPJ_STATIC", "NO_LCMS", "LIBRAW_NODLL", "DISABLE_PERF_MEASUREMENT")
+                add_defines("OPJ_STATIC", "NO_LCMS", "LIBRAW_NODLL", "DISABLE_PERF_MEASUREMENT", "]] .. rgb_type .. [[")
                 if is_plat("windows") then
                     add_files("FreeImage.rc")
                     add_defines("WIN32", "_CRT_SECURE_NO_DEPRECATE")


### PR DESCRIPTION
This is done by adding config option `rgb` to `FreeImage` for configuring between rgb and grb color formats