### PR TITLE
json-glib: fix pthread link

### DIFF
--- a/packages/j/json-glib/xmake.lua
+++ b/packages/j/json-glib/xmake.lua
@@ -7,9 +7,12 @@ package("json-glib")
     add_urls("https://github.com/GNOME/json-glib/archive/refs/tags/$(version).tar.gz")
     add_versions("1.9.2", "277c3b7fc98712e30115ee3a60c3eac8acc34570cb98d3ff78de85ed804e0c80")
 
-
     add_patches("1.9.2", "patches/1.9.2/add_brace_to_json_scanner.patch", "5d77c14d25ad24a911d28d51e9defee9a3c382428dc3e23101f6319fc46b227c")
     add_deps("glib", "meson", "ninja")
+
+    if is_plat("linux") then
+        add_syslinks("pthread")
+    end
 
     add_includedirs("include", "include/json-glib-1.0")
 


### PR DESCRIPTION
json-glib 中在另一个环境中测试时有可能因为没有手动加addsyslinks("pthread") 而失败，所以此处加上