### PR TITLE
Auto-update fast_float to v6.1.6

### DIFF
--- a/packages/f/fast_float/xmake.lua
+++ b/packages/f/fast_float/xmake.lua
@@ -17,6 +17,7 @@ package("fast_float")
     add_versions("v6.1.3", "7dd99cc2ff44e07dc2a42bed0c6b8c4a8ee4e3b1c330f77073b6cfdb48724c8e")
     add_versions("v6.1.4", "12cb6d250824160ca16bcb9d51f0ca7693d0d10cb444f34f1093bc02acfce704")
     add_versions("v6.1.5", "597126ff5edc3ee59d502c210ded229401a30dafecb96a513135e9719fcad55f")
+    add_versions("v6.1.6", "4458aae4b0eb55717968edda42987cabf5f7fc737aee8fede87a70035dba9ab0")
 
     if is_plat("wasm") then
         add_patches("v3.4.0", path.join(os.scriptdir(), "patches", "emscripten_fix.patch"), "482705431f67e6f0a375ed7bfe87d6856e7d13f071db6157e1d5659834b0eb50")


### PR DESCRIPTION
New version of fast_float detected (package version: v6.1.5, last github version: v6.1.6)