### PR TITLE
Auto-update harfbuzz to 10.0.1

### DIFF
--- a/packages/h/harfbuzz/xmake.lua
+++ b/packages/h/harfbuzz/xmake.lua
@@ -7,6 +7,7 @@ package("harfbuzz")
     add_urls("https://github.com/harfbuzz/harfbuzz/archive/refs/tags/$(version).tar.gz", {excludes = "README"})
     add_urls("https://github.com/harfbuzz/harfbuzz.git")
     
+    add_versions("10.0.1", "e7358ea86fe10fb9261931af6f010d4358dac64f7074420ca9bc94aae2bdd542")
     add_versions("9.0.0", "b7e481b109d19aefdba31e9f5888aa0cdfbe7608fed9a43494c060ce1f8a34d2")
     add_versions("8.5.0", "7ad8e4e23ce776efb6a322f653978b3eb763128fd56a90252775edb9fd327956")
     add_versions("8.4.0", "9f1ca089813b05944ad1ce8c7e018213026d35dc9bab480a21eb876838396556")


### PR DESCRIPTION
New version of harfbuzz detected (package version: 9.0.0, last github version: 10.0.1)