### PR TITLE
Auto-update c-ares to 1.34.1

### DIFF
--- a/packages/c/c-ares/xmake.lua
+++ b/packages/c/c-ares/xmake.lua
@@ -12,6 +12,7 @@ package("c-ares")
         end
     end})
 
+    add_versions("1.34.1", "7e846f1742ab5998aced36d170408557de5292b92ec404fb0f7422f946d60103")
     add_versions("1.33.1", "06869824094745872fa26efd4c48e622b9bd82a89ef0ce693dc682a23604f415")
     add_versions("1.33.0", "3e41df2f172041eb4ecb754a464c11ccc5046b2a1c8b1d6a40dac45d3a3b2346")
     add_versions("1.32.3", "5f02cc809aac3f6cc5edc1fac6c4423fd5616d7406ce47b904c24adf0ff2cd0f")


### PR DESCRIPTION
New version of c-ares detected (package version: 1.33.1, last github version: 1.34.1)