### PR TITLE
Auto-update tree-sitter to 0.23.0

### DIFF
--- a/packages/t/tree-sitter/port/xmake.lua
+++ b/packages/t/tree-sitter/port/xmake.lua
@@ -1,8 +1,11 @@
 add_rules("mode.debug", "mode.release")
+
 target("tree-sitter")
     set_kind("$(kind)")
     add_files("lib/src/lib.c")
-    add_includedirs({
-        "lib/src",
-        "lib/include"})
+    add_includedirs("lib/src", "lib/include")
     add_headerfiles("lib/include/(**.h)")
+
+    if is_plat("windows") and is_kind("shared") then
+        add_rules("utils.symbols.export_all")
+    end

--- a/packages/t/tree-sitter/xmake.lua
+++ b/packages/t/tree-sitter/xmake.lua
@@ -1,9 +1,10 @@
 package("tree-sitter")
-
     set_homepage("https://tree-sitter.github.io/")
     set_description("An incremental parsing system for programming tools")
+    set_license("MIT")
 
-    add_urls("https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v$(version).zip")
+    add_urls("https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v$(version).zip",
+             "https://github.com/tree-sitter/tree-sitter.git")
 
     add_versions("0.23.0", "e9f2772b12d4b12a0db5542ce72e8c85a34e397f2c3fd7b3fa08814f71fd35b3")
     add_versions("0.22.6", "eb2d8bfcb6d21b820ac88add96d71ef9ebaec9d2a171b86a48c27c0511a17e4e")
@@ -13,29 +14,9 @@ package("tree-sitter")
 
     on_install(function(package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
-
-        local configs = {}
-        if package:config("shared") then
-            configs.kind = "shared"
-        end
         import("package.tools.xmake").install(package, configs)
     end)
 
     on_test(function(package)
-        assert(package:check_csnippets({
-            test = [[
-            #include <string.h>
-            #include <tree_sitter/api.h>
-            void test() {
-                TSParser *parser = ts_parser_new();
-                const char *source_code = "[1, null]";
-                TSTree *tree = ts_parser_parse_string(
-                    parser,
-                    NULL,
-                    source_code,
-                    strlen(source_code)
-                );
-            }
-        ]]
-        }))
+        assert(package:has_cfuncs("ts_parser_new", {includes = "tree_sitter/api.h"}))
     end)

--- a/packages/t/tree-sitter/xmake.lua
+++ b/packages/t/tree-sitter/xmake.lua
@@ -5,6 +5,7 @@ package("tree-sitter")
 
     add_urls("https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v$(version).zip")
 
+    add_versions("0.23.0", "e9f2772b12d4b12a0db5542ce72e8c85a34e397f2c3fd7b3fa08814f71fd35b3")
     add_versions("0.22.6", "eb2d8bfcb6d21b820ac88add96d71ef9ebaec9d2a171b86a48c27c0511a17e4e")
     add_versions("0.22.5", "b8c0da9f5cafa3214547bc3bbfa0d0f05a642f9d0c045e505a940cf487300849")
     add_versions("0.22.2", "df0cd4aacc53b6feb9519dd4b74a7a6c8b7f3f7381fcf7793250db3e5e63fb80")


### PR DESCRIPTION
New version of tree-sitter detected (package version: 0.22.6, last github version: 0.23.0)