### PR TITLE
Auto-update toml11 to v4.2.0

### DIFF
--- a/packages/t/toml11/xmake.lua
+++ b/packages/t/toml11/xmake.lua
@@ -7,6 +7,7 @@ package("toml11")
     add_urls("https://github.com/ToruNiina/toml11/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ToruNiina/toml11.git")
 
+    add_versions("v4.2.0", "9287971cd4a1a3992ef37e7b95a3972d1ae56410e7f8e3f300727ab1d6c79c2c")
     add_versions("v4.1.0", "fb4c02cc708ae28e6fc3496514e3625e4b6738ed4ce40897710ca4d7a29de4f7")
     add_versions("v4.0.3", "c8cbc7839cb3f235153045ce550e559f55a04554dfcab8743ba8a1e8ef6a54bf")
     add_versions("v4.0.2", "d1bec1970d562d328065f2667b23f9745a271bf3900ca78e92b71a324b126070")


### PR DESCRIPTION
New version of toml11 detected (package version: v4.1.0, last github version: v4.2.0)