### PR TITLE
Auto-update rapidfuzz to v3.1.1

### DIFF
--- a/packages/r/rapidfuzz/xmake.lua
+++ b/packages/r/rapidfuzz/xmake.lua
@@ -7,6 +7,7 @@ package("rapidfuzz")
     add_urls("https://github.com/rapidfuzz/rapidfuzz-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/rapidfuzz/rapidfuzz-cpp.git")
 
+    add_versions("v3.1.1", "5a72811a9f5a890c69cb479551c19517426fb793a10780f136eb482c426ec3c8")
     add_versions("v3.0.5", "e32936cc66333a12f659553b5fdd6d0c22257d32ac3b7a806ac9031db8dea5a1")
     add_versions("v3.0.4", "18d1c41575ceddd6308587da8befc98c85d3b5bc2179d418daffed6d46b8cb0a")
     add_versions("v3.0.2", "4fddce5c0368e78bd604c6b820e6be248d669754715e39b4a8a281bda4c06de1")


### PR DESCRIPTION
New version of rapidfuzz detected (package version: v3.0.5, last github version: v3.1.1)