### PR TITLE
Auto-update nghttp2 to 1.63.0

### DIFF
--- a/packages/n/nghttp2/xmake.lua
+++ b/packages/n/nghttp2/xmake.lua
@@ -4,6 +4,7 @@ package("nghttp2")
     set_license("MIT")
 
     add_urls("https://github.com/nghttp2/nghttp2/releases/download/v$(version)/nghttp2-$(version).tar.gz")
+    add_versions("1.63.0", "9318a2cc00238f5dd6546212109fb833f977661321a2087f03034e25444d3dbb")
     add_versions("1.62.1", "d0b0b9d00500ee4aa3bfcac00145d3b1ef372fd301c35bff96cf019c739db1b4")
     add_versions("1.62.0", "482e41a46381d10adbdfdd44c1942ed5fd1a419e0ab6f4a5ff5b61468fe6f00d")
     add_versions("1.61.0", "aa7594c846e56a22fbf3d6e260e472268808d3b49d5e0ed339f589e9cc9d484c")


### PR DESCRIPTION
New version of nghttp2 detected (package version: 1.62.1, last github version: 1.63.0)