### PR TITLE
Auto-update intx to v0.12.1

### DIFF
--- a/packages/i/intx/xmake.lua
+++ b/packages/i/intx/xmake.lua
@@ -7,6 +7,7 @@ package("intx")
     add_urls("https://github.com/chfast/intx/archive/refs/tags/$(version).tar.gz",
              "https://github.com/chfast/intx.git")
 
+    add_versions("v0.12.1", "279a9aa1e46e60f72eb0eb4ea92fec786e02b35069942ed161be7dcfb6700dd8")
     add_versions("v0.12.0", "d68ff5dde9a2f340c73be67888f3f72bb18a2ad30aa16cd663ec3bc611afc9b4")
     add_versions("v0.11.0", "bff2a78e3a9a3b9bbabf50500feae65bc0ec50a2364f4a83768277d6eba7a844")
 


### PR DESCRIPTION
New version of intx detected (package version: v0.12.0, last github version: v0.12.1)