### PR TITLE
drogon: fix shared build for version >=1.8.0

### DIFF
--- a/packages/d/drogon/xmake.lua
+++ b/packages/d/drogon/xmake.lua
@@ -100,7 +100,6 @@ package("drogon")
         -- no support for windows shared library
         if not package:is_plat("windows") then
             local shared = (package:config("shared") and "ON" or "OFF")
-
             if version:ge("1.8.0") then
                 table.insert(configs, "-DBUILD_SHARED_LIBS=" .. shared)
             else

--- a/packages/d/drogon/xmake.lua
+++ b/packages/d/drogon/xmake.lua
@@ -99,7 +99,13 @@ package("drogon")
 
         -- no support for windows shared library
         if not package:is_plat("windows") then
-            table.insert(configs, "-DBUILD_DROGON_SHARED=" .. (package:config("shared") and "ON" or "OFF"))
+            local shared = (package:config("shared") and "ON" or "OFF")
+
+            if version:ge("1.8.0") then
+                table.insert(configs, "-DBUILD_SHARED_LIBS=" .. shared)
+            else
+                table.insert(configs, "-DBUILD_DROGON_SHARED=" .. shared)
+            end
         end
 
         for name, enabled in pairs(package:configs()) do

--- a/packages/d/drogon/xmake.lua
+++ b/packages/d/drogon/xmake.lua
@@ -99,7 +99,7 @@ package("drogon")
 
         -- no support for windows shared library
         if not package:is_plat("windows") then
-            local shared = (package:config("shared") and "ON" or "OFF")
+            local shared = package:config("shared") and "ON" or "OFF"
             if version:ge("1.8.0") then
                 table.insert(configs, "-DBUILD_SHARED_LIBS=" .. shared)
             else


### PR DESCRIPTION
Fix `config = { shared = true }` producing static lib.

In drogon 1.8.0 the CMake config `BUILD_DROGON_SHARED` was changed to `BUILD_SHARED_LIBS`