### PR TITLE
Auto-update rocksdb to v9.7.3

### DIFF
--- a/packages/r/rocksdb/xmake.lua
+++ b/packages/r/rocksdb/xmake.lua
@@ -6,6 +6,7 @@ package("rocksdb")
     add_urls("https://github.com/facebook/rocksdb/archive/refs/tags/$(version).tar.gz",
              "https://github.com/facebook/rocksdb.git")
 
+    add_versions("v9.7.3", "acfabb989cbfb5b5c4d23214819b059638193ec33dad2d88373c46448d16d38b")
     add_versions("v9.7.2", "13e9c41d290199ee0185590d4fa9d327422aaf75765b3193945303c3c314e07d")
     add_versions("v9.6.1", "98cf497c1d6d0a927142d2002a0b6b4816a0998c74fda9ae7b1bdaf6b784e895")
     add_versions("v9.5.2", "b20780586d3df4a3c5bcbde341a2c1946b03d18237960bda5bc5e9538f42af40")


### PR DESCRIPTION
New version of rocksdb detected (package version: v9.7.2, last github version: v9.7.3)