### PR TITLE
fix_poco_shared_build

### DIFF
--- a/packages/e/expat/xmake.lua
+++ b/packages/e/expat/xmake.lua
@@ -24,7 +24,7 @@ package("expat")
         end
     end)
 
-    on_install("windows", "linux", "macosx", "android", "mingw", "cross", "bsd", function (package)
+    on_install(function (package)
         local configs = {"-DEXPAT_BUILD_EXAMPLES=OFF", "-DEXPAT_BUILD_TESTS=OFF", "-DEXPAT_BUILD_DOCS=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DEXPAT_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))

--- a/packages/p/poco/xmake.lua
+++ b/packages/p/poco/xmake.lua
@@ -138,6 +138,10 @@ package("poco")
             io.replace("cmake/FindPCRE2.cmake", "NAMES pcre2-8", "NAMES pcre2-8-static pcre2-8", {plain = true})
             io.replace("cmake/FindPCRE2.cmake", "IMPORTED_LOCATION \"${PCRE2_LIBRARY}\"", "IMPORTED_LOCATION \"${PCRE2_LIBRARY}\"\nINTERFACE_COMPILE_DEFINITIONS PCRE2_STATIC", {plain = true})
         end
+        -- pcre2 has some problem on wasm plat, set it's root directory manually
+        if package:version():ge("1.12.0") then
+            table.insert(configs, "-DPCRE2_ROOT_DIR=" .. package:dep("pcre2"):installdir())
+        end
 
         if not package:config("install_cpp_runtimes") then
             io.replace("CMakeLists.txt", 'include(InstallRequiredSystemLibraries)', '', {plain = true})

--- a/packages/p/poco/xmake.lua
+++ b/packages/p/poco/xmake.lua
@@ -112,7 +112,7 @@ package("poco")
         end
     end)
 
-    on_install("windows", "linux", "macosx", "mingw|x86_64@msys", function (package)
+    on_install(function (package)
         local configs = {"-DPOCO_UNBUNDLED=ON"} -- Using external dependencies
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. ((package:debug() or package:has_runtime("MTd", "MDd")) and "Debug" or "Release"))
         table.insert(configs, "-DPOCO_STATIC=" .. (package:config("shared") and "OFF" or "ON"))

--- a/packages/p/poco/xmake.lua
+++ b/packages/p/poco/xmake.lua
@@ -16,52 +16,129 @@ package("poco")
     add_versions("1.12.5", "92b18eb0fcd2263069f03e7cc80f9feb43fb7ca23b8c822a48e42066b2cd17a6")
     add_versions("1.13.3", "9f074d230daf30f550c5bde5528037bdab6aa83b2a06c81a25e89dd3bcb7e419")
 
+    add_configs("shared", {description = "Build shared library.", default = false, type = "boolean"})
+    add_configs("debug", {description = "Build debug library.", default = false, type = "boolean"})
+    
+    add_configs("install_cpp_runtimes", {description = "Install c++ runtimes with Poco.", default = false, type = "boolean"})
+
+    -- https://docs.pocoproject.org/current/00200-GettingStarted.html
+    add_configs("xml", {description = "Build XML support library.", default = true, type = "boolean"})
+    add_configs("json", {description = "Build JSON support library.", default = false, type = "boolean"})
+    add_configs("net", {description = "Build Net support library.", default = false, type = "boolean"})
+    add_configs("netssl", {description = "Build NetSSL support library (Need installed openssl libraries).", default = false, type = "boolean"})
+    add_configs("crypto", {description = "Build Crypto support library (Need installed openssl libraries).", default = false, type = "boolean"})
+    add_configs("jwt", {description = "Build JWT (JSON Web Token) library (Need installed openssl libraries).", default = false, type = "boolean"})
+    add_configs("data", {description = "Build Data support library.", default = false, type = "boolean"})
+    add_configs("sqlite", {description = "Build Data SQlite support library.", default = false, type = "boolean"})
+    add_configs("mysql", {description = "Build Data MySQL or MariaDB support library (Need installed MySQL or MariaDB client libraries).", default = false, type = "boolean"})
+    add_configs("mariadb", {description = "Build Data MySQL or MariaDB support library (Need installed MySQL or MariaDB client libraries).", default = false, type = "boolean"})
+    add_configs("postgresql", {description = "Build SQL PosgreSQL support library (Need installed PostgreSQL client libraries).", default = false, type = "boolean"})
+    add_configs("sql_parser", {description = "Build SQL Parser support library.", default = false, type = "boolean"})
+    -- There is no odbc in xmake for now.
+    -- Todo:
+    add_configs("odbc", {description = "Build Data ODBC support library (Need installed ODBC libraries).", default = false, type = "boolean", readonly = true})
+    add_configs("mongodb", {description = "Build MongoDB support library.", default = false, type = "boolean"})
+    add_configs("redis", {description = "Build Redis support library.", default = false, type = "boolean"})
+    add_configs("pdf", {description = "Build PDF support library.", default = false, type = "boolean"})
+    add_configs("util", {description = "Build Util support library.", default = false, type = "boolean"})
+    add_configs("zip", {description = "Build Zip support library.", default = true, type = "boolean"})
+    add_configs("sevenzip", {description = "Build 7Zip support library.", default = false, type = "boolean"})
+    -- There is no aprutil and apache2 in xmake for now.
+    -- Todo:
+    add_configs("apache_connector", {description = "Build ApacheConnector support library (Need installed apache and apr libraries).", default = false, type = "boolean", readonly = true})
+    add_configs("cpp_parser", {description = "Build C++ parser library.", default = false, type = "boolean"})
+    add_configs("encodings", {description = "Build Encodings library.", default = false, type = "boolean"})
+    add_configs("encodings_compiler", {description = "Enable Encodings Compiler.", default = false, type = "boolean"})
+    add_configs("page_compiler", {description = "Build PageCompiler.", default = false, type = "boolean"})
+    add_configs("file2page", {description = "Build PageCompiler File2Page.", default = false, type = "boolean"})
+    
     if is_plat("windows") then
-        add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+        add_configs("netssl_win", {description = "Build NetSSL support library(Need installed openssl libraries For Windows only).", default = false, type = "boolean"})
     end
-    add_configs("mysql", {description = "Enable mysql support.", default = false, type = "boolean"})
-    add_configs("postgresql", {description = "Enable postgresql support.", default = false, type = "boolean"})
-    add_configs("mongodb", {description = "Enable mongodb support.", default = false, type = "boolean"})
-    add_configs("odbc", {description = "Enable odbc support.", default = is_plat("windows"), type = "boolean"})
-    add_configs("sql_parser", {description = "Enable poco data sql parser.", default = false, type = "boolean"})
+    add_configs("prometheus", {description = "Enable Prometheus.", default = false, type = "boolean"})
+    add_configs("active_record", {description = "Enable ActiveRecord.", default = false, type = "boolean"})
+    add_configs("active_record_compiler", {description = "Enable ActiveRecord Compiler.", default = false, type = "boolean"})
+
+    add_configs("poco_doc", {description = "Build Poco Documentation Generator.", default = false, type = "boolean"})
+    add_configs("poco_test", {description = "Build Unit tests.", default = false, type = "boolean"})
 
     add_deps("cmake")
-    add_deps("openssl", "sqlite3", "expat", "zlib")
+    add_deps("sqlite3", "expat", "zlib") -- required: sqlite3(No option sqlite, sqlite3 is also required), expat, zlib, pcre/pcre2
     add_defines("POCO_NO_AUTOMATIC_LIBS")
     if is_plat("windows") then
         add_syslinks("iphlpapi")
     end
 
     on_load(function (package)
-        if package:config("postgresql") then
-            package:add("deps", "postgresql")
-        end
-        if package:config("mysql") then
-            package:add("deps", "mysql")
-        end
+        assert(not (package:has_runtime("MT", "MTd") and package:config("shared")), "Poco cannot have both BUILD_SHARED_LIBS and POCO_MT")
+        assert(not (package:config("mysql") and package:config("mariadb")), "Poco's options 'mysql' and 'mariadb' cannot exist together")
         if package:version():ge("1.12.0") then
             package:add("deps", "pcre2")
         else
             package:add("deps", "pcre")
         end
+
+        -- Todo: Rewrite to xmake based on the poco's module dependencies in CMakeList.txt
+        -- sample: in poco's CMakeList.txt:198
+        -- if(ENABLE_ACTIVERECORD AND NOT ENABLE_DATA)
+        --     set(ENABLE_DATA ON CACHE BOOL "Enable Data" FORCE)
+        -- endif()
+        -- Rewrite to xmake:
+        -- if package:config("active_record") then
+        --     package:config_set("data", true)
+        -- end
+
+        if package:config("netssl") or package:config("crypto") or package:config("jwt") then
+            package:add("deps", "openssl")
+        end
+        if package:config("mysql") then
+            package:add("deps", "mysql")
+        end
+        if package:config("mariadb") then
+            package:add("deps", "mariadb-connector-c")
+        end
+        if package:config("postgresql") then
+            package:add("deps", "postgresql")
+        end
+        -- There is no odbc in xmake for now.
+        if package:config("odbc") then
+            package:add("deps", "odbc")
+        end
+        -- There is no aprutil and apache2 in xmake for now.
+        if package:config("apache_connector") then
+            package:add("deps", "apr")
+            package:add("deps", "aprutil")
+            package:add("deps", "apache2")
+        end
     end)
 
     on_install("windows", "linux", "macosx", "mingw|x86_64@msys", function (package)
-        io.replace("XML/CMakeLists.txt", "EXPAT REQUIRED", "EXPAT CONFIG REQUIRED")
-        io.replace("XML/CMakeLists.txt", "EXPAT::EXPAT", "expat::expat")
-        io.replace("XML/CMakeLists.txt", "PUBLIC POCO_UNBUNDLED", "PUBLIC POCO_UNBUNDLED XML_DTD XML_NS")
-        io.replace("Foundation/CMakeLists.txt", "PUBLIC POCO_UNBUNDLED", "PUBLIC POCO_UNBUNDLED PCRE_STATIC")
-        io.replace("Foundation/CMakeLists.txt", "POCO_SOURCES%(SRCS RegExp.-%)", "")
-        if package:version():ge("1.12.0") and package:dep("pcre2"):exists() and not package:dep("pcre2"):config("shared") then
+        local configs = {"-DPOCO_UNBUNDLED=ON"} -- Using external dependencies
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. ((package:debug() or package:has_runtime("MTd", "MDd")) and "Debug" or "Release"))
+        table.insert(configs, "-DPOCO_STATIC=" .. (package:config("shared") and "OFF" or "ON"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        if package:is_plat("windows") then
+            table.insert(configs, "-DPOCO_MT=" .. (package:has_runtime("MT", "MTd") and "ON" or "OFF"))
+        end
+
+        -- Todo: need to fix expat
+        -- expat has a partial problem with the static library, resulting in missing macros in poco's xml module; the shared library has no problems
+        if not package:dep("expat"):config("shared") then
+            io.replace("XML/CMakeLists.txt", "EXPAT REQUIRED", "EXPAT CONFIG REQUIRED")
+            io.replace("XML/CMakeLists.txt", "EXPAT::EXPAT", "expat::expat")
+            io.replace("XML/CMakeLists.txt", "PUBLIC POCO_UNBUNDLED", "PUBLIC POCO_UNBUNDLED XML_DTD XML_NS")
+        end
+        -- Todo: need to fix pcre2
+        -- pcre2 has a partial problem with the static library, resulting in missing macros in poco's foundation module; the shared library has no problems
+        if package:version():ge("1.12.0") and not package:dep("pcre2"):config("shared") then
+            io.replace("Foundation/CMakeLists.txt", "PUBLIC POCO_UNBUNDLED", "PUBLIC POCO_UNBUNDLED PCRE_STATIC")
+            io.replace("Foundation/CMakeLists.txt", "POCO_SOURCES%(SRCS RegExp.-%)", "")
             io.replace("cmake/FindPCRE2.cmake", "NAMES pcre2-8", "NAMES pcre2-8-static pcre2-8", {plain = true})
             io.replace("cmake/FindPCRE2.cmake", "IMPORTED_LOCATION \"${PCRE2_LIBRARY}\"", "IMPORTED_LOCATION \"${PCRE2_LIBRARY}\"\nINTERFACE_COMPILE_DEFINITIONS PCRE2_STATIC", {plain = true})
         end
 
-        local configs = {"-DPOCO_UNBUNDLED=ON", "-DENABLE_TESTS=OFF", "-DENABLE_PDF=ON"}
-        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if package:is_plat("windows") and not package:config("shared") then
-            table.insert(configs, "-DPOCO_MT=" .. (package:has_runtime("MT", "MTd") and "ON" or "OFF"))
+        if not package:config("install_cpp_runtimes") then
+            io.replace("CMakeLists.txt", 'include(InstallRequiredSystemLibraries)', '', {plain = true})
         end
 
         if package:is_plat("windows") then
@@ -74,18 +151,54 @@ package("poco")
             end
         end
 
-        for _, lib in ipairs({"mysql", "postgresql", "odbc", "mongodb"}) do
-            table.insert(configs, "-DENABLE_DATA_" .. lib:upper() .. "=" .. (package:config(lib) and "ON" or "OFF"))
-        end
+        table.insert(configs, "-DENABLE_XML=" .. (package:config("xml") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_JSON=" .. (package:config("json") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_NET=" .. (package:config("net") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_NETSSL=" .. (package:config("netssl") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_CRYPTO=" .. (package:config("crypto") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_JWT=" .. (package:config("jwt") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_DATA=" .. (package:config("data") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_DATA_SQLITE=" .. (package:config("sqlite") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_DATA_MYSQL=" .. (package:config("mysql") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_DATA_MYSQL=" .. (package:config("mariadb") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_DATA_POSTGRESQL=" .. (package:config("postgresql") and "ON" or "OFF"))
         table.insert(configs, "-DPOCO_DATA_NO_SQL_PARSER=" .. (package:config("sql_parser") and "OFF" or "ON"))
+        table.insert(configs, "-DENABLE_DATA_ODBC=" .. (package:config("odbc") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_MONGODB=" .. (package:config("mongodb") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_REDIS=" .. (package:config("redis") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_PDF=" .. (package:config("pdf") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_UTIL=" .. (package:config("util") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_ZIP=" .. (package:config("zip") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_SEVENZIP=" .. (package:config("sevenzip") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_APACHECONNECTOR=" .. (package:config("apache_connector") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_CPPPARSER=" .. (package:config("cpp_parser") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_ENCODINGS=" .. (package:config("encodings") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_ENCODINGS_COMPILER=" .. (package:config("encodings_compiler") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_PAGECOMPILER=" .. (package:config("page_compiler") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_PAGECOMPILER_FILE2PAGE=" .. (package:config("file2page") and "ON" or "OFF"))
+        if package:is_plat("windows") then
+            table.insert(configs, "-DENABLE_NETSSL_WIN=" .. (package:config("netssl_win") and "ON" or "OFF"))
+        end
+        table.insert(configs, "-DENABLE_PROMETHEUS=" .. (package:config("prometheus") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_ACTIVERECORD=" .. (package:config("active_record") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_ACTIVERECORD_COMPILER=" .. (package:config("active_record_compiler") and "ON" or "OFF"))
 
-        if package:config("mysql") then
-            io.replace("Data/MySQL/include/Poco/Data/MySQL/MySQL.h", '#pragma comment(lib, "libmysql")', '', {plain = true})
-            local libmysql = package:dep("mysql"):fetch()
-            if libmysql then
-                table.insert(configs, "-DMYSQL_INCLUDE_DIR=" .. table.concat(libmysql.includedirs or libmysql.sysincludedirs, ";"))
-                table.insert(configs, "-DMYSQL_LIBRARY=" .. table.concat(libmysql.libfiles or {}, ";"))
+        table.insert(configs, "-DENABLE_POCODOC=" .. (package:config("poco_doc") and "ON" or "OFF"))
+        table.insert(configs, "-DENABLE_TESTS=" .. (package:config("poco_test") and "ON" or "OFF"))
+
+        if package:config("mariadb") then
+            for _, file in ipairs(os.files("Data/MySQL/include/**")) do
+                io.replace(file, '#include <mysql/mysql.h>', '#include <mariadb/mysql.h>', {plain = true})
             end
+            for _, file in ipairs(os.files("Data/MySQL/src/**")) do
+                io.replace(file, '#include <mysql/mysql.h>', '#include <mariadb/mysql.h>', {plain = true})
+            end
+        end
+        if package:config("mysql") or package:config("mariadb") then
+            io.replace("Data/MySQL/include/Poco/Data/MySQL/MySQL.h", '#pragma comment(lib, "libmysql")', '', {plain = true})
+            io.replace("cmake/FindMySQL.cmake", 'find_path(MYSQL_INCLUDE_DIR mysql/mysql.h', 'find_path(MYSQL_INCLUDE_DIR mysql/mysql.h mariadb/mysql.h', {plain = true})
+            io.replace("cmake/FindMySQL.cmake", 'pkg_check_modules(PC_MARIADB QUIET mariadb)', 'pkg_check_modules(PC_MARIADB QUIET mariadb-connector-c)', {plain = true})
+            io.replace("cmake/FindMySQL.cmake", 'find_library(MYSQL_LIBRARY NAMES mysqlclient\n', 'find_library(MYSQL_LIBRARY NAMES mysqlclient libmariadb\n', {plain = true})
         end
 
         -- warning: only works on windows sdk 10.0.18362.0 and later
@@ -94,4 +207,5 @@ package("poco")
 
     on_test(function (package)
         assert(package:has_cxxtypes("Poco::BasicEvent<int>", {configs = {languages = "c++14"}, includes = "Poco/BasicEvent.h"}))
+        -- Todo: add more test for each poco's module
     end)

--- a/packages/p/poco/xmake.lua
+++ b/packages/p/poco/xmake.lua
@@ -100,6 +100,7 @@ package("poco")
 
     on_check(function (package)
         assert(not (package:is_plat("mingw") and package:is_subhost("macos")), "Poco not support mingw@macos")
+        assert(not (package:is_plat("wasm")), "Poco not support wasm")
 
         assert(not (package:has_runtime("MT", "MTd") and package:config("shared")), "Poco cannot have both BUILD_SHARED_LIBS and POCO_MT")
         assert(not (package:config("mysql") and package:config("mariadb")), "Poco's options 'mysql' and 'mariadb' cannot exist together")
@@ -137,10 +138,6 @@ package("poco")
             io.replace("Foundation/CMakeLists.txt", "POCO_SOURCES%(SRCS RegExp.-%)", "")
             io.replace("cmake/FindPCRE2.cmake", "NAMES pcre2-8", "NAMES pcre2-8-static pcre2-8", {plain = true})
             io.replace("cmake/FindPCRE2.cmake", "IMPORTED_LOCATION \"${PCRE2_LIBRARY}\"", "IMPORTED_LOCATION \"${PCRE2_LIBRARY}\"\nINTERFACE_COMPILE_DEFINITIONS PCRE2_STATIC", {plain = true})
-        end
-        -- pcre2 has some problem on wasm plat, set it's root directory manually
-        if package:version():ge("1.12.0") then
-            table.insert(configs, "-DPCRE2_ROOT_DIR=" .. package:dep("pcre2"):installdir())
         end
 
         if not package:config("install_cpp_runtimes") then

--- a/packages/p/poco/xmake.lua
+++ b/packages/p/poco/xmake.lua
@@ -98,7 +98,9 @@ package("poco")
         end
     end)
 
-    on_check("!mingw@macos", function (package)
+    on_check(function (package)
+        assert(not (package:is_plat("mingw") and package:is_subhost("macos")), "Poco not support mingw@macos")
+
         assert(not (package:has_runtime("MT", "MTd") and package:config("shared")), "Poco cannot have both BUILD_SHARED_LIBS and POCO_MT")
         assert(not (package:config("mysql") and package:config("mariadb")), "Poco's options 'mysql' and 'mariadb' cannot exist together")
 

--- a/packages/p/poco/xmake.lua
+++ b/packages/p/poco/xmake.lua
@@ -15,12 +15,8 @@ package("poco")
     add_versions("1.12.4", "71ef96c35fced367d6da74da294510ad2c912563f12cd716ab02b6ed10a733ef")
     add_versions("1.12.5", "92b18eb0fcd2263069f03e7cc80f9feb43fb7ca23b8c822a48e42066b2cd17a6")
     add_versions("1.13.3", "9f074d230daf30f550c5bde5528037bdab6aa83b2a06c81a25e89dd3bcb7e419")
-
-    add_configs("shared", {description = "Build shared library.", default = false, type = "boolean"})
-    add_configs("debug", {description = "Build debug library.", default = false, type = "boolean"})
     
     add_configs("install_cpp_runtimes", {description = "Install c++ runtimes with Poco.", default = false, type = "boolean"})
-
     -- https://docs.pocoproject.org/current/00200-GettingStarted.html
     add_configs("xml", {description = "Build XML support library.", default = true, type = "boolean"})
     add_configs("json", {description = "Build JSON support library.", default = false, type = "boolean"})
@@ -79,14 +75,6 @@ package("poco")
         end
 
         -- Todo: Rewrite to xmake based on the poco's module dependencies in CMakeList.txt
-        -- sample: in poco's CMakeList.txt:198
-        -- if(ENABLE_ACTIVERECORD AND NOT ENABLE_DATA)
-        --     set(ENABLE_DATA ON CACHE BOOL "Enable Data" FORCE)
-        -- endif()
-        -- Rewrite to xmake:
-        -- if package:config("active_record") then
-        --     package:config_set("data", true)
-        -- end
 
         if package:config("netssl") or package:config("crypto") or package:config("jwt") then
             package:add("deps", "openssl")

--- a/packages/p/poco/xmake.lua
+++ b/packages/p/poco/xmake.lua
@@ -105,12 +105,9 @@ package("poco")
         -- warning: only works on windows sdk 10.0.18362.0 and later
         if package:is_plat("windows") then
             local vs_sdkver = package:toolchain("msvc"):config("vs_sdkver")
-            print(vs_sdkver)
             if vs_sdkver then
                 local build_ver = string.match(vs_sdkver, "%d+%.%d+%.(%d+)%.?%d*")
                 assert(tonumber(build_ver) >= 18362, "poco requires Windows SDK to be at least 10.0.18362.0")
-                table.insert(configs, "-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=" .. vs_sdkver)
-                table.insert(configs, "-DCMAKE_SYSTEM_VERSION=" .. vs_sdkver)
             end
         end
     end)

--- a/packages/p/poco/xmake.lua
+++ b/packages/p/poco/xmake.lua
@@ -98,7 +98,7 @@ package("poco")
         end
     end)
 
-    on_check(function (package)
+    on_check("!mingw@macos", function (package)
         assert(not (package:has_runtime("MT", "MTd") and package:config("shared")), "Poco cannot have both BUILD_SHARED_LIBS and POCO_MT")
         assert(not (package:config("mysql") and package:config("mariadb")), "Poco's options 'mysql' and 'mariadb' cannot exist together")
 


### PR DESCRIPTION
* Fix Poco libraries cannot compile with shared build on Windows
* Fix: Compiling Poco's xml module has some problems due to missing macros with the expat static library. Appending macros directly will cause to fail to compile Poco with a dynamic expat library. Change some previous code to be executed only when expat is a static library.
* Fix: Compiling Poco's foundation module has some problems due to missing macros with the pcre2 static library. Appending macros directly will cause to fail to compile Poco with a dynamic pcre2 library. Change some previous code to be executed only when pcre2 is a static library.
* Refine the Poco library modules so that you don't need to install the entire Poco library if you only need a small part of it.
* Provide the option of mariadb when using the MySql module in Poco (not selectable at the same time as mysql).

