### PR TITLE
Auto-update pdfhummus to v4.6.7

### DIFF
--- a/packages/p/pdfhummus/xmake.lua
+++ b/packages/p/pdfhummus/xmake.lua
@@ -6,6 +6,7 @@ package("pdfhummus")
     add_urls("https://github.com/galkahana/PDF-Writer/archive/refs/tags/$(version).tar.gz",
              "https://github.com/galkahana/PDF-Writer/archive/refs/tags/v$(version).tar.gz",
              "https://github.com/galkahana/PDF-Writer.git")
+    add_versions("v4.6.7", "735c65d4685c5156f0876635f3bc1565700d0f648fbb1f384e46d186796c8bae")
     add_versions("v4.6.6", "8343820313e553052df68c75fe2bf35353da2719106e81eb2a8b026ff96c7d7c")
     add_versions("v4.6.4", "93b5f1dc88fd67fdebde409e927e828dfbae02efa44936e89728622411c6a047")
     add_versions("v4.6.3", "3b5d9ba4b49d0380678e8172f27cdb8eda196ea448e7f1cdd79620066d082ab9")


### PR DESCRIPTION
New version of pdfhummus detected (package version: v4.6.6, last github version: v4.6.7)