### PR TITLE
bgfx: fix shader compilation

### DIFF
--- a/packages/b/bgfx/xmake.lua
+++ b/packages/b/bgfx/xmake.lua
@@ -47,7 +47,7 @@ package("bgfx")
         local bimgdir = package:resourcefile("bimg")
         local genie = is_host("windows") and "genie.exe" or "genie"
         local args = {}
-        if is_plat("windows|native", "macosx", "linux") then
+        if package:is_plat("windows", "macosx", "linux") then
             args = {"--with-tools"}
         end
         if package:config("shared") then


### PR DESCRIPTION
Fixes #5105

* Adds ".sc" as a supported extension for bgfx shaders;
* Adds support for vs_, fs, and cs_ prefixes for vertex, fragment, and compute shaders;
* Adds support for bin2c confguration (header generation)