### PR TITLE
Auto-update daw_header_libraries to v2.110.0

### DIFF
--- a/packages/d/daw_header_libraries/xmake.lua
+++ b/packages/d/daw_header_libraries/xmake.lua
@@ -7,6 +7,7 @@ package("daw_header_libraries")
     add_urls("https://github.com/beached/header_libraries/archive/refs/tags/$(version).tar.gz",
              "https://github.com/beached/header_libraries.git")
 
+    add_versions("v2.110.0", "6515bb7a130656adff9f1f17d6be69dbd7c40dbcebbe418e9d0cf15bbc71bffc")
     add_versions("v2.106.1", "393815fbf249ca1220a216899cae3d2672ca193f9db228a0b99925a9b0f90854")
     add_versions("v2.106.0", "7838ada09afa69e7a42d742991c4b24b32ba27681e7b4dadf7b1e45c168937b5")
     add_versions("v2.102.0", "bc80936b439da0ef8a432175732e94573b14069a778b83d5f26ce8847f11ebb8")

--- a/packages/d/daw_header_libraries/xmake.lua
+++ b/packages/d/daw_header_libraries/xmake.lua
@@ -20,10 +20,19 @@ package("daw_header_libraries")
     end)
 
     on_test(function (package)
-        assert(package:check_cxxsnippets({test = [[
+        local code = [[
             #include <daw/daw_carray.h>
             void test() {
                 daw::carray<int, 6> t = {1, 2, 3, 4, 5, 6};
             }
-        ]]}, {configs = {languages = "c++17"}}))
+        ]]
+        if package:gitref() or package:version():ge("2.109.0") then
+            code = [[
+                #include <daw/daw_bounded_array.h>
+                void test() {
+                    daw::array<int, 6> t = { 1, 2, 3, 4, 5, 6 };
+            }
+            ]]
+        end
+        assert(package:check_cxxsnippets({test = code}, {configs = {languages = "c++17"}}))
     end)


### PR DESCRIPTION
New version of daw_header_libraries detected (package version: v2.106.1, last github version: v2.110.0)