### PR TITLE
Update llvm to 19.1.1.

### DIFF
--- a/packages/l/llvm/xmake.lua
+++ b/packages/l/llvm/xmake.lua
@@ -56,6 +56,7 @@ package("llvm")
                 package:add("versions", "16.0.6", "ce5e71081d17ce9e86d7cbcfa28c4b04b9300f8fb7e78422b1feb6bc52c3028e")
                 package:add("versions", "17.0.6", "58a8818c60e6627064f312dbf46c02d9949956558340938b71cf731ad8bc0813")
                 package:add("versions", "18.1.1", "8f34c6206be84b186b4b31f47e1b52758fa38348565953fad453d177ef34c0ad")
+                package:add("versions", "19.1.1", "d40e933e2a208ee142898f85d886423a217e991abbcd42dd8211f507c93e1266")
             end
         end)
     else
@@ -91,6 +92,7 @@ package("llvm")
             add_versions("16.0.6", "ce5e71081d17ce9e86d7cbcfa28c4b04b9300f8fb7e78422b1feb6bc52c3028e")
             add_versions("17.0.6", "58a8818c60e6627064f312dbf46c02d9949956558340938b71cf731ad8bc0813")
             add_versions("18.1.1", "8f34c6206be84b186b4b31f47e1b52758fa38348565953fad453d177ef34c0ad")
+            add_versions("19.1.1", "d40e933e2a208ee142898f85d886423a217e991abbcd42dd8211f507c93e1266")
         end
     end
 


### PR DESCRIPTION
## Update Package 
update llvm to 19.1.1, release: https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.1

but this is `linux` only, I did't add support of `llvm-windows 19.1.1` in this PR.

## Local test 
``` sh
$ xmake l scripts/test.lua -v --shallow llvm   
...
llvm-config --version
19.1.1
clang --version
clang version 19.1.1
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /home/shiyu/.xmake/packages/l/llvm/19.1.1/e9ea39a6aadd442286e4abea9304dc2a/bin
  => install llvm 19.1.1 .. ok
```