### PR TITLE
Auto-update fribidi to 1.0.16

### DIFF
--- a/packages/f/fribidi/xmake.lua
+++ b/packages/f/fribidi/xmake.lua
@@ -5,6 +5,7 @@ package("fribidi")
     set_license("LGPL-2.1")
 
     add_urls("https://github.com/fribidi/fribidi/releases/download/v$(version)/fribidi-$(version).tar.xz")
+    add_versions("1.0.16", "1b1cde5b235d40479e91be2f0e88a309e3214c8ab470ec8a2744d82a5a9ea05c")
     add_versions("1.0.15", "0bbc7ff633bfa208ae32d7e369cf5a7d20d5d2557a0b067c9aa98bcbf9967587")
     add_versions("1.0.14", "76ae204a7027652ac3981b9fa5817c083ba23114340284c58e756b259cd2259a")
     add_versions("1.0.10", "7f1c687c7831499bcacae5e8675945a39bacbad16ecaa945e9454a32df653c01")


### PR DESCRIPTION
New version of fribidi detected (package version: 1.0.15, last github version: 1.0.16)