### PR TITLE
ci: upgrade al-cheb/configure-pagefile-action to fix warnings

### DIFF
--- a/.github/workflows/android_windows.yml
+++ b/.github/workflows/android_windows.yml
@@ -25,7 +25,7 @@ jobs:
           xmake-version: branch@master
 
       - name: Configure Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.2
+        uses: al-cheb/configure-pagefile-action@v1.4
         with:
           minimum-size: 8GB
           maximum-size: 32GB

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,7 @@ jobs:
           xmake-version: branch@master
 
       - name: Configure Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.2
+        uses: al-cheb/configure-pagefile-action@v1.4
         with:
           minimum-size: 8GB
           maximum-size: 32GB

--- a/.github/workflows/windows_v3.yml
+++ b/.github/workflows/windows_v3.yml
@@ -26,7 +26,7 @@ jobs:
           xmake-version: branch@master
 
       - name: Configure Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.2
+        uses: al-cheb/configure-pagefile-action@v1.4
         with:
           minimum-size: 8GB
           maximum-size: 32GB


### PR DESCRIPTION
Fix github action warnings:

![image](https://github.com/user-attachments/assets/337c3568-5559-49e3-b480-13fceb5c4d7f)
![image](https://github.com/user-attachments/assets/c835e981-dbd6-410b-a73e-0c0fac59ad9c)


