### PR TITLE
Auto-update ls-hpack to v2.3.4

### DIFF
--- a/packages/l/ls-hpack/xmake.lua
+++ b/packages/l/ls-hpack/xmake.lua
@@ -6,6 +6,7 @@ package("ls-hpack")
     add_urls("https://github.com/litespeedtech/ls-hpack/archive/refs/tags/$(version).tar.gz",
              "https://github.com/litespeedtech/ls-hpack.git")
 
+    add_versions("v2.3.4", "db6775ce6aea2db7f90bdb4a798d2b21bdf88493da97cfd4eb40e9aa375d77c0")
     add_versions("v2.3.3", "3d7d539bd659fefc7168fb514368065cb12a1a7a0946ded60e4e10f1637f1ea2")
 
     add_deps("xxhash")


### PR DESCRIPTION
New version of ls-hpack detected (package version: v2.3.3, last github version: v2.3.4)