### PR TITLE
Auto-update aws-c-http to v0.9.0

### DIFF
--- a/packages/a/aws-c-http/xmake.lua
+++ b/packages/a/aws-c-http/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-http")
     add_urls("https://github.com/awslabs/aws-c-http/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-http.git")
 
+    add_versions("v0.9.0", "ffba3a208e605ed247a130e2986f9d524283faf85f26da3452aac878ecefdfa2")
     add_versions("v0.8.10", "f878802a4e0bcefadce9959ce443acaf77607a68d138f9d3db04a5a878f1a871")
     add_versions("v0.8.7", "173ed7634c87485c2defbd9a96a246a79ec3f3659b28b235ac38e6e92d67392a")
     add_versions("v0.8.2", "a76ba75e59e1ac169df3ec00c0d1c453db1a4db85ee8acd3282a85ee63d6b31c")


### PR DESCRIPTION
New version of aws-c-http detected (package version: v0.8.10, last github version: v0.9.0)