### PR TITLE
Auto-update pybind11 to v2.13.5

### DIFF
--- a/packages/p/pybind11/xmake.lua
+++ b/packages/p/pybind11/xmake.lua
@@ -7,6 +7,7 @@ package("pybind11")
 
     add_urls("https://github.com/pybind/pybind11/archive/refs/tags/$(version).zip",
              "https://github.com/pybind/pybind11.git")
+    add_versions("v2.13.5", "0b4f2d6a0187171c6d41e20cbac2b0413a66e10e014932c14fae36e64f23c565")
     add_versions("v2.5.0", "1859f121837f6c41b0c6223d617b85a63f2f72132bae3135a2aa290582d61520")
     add_versions("v2.6.2", "0bdb5fd9616fcfa20918d043501883bf912502843d5afc5bc7329a8bceb157b3")
     add_versions("v2.7.1", "350ebf8f4c025687503a80350897c95d8271bf536d98261f0b8ed2c1a697070f")


### PR DESCRIPTION
New version of pybind11 detected (package version: v2.13.1, last github version: v2.13.5)