### PR TITLE
add package ipaddress

### DIFF
--- a/packages/i/ipaddress/xmake.lua
+++ b/packages/i/ipaddress/xmake.lua
@@ -1,0 +1,95 @@
+package("ipaddress", function()
+    set_homepage("https://vladimirshaleev.github.io/ipaddress/")
+    set_description("A library for working and manipulating IPv4/IPv6 addresses and networks")
+    set_license("MIT")
+    set_kind("library", {
+        headeronly = true
+    })
+
+    add_urls("https://github.com/VladimirShaleev/ipaddress/archive/refs/tags/$(version).tar.gz",
+        "https://github.com/VladimirShaleev/ipaddress.git")
+
+    add_versions("v1.1.0", "e5084d83ebd712210882eb6dac14ed1b9b71584dede523b35c6181e0a06375f1")
+
+    add_configs("noexcept", {
+        description = "Disable handling cpp exception for",
+        default = false,
+        type = "boolean"
+    })
+    add_configs("no_overload_std", {
+        description = "Do not overload std functions such as to_string, hash etc",
+        default = false,
+        type = "boolean"
+    })
+    add_configs("no_ipv6_scope", {
+        description = "Disable scope id for IPv6 addresses",
+        default = false,
+        type = "boolean"
+    })
+    add_configs("ipv6_scope_max_length", {
+        description = "Maximum scope-id length for IPv6 addresses",
+        default = 16,
+        type = "number"
+    })
+
+    add_deps("cmake")
+
+    on_install(function(package)
+        local configs = {"-DBUILD_TESTING=OFF", "-DIPADDRESS_ENABLE_CLANG_TIDY=OFF", "-DIPADDRESS_BUILD_TESTS=OFF",
+                         "-DIPADDRESS_BUILD_BENCHMARK=OFF", "-DIPADDRESS_BUILD_DOC=OFF",
+                         "-DIPADDRESS_BUILD_PACKAGES=OFF"}
+
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+
+        table.insert(configs, "-DIPADDRESS_NO_EXCEPTIONS=" .. (package:config("noexcept") and "ON" or "OFF"))
+        table.insert(configs, "-DIPADDRESS_NO_OVERLOAD_STD=" .. (package:config("no_overload_std") and "ON" or "OFF"))
+        table.insert(configs, "-DIPADDRESS_NO_IPV6_SCOPE=" .. (package:config("no_ipv6_scope") and "ON" or "OFF"))
+        table.insert(configs, "-DIPADDRESS_IPV6_SCOPE_MAX_LENGTH=" .. package:config("ipv6_scope_max_length"))
+
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function(package)
+        assert(package:check_cxxsnippets({
+            test = [[
+            #include <iostream>
+
+            #include <ipaddress/ipaddress.hpp>
+
+            using namespace ipaddress;
+
+            void parse_ip_sample() {
+                constexpr auto ip = ipv6_address::parse("fec0::1ff:fe23:4567:890a%eth2");
+                constexpr auto is_site_local = ip.is_site_local();
+
+                std::cout << "ip " << ip << " is local: " << std::boolalpha << is_site_local << std::endl;
+                std::cout << "DNS PTR " << ip.reverse_pointer() << std::endl << std::endl;
+            }
+
+            void teredo_sample() {
+                constexpr auto teredo_ip = "2001:0000:4136:e378:8000:63bf:3fff:fdd2"_ipv6;
+                auto [server, client] = teredo_ip.teredo().value();
+
+                std::cout << "server: " << server << " and client: " << client << " for " << teredo_ip << std::endl << std::endl;
+            }
+
+            void subnets_sample() {
+                constexpr auto net = ipv4_network::parse("192.0.2.0/24");
+
+                std::cout << "subnets for " << net << ':' << std::endl;
+                for (const auto& subnet : net.subnets(2)) {
+                    std::cout << "  " << subnet << std::endl;
+                }
+
+                constexpr auto last_subnet = net.subnets(2).back();
+                std::cout << "last subnet " << last_subnet << std::endl;
+            }
+        ]]
+        }, {
+            configs = {
+                languages = "c++17"
+            }
+        }))
+    end)
+end)

--- a/packages/v/vladimirshaleev-ipaddress/xmake.lua
+++ b/packages/v/vladimirshaleev-ipaddress/xmake.lua
@@ -5,7 +5,7 @@ package("vladimirshaleev-ipaddress")
     set_license("MIT")
 
     add_urls("https://github.com/VladimirShaleev/ipaddress/archive/refs/tags/$(version).tar.gz",
-        "https://github.com/VladimirShaleev/ipaddress.git")
+             "https://github.com/VladimirShaleev/ipaddress.git")
 
     add_versions("v1.1.0", "e5084d83ebd712210882eb6dac14ed1b9b71584dede523b35c6181e0a06375f1")
 

--- a/packages/v/vladimirshaleev-ipaddress/xmake.lua
+++ b/packages/v/vladimirshaleev-ipaddress/xmake.lua
@@ -33,8 +33,7 @@ package("vladimirshaleev-ipaddress")
     end)
 
     on_test(function(package)
-        assert(package:check_cxxsnippets({
-            test = [[
+        assert(package:check_cxxsnippets({test = [[
             #include <iostream>
             #include <ipaddress/ipaddress.hpp>
             using namespace ipaddress;

--- a/packages/v/vladimirshaleev-ipaddress/xmake.lua
+++ b/packages/v/vladimirshaleev-ipaddress/xmake.lua
@@ -1,4 +1,4 @@
-package("ipaddress", function()
+package("vladimirshaleev-ipaddress", function()
     set_homepage("https://vladimirshaleev.github.io/ipaddress/")
     set_description("A library for working and manipulating IPv4/IPv6 addresses and networks")
     set_license("MIT")

--- a/packages/v/vladimirshaleev-ipaddress/xmake.lua
+++ b/packages/v/vladimirshaleev-ipaddress/xmake.lua
@@ -9,9 +9,9 @@ package("vladimirshaleev-ipaddress")
 
     add_versions("v1.1.0", "e5084d83ebd712210882eb6dac14ed1b9b71584dede523b35c6181e0a06375f1")
 
-    add_configs("exceptions", {description = "Disable handling cpp exception for", default = true, type = "boolean"})
-    add_configs("overload_std", {description = "Do not overload std functions such as to_string, hash etc", default = true, type = "boolean"})
-    add_configs("ipv6_scope", {description = "Disable scope id for IPv6 addresses", default = true, type = "boolean"})
+    add_configs("exceptions", {description = "Support handling cpp exception", default = true, type = "boolean"})
+    add_configs("overload_std", {description = "Overload std functions such as to_string, hash etc", default = true, type = "boolean"})
+    add_configs("ipv6_scope", {description = "Support scope id for IPv6 addresses", default = true, type = "boolean"})
     add_configs("ipv6_scope_max_length", {description = "Maximum scope-id length for IPv6 addresses", default = 16, type = "number"})
 
     add_deps("cmake")

--- a/packages/v/vladimirshaleev-ipaddress/xmake.lua
+++ b/packages/v/vladimirshaleev-ipaddress/xmake.lua
@@ -9,9 +9,9 @@ package("vladimirshaleev-ipaddress")
 
     add_versions("v1.1.0", "e5084d83ebd712210882eb6dac14ed1b9b71584dede523b35c6181e0a06375f1")
 
-    add_configs("noexcept", {description = "Disable handling cpp exception for", default = false, type = "boolean"})
-    add_configs("no_overload_std", {description = "Do not overload std functions such as to_string, hash etc", default = false, type = "boolean"})
-    add_configs("no_ipv6_scope", {description = "Disable scope id for IPv6 addresses", default = false, type = "boolean"})
+    add_configs("exceptions", {description = "Disable handling cpp exception for", default = true, type = "boolean"})
+    add_configs("overload_std", {description = "Do not overload std functions such as to_string, hash etc", default = true, type = "boolean"})
+    add_configs("ipv6_scope", {description = "Disable scope id for IPv6 addresses", default = true, type = "boolean"})
     add_configs("ipv6_scope_max_length", {description = "Maximum scope-id length for IPv6 addresses", default = 16, type = "number"})
 
     add_deps("cmake")
@@ -24,9 +24,9 @@ package("vladimirshaleev-ipaddress")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
 
-        table.insert(configs, "-DIPADDRESS_NO_EXCEPTIONS=" .. (package:config("noexcept") and "ON" or "OFF"))
-        table.insert(configs, "-DIPADDRESS_NO_OVERLOAD_STD=" .. (package:config("no_overload_std") and "ON" or "OFF"))
-        table.insert(configs, "-DIPADDRESS_NO_IPV6_SCOPE=" .. (package:config("no_ipv6_scope") and "ON" or "OFF"))
+        table.insert(configs, "-DIPADDRESS_NO_EXCEPTIONS=" .. (package:config("exceptions") and "OFF" or "ON"))
+        table.insert(configs, "-DIPADDRESS_NO_OVERLOAD_STD=" .. (package:config("overload_std") and "OFF" or "ON"))
+        table.insert(configs, "-DIPADDRESS_NO_IPV6_SCOPE=" .. (package:config("ipv6_scope") and "OFF" or "ON"))
         table.insert(configs, "-DIPADDRESS_IPV6_SCOPE_MAX_LENGTH=" .. package:config("ipv6_scope_max_length"))
 
         import("package.tools.cmake").install(package, configs)

--- a/packages/v/vladimirshaleev-ipaddress/xmake.lua
+++ b/packages/v/vladimirshaleev-ipaddress/xmake.lua
@@ -1,8 +1,8 @@
 package("vladimirshaleev-ipaddress")
+    set_kind("library", {headeronly = true})
     set_homepage("https://vladimirshaleev.github.io/ipaddress/")
     set_description("A library for working and manipulating IPv4/IPv6 addresses and networks")
     set_license("MIT")
-    set_kind("library", {headeronly = true})
 
     add_urls("https://github.com/VladimirShaleev/ipaddress/archive/refs/tags/$(version).tar.gz",
         "https://github.com/VladimirShaleev/ipaddress.git")
@@ -48,9 +48,5 @@ package("vladimirshaleev-ipaddress")
                 std::cout << "server: " << server << " and client: " << client << " for " << teredo_ip << std::endl << std::endl;
             }
         ]]
-        }, {
-            configs = {
-                languages = "c++17"
-            }
-        }))
+        }, {configs = {languages = "c++17"}}))
     end)

--- a/packages/v/vladimirshaleev-ipaddress/xmake.lua
+++ b/packages/v/vladimirshaleev-ipaddress/xmake.lua
@@ -1,36 +1,18 @@
-package("vladimirshaleev-ipaddress", function()
+package("vladimirshaleev-ipaddress")
     set_homepage("https://vladimirshaleev.github.io/ipaddress/")
     set_description("A library for working and manipulating IPv4/IPv6 addresses and networks")
     set_license("MIT")
-    set_kind("library", {
-        headeronly = true
-    })
+    set_kind("library", {headeronly = true})
 
     add_urls("https://github.com/VladimirShaleev/ipaddress/archive/refs/tags/$(version).tar.gz",
         "https://github.com/VladimirShaleev/ipaddress.git")
 
     add_versions("v1.1.0", "e5084d83ebd712210882eb6dac14ed1b9b71584dede523b35c6181e0a06375f1")
 
-    add_configs("noexcept", {
-        description = "Disable handling cpp exception for",
-        default = false,
-        type = "boolean"
-    })
-    add_configs("no_overload_std", {
-        description = "Do not overload std functions such as to_string, hash etc",
-        default = false,
-        type = "boolean"
-    })
-    add_configs("no_ipv6_scope", {
-        description = "Disable scope id for IPv6 addresses",
-        default = false,
-        type = "boolean"
-    })
-    add_configs("ipv6_scope_max_length", {
-        description = "Maximum scope-id length for IPv6 addresses",
-        default = 16,
-        type = "number"
-    })
+    add_configs("noexcept", {description = "Disable handling cpp exception for", default = false, type = "boolean"})
+    add_configs("no_overload_std", {description = "Do not overload std functions such as to_string, hash etc", default = false, type = "boolean"})
+    add_configs("no_ipv6_scope", {description = "Disable scope id for IPv6 addresses", default = false, type = "boolean"})
+    add_configs("ipv6_scope_max_length", {description = "Maximum scope-id length for IPv6 addresses", default = 16, type = "number"})
 
     add_deps("cmake")
 
@@ -54,36 +36,16 @@ package("vladimirshaleev-ipaddress", function()
         assert(package:check_cxxsnippets({
             test = [[
             #include <iostream>
-
             #include <ipaddress/ipaddress.hpp>
-
             using namespace ipaddress;
-
             void parse_ip_sample() {
                 constexpr auto ip = ipv6_address::parse("fec0::1ff:fe23:4567:890a%eth2");
-                constexpr auto is_site_local = ip.is_site_local();
-
-                std::cout << "ip " << ip << " is local: " << std::boolalpha << is_site_local << std::endl;
                 std::cout << "DNS PTR " << ip.reverse_pointer() << std::endl << std::endl;
             }
-
             void teredo_sample() {
                 constexpr auto teredo_ip = "2001:0000:4136:e378:8000:63bf:3fff:fdd2"_ipv6;
                 auto [server, client] = teredo_ip.teredo().value();
-
                 std::cout << "server: " << server << " and client: " << client << " for " << teredo_ip << std::endl << std::endl;
-            }
-
-            void subnets_sample() {
-                constexpr auto net = ipv4_network::parse("192.0.2.0/24");
-
-                std::cout << "subnets for " << net << ':' << std::endl;
-                for (const auto& subnet : net.subnets(2)) {
-                    std::cout << "  " << subnet << std::endl;
-                }
-
-                constexpr auto last_subnet = net.subnets(2).back();
-                std::cout << "last subnet " << last_subnet << std::endl;
             }
         ]]
         }, {
@@ -92,4 +54,3 @@ package("vladimirshaleev-ipaddress", function()
             }
         }))
     end)
-end)


### PR DESCRIPTION
# ipaddress
https://github.com/VladimirShaleev/ipaddress/tree/main

A library for working and manipulating IPv4/IPv6 addresses and networks in modern C++.

This cross-platfrom header-only library (for C++11 and newer) is inspired by the [ipaddress API in Python](https://docs.python.org/3.12/library/ipaddress.html), from which it derives its name. It aims to be simpler to use due to its familiar interface. However, the C++ implementation takes a different approach: it uses static polymorphism through the strategy pattern instead of dynamic polymorphism to handle differences between IP versions (IPv4 and IPv6). This design choice eliminates the overhead of dynamic calls and virtual tables. For instance, an instance of the ipv4_address class will be represented by 4 bytes.

The library leverages modern C++ features, ensuring that all IP address and network operations support constant expressions.
