### PR TITLE
Auto-update croaring to v4.2.1

### DIFF
--- a/packages/c/croaring/xmake.lua
+++ b/packages/c/croaring/xmake.lua
@@ -6,6 +6,7 @@ package("croaring")
     add_urls("https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/$(version).tar.gz",
              "https://github.com/RoaringBitmap/CRoaring.git")
 
+    add_versions("v4.2.1", "3514728e9eb8c90dbc00a9e337302eb458c65be2f9501a3e882d051599c4a74c")
     add_versions("v4.1.7", "ea235796c074c3a8a8c3e5c84bb5f09619723b8e4913cf99cc349f626c193569")
     add_versions("v4.1.5", "7eafa9fd0dace499e80859867a6ba5a010816cf6e914dd9350ad1d44c0fc83eb")
     add_versions("v4.1.1", "42804cc2bb5c9279ec4fcaa56d2d6b389da934634abcce8dbc4e4c1d60e1468d")


### PR DESCRIPTION
New version of croaring detected (package version: v4.1.7, last github version: v4.2.1)