### PR TITLE
Auto-update gdal to 3.9.3

### DIFF
--- a/packages/g/gdal/xmake.lua
+++ b/packages/g/gdal/xmake.lua
@@ -4,6 +4,7 @@ package("gdal")
     set_license("MIT")
 
     add_urls("https://github.com/OSGeo/gdal/releases/download/v$(version)/gdal-$(version).tar.gz")
+    add_versions("3.9.3", "f293d8ccc6b98f617db88f8593eae37f7e4b32d49a615b2cba5ced12c7bebdae")
     add_versions("3.9.2", "c9767e79ca7245f704bfbcb47d771b2dc317d743536b78d648c3e92b95fbc21e")
     add_versions("3.9.1", "46cd95ad0f270af0cd317ddc28fa5e0a7ad0b0fd160a7bd22909150df53e3418")
     add_versions("3.9.0", "3b29b573b60d156cf160805290474b625c4197ca36a79fd14f83ec8f77f29ba0")


### PR DESCRIPTION
New version of gdal detected (package version: 3.9.2, last github version: 3.9.3)