### PR TITLE
Auto-update cpp-dump to v0.7.0

### DIFF
--- a/packages/c/cpp-dump/xmake.lua
+++ b/packages/c/cpp-dump/xmake.lua
@@ -11,18 +11,32 @@ package("cpp-dump")
     add_versions("v0.6.0", "22bc5fafa22ac7c1e99db8824fdabec4af6baabed0c8b7cc80a0205dfb550414")
     add_versions("v0.5.0", "31fa8b03c9ee820525137be28f37b36e2abe7fd91df7d67681cb894db2230fe6")
 
+    on_load(function (package)
+        if package:gitref() or package:version():ge("0.7.0") then
+            package:add("deps", "cmake")
+        end
+    end)
+
     on_install(function (package)
-        os.cp("hpp", package:installdir("include/cpp-dump"))
-        os.cp("dump.hpp", package:installdir("include/cpp-dump"))
+        if package:gitref() or package:version():ge("0.7.0") then
+            io.replace("CMakeLists.txt", "if(IS_TOP_LEVEL)", "if(0)", {plain = true})
+            import("package.tools.cmake").install(package)
+        else
+            os.cp("hpp", package:installdir("include/cpp-dump"))
+            os.cp("dump.hpp", package:installdir("include/cpp-dump"))
+        end
     end)
 
     on_test(function (package)
+        local includes = "cpp-dump/dump.hpp"
+        if package:gitref() or package:version():ge("0.7.0") then
+            includes = "cpp-dump.hpp"
+        end
+
         assert(package:check_cxxsnippets({test = [[
-            #include <vector>
-            #include "cpp-dump/dump.hpp"
             void test() {
                 std::vector<std::vector<int>> my_vector{{3, 5, 8, 9, 7}, {9, 3, 2, 3, 8}};
                 cpp_dump(my_vector);
             }
-        ]]}, {configs = {languages = "c++17"}}))
+        ]]}, {configs = {languages = "c++17"}, includes = includes}))
     end)

--- a/packages/c/cpp-dump/xmake.lua
+++ b/packages/c/cpp-dump/xmake.lua
@@ -7,6 +7,7 @@ package("cpp-dump")
     add_urls("https://github.com/philip82148/cpp-dump/archive/refs/tags/$(version).tar.gz",
              "https://github.com/philip82148/cpp-dump.git")
 
+    add_versions("v0.7.0", "b27a0854a405aa10619f341f66e26a6c39dca1ad41a26dd4fa6d86ad6752c4f8")
     add_versions("v0.6.0", "22bc5fafa22ac7c1e99db8824fdabec4af6baabed0c8b7cc80a0205dfb550414")
     add_versions("v0.5.0", "31fa8b03c9ee820525137be28f37b36e2abe7fd91df7d67681cb894db2230fe6")
 


### PR DESCRIPTION
New version of cpp-dump detected (package version: v0.6.0, last github version: v0.7.0)