### PR TITLE
`npcap_sdk`: add `mingw` support with workaround for unrecognized SAL

### DIFF
--- a/packages/n/npcap_sdk/xmake.lua
+++ b/packages/n/npcap_sdk/xmake.lua
@@ -5,8 +5,14 @@ package("npcap_sdk")
     set_urls("https://npcap.com/dist/npcap-sdk-$(version).zip")
     add_versions("1.13", "dad1f2bf1b02b787be08ca4862f99e39a876c1f274bac4ac0cedc9bbc58f94fd")
 
-    on_install("windows", function (package)
-        os.cp("Include", package:installdir())
+    on_load("mingw", function (package)
+        if package:version():eq("1.13") then
+            package:add("defines", "_Post_invalid_=")
+        end
+    end)
+
+    on_install("windows", "mingw", function (package)
+        os.cp("Include/*", package:installdir("include"))
         if package:is_arch("arm64") then
             os.cp("Lib/ARM64/*", package:installdir("lib"))
         elseif package:is_arch("x86") then

--- a/packages/n/npcap_sdk/xmake.lua
+++ b/packages/n/npcap_sdk/xmake.lua
@@ -16,7 +16,7 @@ package("npcap_sdk")
         os.cp("Include/*", package:installdir("include"))
         if package:is_arch("arm64") then
             os.cp("Lib/ARM64/*", package:installdir("lib"))
-        elseif package:is_arch("x86") then
+        elseif package:is_arch("x86") or package:is_arch("i386") then
             os.cp("Lib/*.lib", package:installdir("lib"))
         else
             os.cp("Lib/x64/*.lib", package:installdir("lib"))

--- a/packages/n/npcap_sdk/xmake.lua
+++ b/packages/n/npcap_sdk/xmake.lua
@@ -4,6 +4,7 @@ package("npcap_sdk")
 
     set_urls("https://npcap.com/dist/npcap-sdk-$(version).zip")
     add_versions("1.13", "dad1f2bf1b02b787be08ca4862f99e39a876c1f274bac4ac0cedc9bbc58f94fd")
+    add_versions("1.12", "24c4862723f61d28048a24e10eb31d2269b2152a5762410dd1caffc041871337")
 
     on_load("mingw", function (package)
         if package:version():eq("1.13") then


### PR DESCRIPTION
## Workaround for Unrecognized MSVC SAL Annotation `_Post_invalid_`

### Problem
The introduction of certain SAL annotations by npcap in [this commit](https://github.com/nmap/npcap/commit/a22a54788a7cb8ad6ba984a076316f9961018e22) causes compatibility issues with MinGW, which fails to recognize `_Post_invalid_`.

### Possible Solutions
- Revert to a previous version of npcap that does not include these SAL annotations.
- Upgrade to a newer version of the MinGW toolchain that defines `_Post_invalid_` in `sal.h`.
- Await the next release of npcap_sdk, which is promised to address this issue as discussed in [this issue comment](https://github.com/the-tcpdump-group/libpcap/issues/1118#issuecomment-1367013626). Note that the last release of npcap_sdk was in 2022.