### PR TITLE
Auto-update nanoflann to v1.6.1

### DIFF
--- a/packages/n/nanoflann/xmake.lua
+++ b/packages/n/nanoflann/xmake.lua
@@ -7,6 +7,7 @@ package("nanoflann")
 
     add_urls("https://github.com/jlblancoc/nanoflann/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jlblancoc/nanoflann.git")
+    add_versions("v1.6.1", "e258d6fd6ad18e1809fa9c081553e78036fd6e7b418d3762875c2c5a015dd431")
     add_versions("v1.6.0", "f889026fbcb241e1e9d71bab5dfb9cc35775bf18a6466a283e2cbcd60edb2705")
     add_versions("v1.5.5", "fd28045eabaf0e7f12236092f80905a1750e0e6b580bb40eadd64dc4f75d641d")
     add_versions("v1.3.2", "e100b5fc8d72e9426a80312d852a62c05ddefd23f17cbb22ccd8b458b11d0bea")


### PR DESCRIPTION
New version of nanoflann detected (package version: v1.6.0, last github version: v1.6.1)