### PR TITLE
Auto-update aws-c-mqtt to v0.10.7

### DIFF
--- a/packages/a/aws-c-mqtt/xmake.lua
+++ b/packages/a/aws-c-mqtt/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-mqtt")
     add_urls("https://github.com/awslabs/aws-c-mqtt/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-mqtt.git")
 
+    add_versions("v0.10.7", "197bb549f7b121d05d59bb58dd641b56fdf80337d027f0a69146196bd8f92604")
     add_versions("v0.10.6", "7579fafc74a8751c15c0196eda6ec93d00a17e7f79fb994f34a8f62ceb66cc62")
     add_versions("v0.10.4", "6a41456f9eee15d71e4e2ee162b354865809f26620f1e6e5acb237f190f77f3f")
     add_versions("v0.10.3", "bb938d794b0757d669b5877526363dc6f6f0e43869ca19fc196ffd0f7a35f5b9")


### PR DESCRIPTION
New version of aws-c-mqtt detected (package version: v0.10.6, last github version: v0.10.7)