### PR TITLE
Auto-update cppjieba to v5.4.0

### DIFF
--- a/packages/c/cppjieba/xmake.lua
+++ b/packages/c/cppjieba/xmake.lua
@@ -7,6 +7,7 @@ package("cppjieba")
     add_urls("https://github.com/yanyiwu/cppjieba/archive/refs/tags/$(version).tar.gz",
              "https://github.com/yanyiwu/cppjieba.git", {submodules = false})
 
+    add_versions("v5.4.0", "6358e7f961e601ee6a01ce968bd07dad4e455a2c8721520d0304cc94b2d029ee")
     add_versions("v5.2.0", "00c420e9e1b212827a38b6e252468895f744c0e7be8c4feaab4e0a93b8d3b1ca")
 
     add_deps("limonp")


### PR DESCRIPTION
New version of cppjieba detected (package version: v5.2.0, last github version: v5.4.0)