### PR TITLE
bison: fix Windows and BSD

### DIFF
--- a/packages/b/bison/xmake.lua
+++ b/packages/b/bison/xmake.lua
@@ -27,8 +27,8 @@ package("bison")
             package:add("deps", "m4")
         end
 
-        -- we always set it, because flex may be modified as library
-        -- by add_deps("flex", {kind = "library"})
+        -- we always set it, because bison may be modified as library
+        -- by add_deps("bison", {kind = "library"})
         package:addenv("PATH", "bin")
         if package:is_library() then
             package:set("kind", "library", {headeronly = true})

--- a/packages/b/bison/xmake.lua
+++ b/packages/b/bison/xmake.lua
@@ -4,7 +4,14 @@ package("bison")
     set_description("A general-purpose parser generator.")
     set_license("GPL-3.0")
 
-    if not is_plat("windows") then
+    if on_source then
+        on_source(function (package)
+            if not package:is_plat("windows") then
+                package:add("urls", "http://ftpmirror.gnu.org/gnu/bison/bison-$(version).tar.gz",
+                 "http://ftp.gnu.org/gnu/bison/bison-$(version).tar.gz")
+            end
+        end)
+    elseif not is_plat("windows") then
         add_urls("http://ftpmirror.gnu.org/gnu/bison/bison-$(version).tar.gz",
                  "http://ftp.gnu.org/gnu/bison/bison-$(version).tar.gz")
     end
@@ -13,29 +20,34 @@ package("bison")
     add_versions("3.7.6", "69dc0bb46ea8fc307d4ca1e0b61c8c355eb207d0b0c69f4f8462328e74d7b9ea")
     add_versions("3.8.2", "06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb")
 
-    if is_plat("windows") then
-        add_deps("winflexbison", {private = true})
-    elseif is_plat("linux", "bsd") then
-        add_deps("m4")
-    end
-
     on_load("macosx", "linux", "bsd", "windows", function (package)
-        -- we always set it, because flex may be modified as library
-        -- by add_deps("bison", {kind = "library"})
-        package:addenv("PATH", "bin")
-    end)
-
-    on_install(function (package)
         if package:is_plat("windows") then
-            os.cp(path.join(package:dep("winflexbison"):installdir(), "*"), package:installdir())
-            os.rm(path.join(package:installdir(), "bin", "flex.exe"))
-            os.rm(path.join(package:installdir(), "include", "FlexLexer.h"))
-        else
-            import("package.tools.autoconf").install(package)
-            os.rm(package:installdir("share", "doc"))
+            package:add("deps", "winflexbison", {private = true})
+        elseif package:is_plat("linux") then
+            package:add("deps", "m4")
+        end
+
+        -- we always set it, because flex may be modified as library
+        -- by add_deps("flex", {kind = "library"})
+        package:addenv("PATH", "bin")
+        if package:is_library() then
+            package:set("kind", "library", {headeronly = true})
         end
     end)
 
+    on_install("windows", function (package)
+        os.cp(path.join(package:dep("winflexbison"):installdir(), "*"), package:installdir())
+        os.rm(path.join(package:installdir(), "bin", "flex.exe"))
+        os.rm(path.join(package:installdir(), "include", "FlexLexer.h"))
+    end)
+
+    on_install("macosx", "linux", "bsd", "android", "iphoneos", "cross", function (package)
+        import("package.tools.autoconf").install(package)
+        os.rm(package:installdir("share", "doc"))
+    end)
+
     on_test(function (package)
-        os.vrun("bison -h")
+        if not package:is_cross() then
+            os.vrun("bison -h")
+        end
     end)

--- a/packages/b/bison/xmake.lua
+++ b/packages/b/bison/xmake.lua
@@ -20,6 +20,10 @@ package("bison")
     add_versions("3.7.6", "69dc0bb46ea8fc307d4ca1e0b61c8c355eb207d0b0c69f4f8462328e74d7b9ea")
     add_versions("3.8.2", "06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb")
 
+    on_check("bsd", function (package)
+        assert(package:dep("m4"):version():ge("1.4.16"), "package(bison): m4 >= 1.4.16 is required")
+    end)
+
     on_load("macosx", "linux", "bsd", "windows", function (package)
         if package:is_plat("windows") then
             package:add("deps", "winflexbison", {private = true})

--- a/packages/b/bison/xmake.lua
+++ b/packages/b/bison/xmake.lua
@@ -20,14 +20,10 @@ package("bison")
     add_versions("3.7.6", "69dc0bb46ea8fc307d4ca1e0b61c8c355eb207d0b0c69f4f8462328e74d7b9ea")
     add_versions("3.8.2", "06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb")
 
-    on_check("bsd", function (package)
-        assert(package:dep("m4"):version():ge("1.4.16"), "package(bison): m4 >= 1.4.16 is required")
-    end)
-
     on_load("macosx", "linux", "bsd", "windows", function (package)
         if package:is_plat("windows") then
             package:add("deps", "winflexbison", {private = true})
-        elseif package:is_plat("linux") then
+        elseif package:is_plat("linux", "bsd") then
             package:add("deps", "m4")
         end
 


### PR DESCRIPTION
- **Windows**: Applied fix adapted from the flex package.
- **BSD**: Added m4 as a dependency.