### PR TITLE
Auto-update simsimd to v5.0.1

### DIFF
--- a/packages/s/simsimd/xmake.lua
+++ b/packages/s/simsimd/xmake.lua
@@ -7,6 +7,7 @@ package("simsimd")
     add_urls("https://github.com/ashvardanian/SimSIMD/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ashvardanian/SimSIMD.git")
 
+    add_versions("v5.0.1", "a492a617aa9fcda69c34f0ef675d3729c41aeb18df91735eb249d0064bed3cb3")
     add_versions("v4.3.2", "0732603a0680a4b9c70abe0b59de011447ad7db0e0631c2f7c307c0135aa4d43")
     add_versions("v4.3.1", "d3c54c5b27f8bbb161c8523c47ddc98bfeb75cac17066c959f42ebe78c518b0f")
     add_versions("v3.9.0", "8e79b628ba89beebc7c4c853323db0e10ebb6f85bcda2641e1ebaf77cfbda7f9")


### PR DESCRIPTION
New version of simsimd detected (package version: v4.3.2, last github version: v5.0.1)