### PR TITLE
Auto-update opencolorio to v2.4.0

### DIFF
--- a/packages/o/opencolorio/xmake.lua
+++ b/packages/o/opencolorio/xmake.lua
@@ -6,6 +6,7 @@ package("opencolorio")
 
     add_urls("https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/refs/tags/$(version).tar.gz",
              "https://github.com/AcademySoftwareFoundation/OpenColorIO.git")
+    add_versions("v2.4.0", "0ff3966b9214da0941b2b1cbdab3975a00a51fc6f3417fa860f98f5358f2c282")
     add_versions("v2.1.0", "81fc7853a490031632a69c73716bc6ac271b395e2ba0e2587af9995c2b0efb5f")
     add_versions("v2.1.1", "16ebc3e0f21f72dbe90fe60437eb864f4d4de9c255ef8e212f837824fc9b8d9c")
 


### PR DESCRIPTION
New version of opencolorio detected (package version: v2.1.1, last github version: v2.4.0)