### PR TITLE
Auto-update rapidcsv to 8.84

### DIFF
--- a/packages/r/rapidcsv/xmake.lua
+++ b/packages/r/rapidcsv/xmake.lua
@@ -6,6 +6,7 @@ package("rapidcsv")
     set_license("BSD-3-Clause")
 
     add_urls("https://github.com/d99kris/rapidcsv/archive/refs/tags/v$(version).zip")
+    add_versions("8.84", "6226df921e392eb5fa88dd1efaf26a1a7cfdc23bc00c08a7337fc0314bf8b5a8")
     add_versions("8.83", "ca7e99a7229d50a8d7e59d77f31b53970579429c71bf05bc53729d15135c9b6f")
     add_versions("8.82", "e07c9355846b62b960ddebf79fef306ac21ee297f19880f237b7da8eb007a056")
     add_versions("8.80", "5bdbecc3542a881c058624d63c27574fa171fafe32be857e925fccaa1ae75f46")


### PR DESCRIPTION
New version of rapidcsv detected (package version: 8.83, last github version: 8.84)