### PR TITLE
Auto-update libkmod to v33

### DIFF
--- a/packages/l/libkmod/xmake.lua
+++ b/packages/l/libkmod/xmake.lua
@@ -6,6 +6,7 @@ package("libkmod")
     add_urls("https://github.com/kmod-project/kmod/archive/refs/tags/$(version).tar.gz",
              "https://github.com/kmod-project/kmod.git")
 
+    add_versions("v33", "c72120a2582ae240221671ddc1aa53ee522764806f50f8bf1522bbf055679985")
     add_versions("v31", "16c40aaa50fc953035b4811b29ce3182f220e95f3c9e5eacb4b07b1abf85f003")
     add_versions("v30", "1fa3974abd80b992d61324bcc04fa65ea96cfe2e9e1150f48394833030c4b583")
 


### PR DESCRIPTION
New version of libkmod detected (package version: v31, last github version: v33)