### PR TITLE
Auto-update libmaxminddb to 1.11.0

### DIFF
--- a/packages/l/libmaxminddb/xmake.lua
+++ b/packages/l/libmaxminddb/xmake.lua
@@ -6,6 +6,7 @@ package("libmaxminddb")
     add_urls("https://github.com/maxmind/libmaxminddb/releases/download/$(version)/libmaxminddb-$(version).tar.gz",
              "https://github.com/maxmind/libmaxminddb.git")
 
+    add_versions("1.11.0", "b2eea79a96fed77ad4d6c39ec34fed83d45fcb75a31c58956813d58dcf30b19f")
     add_versions("1.10.0", "5e6db72df423ae225bfe8897069f6def40faa8931f456b99d79b8b4d664c6671")
 
     add_configs("tools", {description = "Build tools", default = false, type = "boolean"})


### PR DESCRIPTION
New version of libmaxminddb detected (package version: 1.10.0, last github version: 1.11.0)