### PR TITLE
Auto-update atomic_queue to v1.6.5

### DIFF
--- a/packages/a/atomic_queue/xmake.lua
+++ b/packages/a/atomic_queue/xmake.lua
@@ -6,6 +6,7 @@ package("atomic_queue")
 
     add_urls("https://github.com/max0x7ba/atomic_queue/archive/refs/tags/$(version).tar.gz",
              "https://github.com/max0x7ba/atomic_queue.git")
+    add_versions("v1.6.5", "0257efe6781637091ff7f11d836cff4a8e0b5ea22c943fa70e00e83d83360583")
     add_versions("v1.6.4", "e9c3ae4b850dc6503ee484748701f06f3737ad177c5cb31030f74e3fef40e282")
     add_versions("v1.5", "599b76a0222e7b54118d6f0fb686845c9d323107f2de76b3f68292b057e5a99f")
     add_versions("v1.6.3", "0ad6e0203d90367f6a4e496449dfd9ad65b80168fadafef4eac08820c6bda79c")


### PR DESCRIPTION
New version of atomic_queue detected (package version: v1.6.4, last github version: v1.6.5)