### PR TITLE
Auto-update quill to v7.0.0

### DIFF
--- a/packages/q/quill/xmake.lua
+++ b/packages/q/quill/xmake.lua
@@ -6,6 +6,7 @@ package("quill")
     set_urls("https://github.com/odygrd/quill/archive/refs/tags/$(version).tar.gz",
              "https://github.com/odygrd/quill.git")
 
+    add_versions("v7.0.0", "15ad108b490ae6d605ed3ca78c149db832acddacb3846bec6d3a89fff2c063e2")
     add_versions("v6.1.2", "3eea9ec9634ce0ef28a2cc766d5316c1f068feb9340cf54e40e431a9342a9220")
     add_versions("v6.1.0", "3893ab422c746d93ff47bbcd61dd5e60bee37974b0d81cdab9cf9a4b10c58477")
     add_versions("v5.1.0", "0b4f34415c4b173f3d0466752fa3d3835e1a58f931bfce5281f817b5f997511f")


### PR DESCRIPTION
New version of quill detected (package version: v6.1.2, last github version: v7.0.0)