### PR TITLE
Auto-update plutovg to v0.0.6

### DIFF
--- a/packages/p/plutovg/xmake.lua
+++ b/packages/p/plutovg/xmake.lua
@@ -6,6 +6,7 @@ package("plutovg")
     add_urls("https://github.com/sammycage/plutovg/archive/refs/tags/$(version).tar.gz",
              "https://github.com/sammycage/plutovg.git")
 
+    add_versions("v0.0.6", "3be0e0d94ade3e739f60ac075c88c2e40d84a0ac05fc3ff8c7c97d0749e9a82b")
     add_versions("v0.0.1", "32b8f3501e3964f288f277a607fa87b512466651")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of plutovg detected (package version: v0.0.1, last github version: v0.0.6)