### PR TITLE
Auto-update cpp-semver to v0.4.0

### DIFF
--- a/packages/c/cpp-semver/xmake.lua
+++ b/packages/c/cpp-semver/xmake.lua
@@ -7,6 +7,7 @@ package("cpp-semver")
     add_urls("https://github.com/z4kn4fein/cpp-semver/archive/refs/tags/$(version).tar.gz",
              "https://github.com/z4kn4fein/cpp-semver.git")
 
+    add_versions("v0.4.0", "9885062b640a4a26dbefa1a07f9c1f0a0e092762d13f2974fdf3fdf0c01ced8d")
     add_versions("v0.3.3", "05d59da347b5b5b4f34670d32704a54219657c9856a7af6645f06064006c6c68")
     add_versions("v0.3.1", "9168cc815d8b9a5b3d73d2a158efec467eff844f1cab929bc145312cfc3958ae")
 


### PR DESCRIPTION
New version of cpp-semver detected (package version: v0.3.3, last github version: v0.4.0)