### PR TITLE
Auto-update cppfront to v0.7.4

### DIFF
--- a/packages/c/cppfront/xmake.lua
+++ b/packages/c/cppfront/xmake.lua
@@ -5,6 +5,7 @@ package("cppfront")
 
     add_urls("https://github.com/hsutter/cppfront/archive/refs/tags/$(version).tar.gz")
     add_urls("https://github.com/hsutter/cppfront.git")
+    add_versions("v0.7.4", "028f44cc0cad26b51829e4abf7c5aedf8a31f852ab5dfbad54bb232f0a1d7447")
     add_versions("v0.7.2", "fb44c6a65fa19b185ddf385dd3bfea05afe0bc8260382b7a8e3c75b3c9004cd6")
     add_versions("v0.7.0", "d4ffb37d19a2b7c054d005cf4687439577ef2f3d93b340a342704e064cd1d047")
 


### PR DESCRIPTION
New version of cppfront detected (package version: v0.7.2, last github version: v0.7.4)