### PR TITLE
Auto-update quickjs-ng to v0.6.1

### DIFF
--- a/packages/q/quickjs-ng/xmake.lua
+++ b/packages/q/quickjs-ng/xmake.lua
@@ -29,7 +29,7 @@ package("quickjs-ng")
     end
 
     on_install("!iphoneos and (!windows or windows|!x86)", function (package)
-        io.replace("CMakeLists.txt", "-Werror", "", {plain = true})
+        io.replace("CMakeLists.txt", "xcheck_add_c_compiler_flag(-Werror)", "", {plain = true})
         io.replace("CMakeLists.txt", "if(NOT WIN32 AND NOT EMSCRIPTEN)", "if(0)", {plain = true})
 
         local configs = {}

--- a/packages/q/quickjs-ng/xmake.lua
+++ b/packages/q/quickjs-ng/xmake.lua
@@ -4,7 +4,7 @@ package("quickjs-ng")
     set_license("MIT")
 
     add_urls("https://github.com/quickjs-ng/quickjs/archive/refs/tags/$(version).tar.gz",
-             "https://github.com/quickjs-ng/quickjs.git")
+             "https://github.com/quickjs-ng/quickjs.git", {submodules = false})
 
     add_versions("v0.6.1", "276edbb30896cdf2eee12a8bdb5b9c1cc2734eac8c898de6d52268ae201e614d")
     add_versions("v0.5.0", "41212a6fb84bfe07d61772c02513734b7a06465843ba8f76f1ce1e5df866f489")
@@ -19,15 +19,19 @@ package("quickjs-ng")
 
     if on_check then
         on_check("windows", function (package)
-            local msvc = package:toolchain("msvc")
-            if msvc then
-                local vs = msvc:config("vs")
-                assert(vs and tonumber(vs) >= 2022, "package(quickjs-ng): need vs >= 2022")
+            local vs_toolset = package:toolchain("msvc"):config("vs_toolset")
+            if vs_toolset then
+                local vs_toolset_ver = import("core.base.semver").new(vs_toolset)
+                local minor = vs_toolset_ver:minor()
+                assert(minor and minor >= 30, "package(quickjs-ng) require vs_toolset >= 14.3")
             end
         end)
     end
 
     on_install("!iphoneos and (!windows or windows|!x86)", function (package)
+        io.replace("CMakeLists.txt", "-Werror", "", {plain = true})
+        io.replace("CMakeLists.txt", "if(NOT WIN32 AND NOT EMSCRIPTEN)", "if(0)", {plain = true})
+
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))

--- a/packages/q/quickjs-ng/xmake.lua
+++ b/packages/q/quickjs-ng/xmake.lua
@@ -6,6 +6,7 @@ package("quickjs-ng")
     add_urls("https://github.com/quickjs-ng/quickjs/archive/refs/tags/$(version).tar.gz",
              "https://github.com/quickjs-ng/quickjs.git")
 
+    add_versions("v0.6.1", "276edbb30896cdf2eee12a8bdb5b9c1cc2734eac8c898de6d52268ae201e614d")
     add_versions("v0.5.0", "41212a6fb84bfe07d61772c02513734b7a06465843ba8f76f1ce1e5df866f489")
 
     add_configs("libc", {description = "Build standard library modules as part of the library", default = false, type = "boolean"})


### PR DESCRIPTION
New version of quickjs-ng detected (package version: v0.5.0, last github version: v0.6.1)