### PR TITLE
Auto-update quantlib to 1.36

### DIFF
--- a/packages/q/quantlib/xmake.lua
+++ b/packages/q/quantlib/xmake.lua
@@ -5,6 +5,7 @@ package("quantlib")
     add_urls("https://github.com/lballabio/QuantLib/releases/download/v$(version)/QuantLib-$(version).tar.gz",
              "https://github.com/lballabio/QuantLib.git")
 
+    add_versions("1.36", "a0eff3d420cc26c21ab8e55d3fd169448abe631a0fbc9f528a6ac444227824fa")
     add_versions("1.35", "fd83657bbc69d8692065256699b7424d5a606dff03e7136a820b6e9675016c89")
     add_versions("1.34", "eb87aa8ced76550361771e167eba26aace018074ec370f7af49a01aa56b2fe50")
     add_versions("1.33", "4810d789261eb36423c7d277266a6ee3b28a3c05af1ee0d45544ca2e0e8312bd")


### PR DESCRIPTION
New version of quantlib detected (package version: 1.35, last github version: 1.36)