### PR TITLE
lzav: add 4.3 version

### DIFF
--- a/packages/l/lzav/xmake.lua
+++ b/packages/l/lzav/xmake.lua
@@ -7,12 +7,11 @@ package("lzav")
     add_urls("https://github.com/avaneev/lzav/archive/refs/tags/$(version).tar.gz",
              "https://github.com/avaneev/lzav.git")
 
-    add_versions("4.2", "0b5643605c67dd6fa1e1dbb8c8b25bfd7d91f852d76a7426aae6748612b7497b")
+    add_versions("4.3", "5b5aa7bb44213d36d1954fcff730e887bbdc8d89eba7522cf9ed5cdf8c77f72e")
     add_versions("4.0", "bf125517492b0481b76a6b48cef849270dca406b0781f6f4595928046747ea99")
     add_versions("2.14", "98a715dc744d86224c941421beddaf3fcc0defd62ccfad7082eedf83be42dbbd")
 
     on_install(function (package)
-        io.replace("lzav.h", "_refblk:", "_refblk:\n;", {plain = true})
         os.cp("lzav.h", package:installdir("include"))
    end)
 


### PR DESCRIPTION
Drop 4.2 version, see https://github.com/avaneev/lzav/issues/8