### PR TITLE
keystone: fix windows dll install

### DIFF
--- a/packages/k/keystone/xmake.lua
+++ b/packages/k/keystone/xmake.lua
@@ -8,8 +8,7 @@ package("keystone")
 
     add_versions("0.9.2", "c9b3a343ed3e05ee168d29daf89820aff9effb2c74c6803c2d9e21d55b5b7c24")
 
-    add_deps("cmake")
-    add_deps("python 3.x", {kind = "binary"})
+    add_deps("cmake", "python 3.x", {kind = "binary"})
 
     if is_plat("windows", "mingw") then
         add_syslinks("shell32", "ole32", "uuid")
@@ -25,22 +24,32 @@ package("keystone")
     end)
 
     on_install(function (package)
-        local configs = {}
+        io.replace("CMakeLists.txt", "add_subdirectory(suite/fuzz)", "", {plain = true})
+        io.replace("llvm/keystone/CMakeLists.txt",
+            "install(TARGETS keystone DESTINATION lib${LLVM_LIBDIR_SUFFIX})", [[
+            install(TARGETS keystone
+                RUNTIME DESTINATION bin
+                LIBRARY DESTINATION lib
+                ARCHIVE DESTINATION lib
+            )
+            install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include)
+        ]], {plain = true})
+
+        local configs = {"-DCMAKE_POLICY_DEFAULT_CMP0057=NEW"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if package:data("build_libs_only") then
-            table.insert(configs, "-DBUILD_LIBS_ONLY=ON")
-        end
+        table.insert(configs, "-DBUILD_LIBS_ONLY=" .. (package:data("build_libs_only") and "ON" or "OFF"))
         if package:is_plat("windows") then
             table.insert(configs, "-DKEYSTONE_BUILD_STATIC_RUNTIME=" .. (package:has_runtime("MT", "MTd") and "ON" or "OFF"))
-        elseif package:is_plat("android") then
-            -- support for ndk >= r27
-            -- https://github.com/android/ndk/issues/2032
-            table.insert(configs, "-DCMAKE_POLICY_DEFAULT_CMP0057=NEW")
+            table.insert(configs, "-DCMAKE_COMPILE_PDB_OUTPUT_DIRECTORY=''")
         end
-        io.replace("CMakeLists.txt", "add_subdirectory(suite/fuzz)", "", {plain = true})
         import("package.tools.cmake").install(package, configs)
-        os.cp("include", package:installdir())
+
+        if package:is_plat("windows") and package:is_debug() then
+            local dir = package:installdir(package:config("shared") and "bin" or "lib")
+            os.vcp(path.join(package:buildir(), "llvm/**.pdb"), dir)
+            os.trycp(path.join(package:buildir(), "kstool/kstool.pdb"), package:installdir("bin"))
+        end
     end)
 
     on_test(function (package)


### PR DESCRIPTION
- Fix ninja debug build on Windows.
- Fix dll install.
- Android see https://github.com/xmake-io/xmake-repo/issues/5142