### PR TITLE
Auto-update highs to v1.8.0

### DIFF
--- a/packages/h/highs/xmake.lua
+++ b/packages/h/highs/xmake.lua
@@ -6,6 +6,7 @@ package("highs")
     add_urls("https://github.com/ERGO-Code/HiGHS/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ERGO-Code/HiGHS.git")
 
+    add_versions("v1.8.0", "e184e63101cf19688a02102f58447acc7c021d77eef0d3475ceaceb61f035539")
     add_versions("v1.7.2", "5ff96c14ae19592d3568e9ae107624cbaf3409d328fb1a586359f0adf9b34bf7")
     add_versions("v1.7.1", "65c6f9fc2365ced42ee8eb2d209a0d3a7942cd59ff4bd20464e195c433f3a885")
     add_versions("v1.7.0", "d10175ad66e7f113ac5dc00c9d6650a620663a6884fbf2942d6eb7a3d854604f")


### PR DESCRIPTION
New version of highs detected (package version: v1.7.2, last github version: v1.8.0)