### PR TITLE
Auto-update mathter to v2.0.0

### DIFF
--- a/packages/m/mathter/xmake.lua
+++ b/packages/m/mathter/xmake.lua
@@ -7,6 +7,7 @@ package("mathter")
     add_urls("https://github.com/petiaccja/Mathter/archive/refs/tags/$(version).tar.gz",
              "https://github.com/petiaccja/Mathter.git")
 
+    add_versions("v2.0.0", "ba1ea1ceef8761385264295953ec9fc48de11d3f5ae36873af2f02c5633c07ca")
     add_versions("v1.1.2", "9e6d03295d28e8792721fedca5d53955d4057d1550e51491408353b6181e6c6d")
     add_versions("v1.1.1", "510e6aa198cd7b207a44d319e4471021f207cba8c4d2d7e40086f1f042fe13ab")
 


### PR DESCRIPTION
New version of mathter detected (package version: v1.1.2, last github version: v2.0.0)