### PR TITLE
Auto-update lzav to 4.2

### DIFF
--- a/packages/l/lzav/xmake.lua
+++ b/packages/l/lzav/xmake.lua
@@ -7,6 +7,7 @@ package("lzav")
     add_urls("https://github.com/avaneev/lzav/archive/refs/tags/$(version).tar.gz",
              "https://github.com/avaneev/lzav.git")
 
+    add_versions("4.2", "0b5643605c67dd6fa1e1dbb8c8b25bfd7d91f852d76a7426aae6748612b7497b")
     add_versions("4.0", "bf125517492b0481b76a6b48cef849270dca406b0781f6f4595928046747ea99")
     add_versions("2.14", "98a715dc744d86224c941421beddaf3fcc0defd62ccfad7082eedf83be42dbbd")
 

--- a/packages/l/lzav/xmake.lua
+++ b/packages/l/lzav/xmake.lua
@@ -12,6 +12,7 @@ package("lzav")
     add_versions("2.14", "98a715dc744d86224c941421beddaf3fcc0defd62ccfad7082eedf83be42dbbd")
 
     on_install(function (package)
+        io.replace("lzav.h", "_refblk:", "_refblk:\n;", {plain = true})
         os.cp("lzav.h", package:installdir("include"))
    end)
 


### PR DESCRIPTION
New version of lzav detected (package version: 4.0, last github version: 4.2)