### PR TITLE
Auto-update openexr to v3.3.0

### DIFF
--- a/packages/o/openexr/xmake.lua
+++ b/packages/o/openexr/xmake.lua
@@ -6,6 +6,7 @@ package("openexr")
 
     add_urls("https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/$(version).tar.gz",
              "https://github.com/AcademySoftwareFoundation/openexr.git")
+    add_versions("v3.3.0", "58b00f50d2012f3107573c4b7371f70516d2972c2b301a50925e1b4a60a7be6f")
     add_versions("v3.2.4", "81e6518f2c4656fdeaf18a018f135e96a96e7f66dbe1c1f05860dd94772176cc")
     add_versions("v3.2.3", "f3f6c4165694d5c09e478a791eae69847cadb1333a2948ca222aa09f145eba63")
     add_versions("v2.5.3", "6a6525e6e3907715c6a55887716d7e42d09b54d2457323fcee35a0376960bebf")


### PR DESCRIPTION
New version of openexr detected (package version: v3.2.4, last github version: v3.3.0)