### PR TITLE
Auto-update haclog to v0.3.0

### DIFF
--- a/packages/h/haclog/xmake.lua
+++ b/packages/h/haclog/xmake.lua
@@ -6,6 +6,7 @@ package("haclog")
     add_urls("https://github.com/MuggleWei/haclog/archive/refs/tags/$(version).tar.gz",
              "https://github.com/MuggleWei/haclog.git")
 
+    add_versions("v0.3.0", "1804bbdc938548adefd4182a8011a2714be3f3b0ddf0fbeb072ef0c75449fa50")
     add_versions("v0.2.0", "5e055f69e490298a9515c38b3b024a97b41d4dfb5daaaf0ef94eb5c1da9db5ca")
     add_versions("v0.1.6", "3afdb52d21b03a085291074612c39fab3ef056b6b32071693df4a2b60b9b6554")
     add_versions("v0.0.5", "789340ba87ac076e4c5559e1e6e0bf4f1e17f2e55c4845d0f9fc8ead8e6d7f5f")


### PR DESCRIPTION
New version of haclog detected (package version: v0.2.0, last github version: v0.3.0)