### PR TITLE
add at-spi2-core repo

### DIFF
--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -13,7 +13,7 @@ package("at-spi2-core")
 
     add_links("atk-bridge-2.0", "atspi", "atk-1.0")
 
-    add_deps("meson", "ninja", "glib", "pkg-config", "dbus", "libx11", "libxtst", "libxi")
+    add_deps("meson", "ninja", "glib", "pkg-config", "dbus", "libx11", "libxtst", "libxi", "libxml2")
     on_install("linux", function (package)
         local configs = {}
         table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -11,6 +11,8 @@ package("at-spi2-core")
 
     add_includedirs("include", "include/at-spi-2.0", "include/atk-1.0", "include/at-spi2-atk/2.0")
 
+    add_links("atk-bridge-2.0", "atspi", "atk-1.0")
+
     add_deps("meson", "ninja", "glib", "pkg-config", "dbus", "libx11", "libxtst", "libxi")
     on_install("linux", function (package)
         local configs = {}

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -15,7 +15,7 @@ package("at-spi2-core")
     on_install("linux", function (package)
         local configs = {}
         table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
-        import("package.tools.meson").install(package, configs)
+        import("package.tools.meson").install(package, configs, {packagedeps = {"glib", "libiconv", "libx11", "libxtst", "libxi", "dbus"}})
     end)
 
     on_test(function (package)

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -1,0 +1,24 @@
+package("at-spi2-core")
+
+    set_homepage("https://gitlab.gnome.org/GNOME/at-spi2-core")
+    set_description("contains the DBus interface definitions for AT-SPI - the core of an accessibility stack for free software systems.")
+    set_license("LGPL-2.1")
+
+    add_urls("https://gitlab.gnome.org/GNOME/at-spi2-core/-/archive/AT_SPI2_CORE_$(version)/at-spi2-core-AT_SPI2_CORE_$(version).tar.gz", {version = function (version)
+        return version:gsub("%.", "_")
+    end})
+    add_versions("2.53.90", "6b0a7c15b5fceb69f501e8b6b8bebe9896c35b9edb1ee08fe0b202d488a71363")
+
+    add_includedirs("include", "include/at-spi-2.0", "include/atk-1.0", "include/at-spi2-atk/2.0")
+
+    add_deps("meson", "ninja", "glib", "pkg-config", "dbus", "libx11", "libxtst", "libxi")
+    on_install("linux", function (package)
+        local configs = {}
+        table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
+        import("package.tools.meson").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("atk_bridge_adaptor_init", {includes = "atk-bridge.h"}))
+        assert(package:has_cfuncs("atk_object_initialize", {includes = "atk/atk.h"}))
+    end)

--- a/packages/p/pango/xmake.lua
+++ b/packages/p/pango/xmake.lua
@@ -48,7 +48,7 @@ package("pango")
         -- fix unexpected -Werror=array-bounds errors, see https://gitlab.gnome.org/GNOME/pango/-/issues/740
         io.replace("meson.build", "'-Werror=array-bounds',", "", {plain = true})
 
-        local envs = meson.buildenvs(package, {packagedeps = {"fontconfig", "freetype", "harfbuzz", "fribidi", "cairo", "glib", "pcre2", "libintl", "libiconv", "libthai", "libdatrie", }})
+        local envs = meson.buildenvs(package, {packagedeps = {"fontconfig", "freetype", "harfbuzz", "fribidi", "cairo", "glib", "pcre2", "libintl", "libiconv", "libthai", "libdatrie"}})
         -- workaround for https://github.com/xmake-io/xmake/issues/4412
         envs.LDFLAGS = string.gsub(envs.LDFLAGS, "%-libpath:", "/libpath:")
         meson.install(package, configs, {envs = envs})


### PR DESCRIPTION
gtk3中需要依赖libatk-adapter。但目前只有atk的包，故添加at-spi2-core的包，包括atk，atspi, atk-bridge(包含atk-adapter)