### PR TITLE
Auto-update upa-url to v1.0.1

### DIFF
--- a/packages/u/upa-url/xmake.lua
+++ b/packages/u/upa-url/xmake.lua
@@ -6,6 +6,7 @@ package("upa-url")
     add_urls("https://github.com/upa-url/upa/archive/refs/tags/$(version).tar.gz",
              "https://github.com/upa-url/upa.git", {submodules = false})
 
+    add_versions("v1.0.1", "458d49c1e84063a2e38b40f5dae5ba01e618e7fba29550f9cc01bf10d04ff7a1")
     add_versions("v1.0.0", "9ad14357c177f7c038a447996a065995e074eb5447015467687726c5d221b5f4")
 
     add_configs("tools", {description = "Build tools", default = false, type = "boolean"})


### PR DESCRIPTION
New version of upa-url detected (package version: v1.0.0, last github version: v1.0.1)