### PR TITLE
Auto-update aws-c-common to v0.10.0

### DIFF
--- a/packages/a/aws-c-common/xmake.lua
+++ b/packages/a/aws-c-common/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-common")
     add_urls("https://github.com/awslabs/aws-c-common/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-common.git")
 
+    add_versions("v0.10.0", "1fc7dea83f1d5a4b6fa86e3c8458200ed6e7f69c65707aa7b246900701874ad1")
     add_versions("v0.9.28", "bf265e9e409d563b0eddcb66e1cb00ff6b371170db3e119348478d911d054317")
     add_versions("v0.9.27", "0c0eecbd7aa04f85b1bdddf6342789bc8052737c6e9aa2ca35e26caed41d06ba")
     add_versions("v0.9.25", "443f3268387715e6e2c417a87114a6b42873aeeebc793d3f6f631323e7c48a80")


### PR DESCRIPTION
New version of aws-c-common detected (package version: v0.9.28, last github version: v0.10.0)