### PR TITLE
Auto-update md4qt to 3.0.0

### DIFF
--- a/packages/m/md4qt/xmake.lua
+++ b/packages/m/md4qt/xmake.lua
@@ -7,6 +7,7 @@ package("md4qt")
     add_urls("https://github.com/igormironchik/md4qt/archive/refs/tags/$(version).tar.gz",
              "https://github.com/igormironchik/md4qt.git")
 
+    add_versions("3.0.0", "757f94ce1818123abe899729bba00aa1d99150d4cbe934ab57a95b308fd536dd")
     add_versions("2.8.1", "02a046c1586da820be0c5dd36f635ca50060f893fe638b542546f4a7a07d3164")
     add_versions("2.8.0", "82ef6acc84ea3a7891e4547f7d79af4caaef0f4d6f152bdab2a5c6ed5a48d11b")
     add_versions("2.4.2", "76f3228dd9afa2661fe9326b51e5ec8dc29e364f99fb0f94704792610d543fa2")


### PR DESCRIPTION
New version of md4qt detected (package version: 2.8.1, last github version: 3.0.0)