### PR TITLE
Auto-update aws-c-compression to v0.2.19

### DIFF
--- a/packages/a/aws-c-compression/xmake.lua
+++ b/packages/a/aws-c-compression/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-compression")
     add_urls("https://github.com/awslabs/aws-c-compression/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-compression.git")
 
+    add_versions("v0.2.19", "51796f98a29a0d6e257c02e1f842bbc41db324758939093e6d46ec28337a3272")
     add_versions("v0.2.18", "517c361f3b7fffca08efd5ad251a20489794f056eab0dfffacc6d5b341df8e86")
     add_versions("v0.2.17", "703d1671e395ea26f8b0b70d678ed471421685a89e127f8aa125e2b2ecedb0e0")
 


### PR DESCRIPTION
New version of aws-c-compression detected (package version: v0.2.18, last github version: v0.2.19)