### PR TITLE
Auto-update aws-lc to v1.37.0

### DIFF
--- a/packages/a/aws-lc/xmake.lua
+++ b/packages/a/aws-lc/xmake.lua
@@ -5,6 +5,7 @@ package("aws-lc")
     add_urls("https://github.com/aws/aws-lc/archive/refs/tags/$(version).tar.gz",
              "https://github.com/aws/aws-lc.git")
 
+    add_versions("v1.37.0", "d5ba1bd922247ce8bdd9139289bf5a021237b121e1f29a323c0ef1730cb1ed07")
     add_versions("v1.34.2", "4958ac76edd53ced46d3a064cb58be8bd11e4937bcc3857623d319c2894d0904")
     add_versions("v1.32.0", "67fbb78659055c2289c9068bb4ca1c0f1b6ca27700c7f6d34c6bc2f27cd46314")
 


### PR DESCRIPTION
New version of aws-lc detected (package version: v1.34.2, last github version: v1.37.0)