### PR TITLE
Auto-update kdbindings to v1.1.0

### DIFF
--- a/packages/k/kdbindings/xmake.lua
+++ b/packages/k/kdbindings/xmake.lua
@@ -7,6 +7,7 @@ package("kdbindings")
     add_urls("https://github.com/KDAB/KDBindings/archive/refs/tags/$(version).tar.gz",
              "https://github.com/KDAB/KDBindings.git")
 
+    add_versions("v1.1.0", "0ee07cb3e2ec4f5688b4b2971c42e5a4f4a41c7bf4aa130e6b118bea4b6340ab")
     add_versions("v1.0.5", "4d001419809a719f8c966e9bc73f457180325655deca0a11c07c47ee112447a3")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of kdbindings detected (package version: v1.0.5, last github version: v1.1.0)