### PR TITLE
fix x264 on windows with shared build

### DIFF
--- a/packages/x/x264/xmake.lua
+++ b/packages/x/x264/xmake.lua
@@ -49,7 +49,6 @@ package("x264")
     end)
 
     on_install("windows", "mingw", "linux", "macosx", "wasm", function (package)
-        io.replace("configure", "x264.dll.lib", "x264.lib", {plain = true})
         local configs = {}
         table.insert(configs, "--enable-" .. (package:config("shared") and "shared" or "static"))
         if package:is_plat("mingw") then
@@ -75,6 +74,7 @@ package("x264")
             import("core.tool.toolchain")
             local msvc = package:toolchain("msvc") or toolchain.load("msvc", {plat = package:plat(), arch = package:arch()})
             assert(msvc:check(), "msvs not found!")
+            io.replace("configure", "x264.dll.lib", "x264.lib", {plain = true})
             -- keep msys2 envs in front to prevent conflict with possibly installed sh.exe
             local envs = os.joinenvs(os.getenvs(), msvc:runenvs())
             envs.CC = path.filename(package:build_getenv("cc"))

--- a/packages/x/x264/xmake.lua
+++ b/packages/x/x264/xmake.lua
@@ -92,7 +92,22 @@ package("x264")
             os.vrunv("make", argv, {envs = envs})
             os.vrunv("make", {"install"}, {envs = envs})
         else
+            try
+            {
+                -- try 代码块
+                function ()
             import("package.tools.autoconf").install(package, configs)
+                end,
+
+                -- catch 代码块
+                catch
+                {
+                    -- 发生异常后，被执行
+                    function (errors)
+                        io.cat("config.log")
+                    end
+                }
+            }
         end
     end)
 

--- a/packages/x/x264/xmake.lua
+++ b/packages/x/x264/xmake.lua
@@ -74,7 +74,6 @@ package("x264")
             import("core.tool.toolchain")
             local msvc = package:toolchain("msvc") or toolchain.load("msvc", {plat = package:plat(), arch = package:arch()})
             assert(msvc:check(), "msvs not found!")
-            print("here is msvc on windows")
             io.replace("configure", "x264.dll.lib", "x264.lib", {plain = true})
             -- keep msys2 envs in front to prevent conflict with possibly installed sh.exe
             local envs = os.joinenvs(os.getenvs(), msvc:runenvs())
@@ -92,22 +91,7 @@ package("x264")
             os.vrunv("make", argv, {envs = envs})
             os.vrunv("make", {"install"}, {envs = envs})
         else
-            try
-            {
-                -- try 代码块
-                function ()
             import("package.tools.autoconf").install(package, configs)
-                end,
-
-                -- catch 代码块
-                catch
-                {
-                    -- 发生异常后，被执行
-                    function (errors)
-                        io.cat("config.log")
-                    end
-                }
-            }
         end
     end)
 

--- a/packages/x/x264/xmake.lua
+++ b/packages/x/x264/xmake.lua
@@ -49,6 +49,7 @@ package("x264")
     end)
 
     on_install("windows", "mingw", "linux", "macosx", "wasm", function (package)
+        io.replace("configure", "x264.dll.", "x264.", {plain = true})
         local configs = {}
         table.insert(configs, "--enable-" .. (package:config("shared") and "shared" or "static"))
         if package:is_plat("mingw") then

--- a/packages/x/x264/xmake.lua
+++ b/packages/x/x264/xmake.lua
@@ -74,6 +74,7 @@ package("x264")
             import("core.tool.toolchain")
             local msvc = package:toolchain("msvc") or toolchain.load("msvc", {plat = package:plat(), arch = package:arch()})
             assert(msvc:check(), "msvs not found!")
+            print("here is msvc on windows")
             io.replace("configure", "x264.dll.lib", "x264.lib", {plain = true})
             -- keep msys2 envs in front to prevent conflict with possibly installed sh.exe
             local envs = os.joinenvs(os.getenvs(), msvc:runenvs())

--- a/packages/x/x264/xmake.lua
+++ b/packages/x/x264/xmake.lua
@@ -49,6 +49,7 @@ package("x264")
     end)
 
     on_install("windows", "mingw", "linux", "macosx", "wasm", function (package)
+        io.replace("configure", "x264.dll.lib", "x264.lib", {plain = true})
         local configs = {}
         table.insert(configs, "--enable-" .. (package:config("shared") and "shared" or "static"))
         if package:is_plat("mingw") then

--- a/packages/x/x264/xmake.lua
+++ b/packages/x/x264/xmake.lua
@@ -49,7 +49,6 @@ package("x264")
     end)
 
     on_install("windows", "mingw", "linux", "macosx", "wasm", function (package)
-        io.replace("configure", "x264.dll.", "x264.", {plain = true})
         local configs = {}
         table.insert(configs, "--enable-" .. (package:config("shared") and "shared" or "static"))
         if package:is_plat("mingw") then


### PR DESCRIPTION
When x264 compiles dynamic libraries on Windows platform, it will generate libx264.dll.lib (msvc) or libx264.dll.a (mingw) import libraries.
However, configue has hardcoded -lx264 when generating x264.pc, so that libraries using pkgconfig can't find the symbols when linking x264 libraries.
Change the import library to libx264.lib (msvc) or libx264.a (mingw).