### PR TITLE
verilator: switch to cmake

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Tests
         run: |
-          xmake l ./scripts/test.lua -vD -k ${{ matrix.kind }} -m ${{ matrix.mode }}
+          xmake l ./scripts/test.lua -D -k ${{ matrix.kind }} -m ${{ matrix.mode }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Tests
         run: |
-          xmake l ./scripts/test.lua -D -k ${{ matrix.kind }} -m ${{ matrix.mode }}
+          xmake l ./scripts/test.lua -vD -k ${{ matrix.kind }} -m ${{ matrix.mode }}

--- a/packages/b/bison/xmake.lua
+++ b/packages/b/bison/xmake.lua
@@ -20,11 +20,7 @@ package("bison")
     add_versions("3.7.6", "69dc0bb46ea8fc307d4ca1e0b61c8c355eb207d0b0c69f4f8462328e74d7b9ea")
     add_versions("3.8.2", "06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb")
 
-    if is_subhost("msys") then
-        add_deps("pacman::bison")
-    end
-
-    on_load("macosx", "linux", "bsd", "windows", function (package)
+    on_load("macosx", "linux", "bsd", "windows", "@msys", function (package)
         if package:is_plat("windows") then
             package:add("deps", "winflexbison", {private = true})
         elseif package:is_plat("linux", "bsd") then
@@ -40,6 +36,7 @@ package("bison")
     end)
 
     on_install("@msys", function (package)
+        os.vrun("pacman -Sy --noconfirm --needed --disable-download-timeout bison")
     end)
 
     on_install("windows", function (package)

--- a/packages/b/bison/xmake.lua
+++ b/packages/b/bison/xmake.lua
@@ -33,10 +33,10 @@ package("bison")
         if package:is_library() then
             package:set("kind", "library", {headeronly = true})
         end
-    end)
 
-    on_install("@msys", function (package)
-        import("package.manager.pacman.install_package")("", {pacmna = "bison"})
+        if is_subhost("msys") and xmake:version():ge("2.9.7") then
+            package:add("deps", "pacman::bison", {configs = {msystem = "msys"}})
+        end
     end)
 
     on_install("windows", function (package)

--- a/packages/b/bison/xmake.lua
+++ b/packages/b/bison/xmake.lua
@@ -36,7 +36,7 @@ package("bison")
     end)
 
     on_install("@msys", function (package)
-        os.vrun("pacman -Sy --noconfirm --needed --disable-download-timeout bison")
+        import("package.manager.pacman.install_package")("", {pacmna = "bison"})
     end)
 
     on_install("windows", function (package)

--- a/packages/f/flex/xmake.lua
+++ b/packages/f/flex/xmake.lua
@@ -1,5 +1,5 @@
 package("flex")
-    set_kind("library")
+    set_kind("binary")
     set_homepage("https://github.com/westes/flex/")
     set_license("BSD-2-Clause")
 
@@ -46,7 +46,13 @@ package("flex")
     end)
 
     on_install("macosx", "linux", "bsd", "android", "iphoneos", "cross", function (package)
-        import("package.tools.autoconf").install(package)
+        local configs = {}
+        table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
+        table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
+        if package:is_debug() then
+            table.insert(configs, "--enable-debug")
+        end
+        import("package.tools.autoconf").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/f/flex/xmake.lua
+++ b/packages/f/flex/xmake.lua
@@ -40,7 +40,7 @@ package("flex")
     end)
 
     on_install("@msys", function (package)
-        os.vrun("pacman -Sy --noconfirm --needed --disable-download-timeout flex")
+        import("package.manager.pacman.install_package")("", {pacmna = "flex"})
         -- https://github.com/msys2/MSYS2-packages/issues/1911
         if package:is_library() then
             local msys_dir = os.getenv("MINGW_PREFIX")

--- a/packages/f/flex/xmake.lua
+++ b/packages/f/flex/xmake.lua
@@ -1,5 +1,4 @@
 package("flex")
-    set_kind("binary")
     set_homepage("https://github.com/westes/flex/")
     set_license("BSD-2-Clause")
 
@@ -14,15 +13,6 @@ package("flex")
     elseif not is_plat("windows", "mingw", "msys") then
         add_urls("https://github.com/westes/flex/releases/download/v$(version)/flex-$(version).tar.gz")
     end
-
-    on_fetch(function (package)
-        -- If pacman::flex already installed
-        if is_subhost("msys") and package:is_library() then
-            local msys_dir = os.getenv("MINGW_PREFIX")
-            local header = path.join(path.directory(msys_dir), "usr/include/FlexLexer.h")
-            os.trycp(header, package:installdir("include"))
-        end
-    end)
 
     on_load("macosx", "linux", "bsd", "windows", "@msys", function (package)
         if package:is_plat("windows") then
@@ -39,7 +29,7 @@ package("flex")
         end
 
         if is_subhost("msys") and xmake:version():ge("2.9.7") then
-            package:add("deps", "pacman::flex", {configs = {msystem = "msys"}})
+            package:add("deps", "pacman::flex", {private = true, configs = {msystem = "msys"}})
         end
     end)
 

--- a/packages/f/flex/xmake.lua
+++ b/packages/f/flex/xmake.lua
@@ -1,4 +1,5 @@
 package("flex")
+    set_kind("library", {headeronly = true})
     set_homepage("https://github.com/westes/flex/")
     set_license("BSD-2-Clause")
 
@@ -21,16 +22,16 @@ package("flex")
             package:add("deps", "m4")
         end
 
-        -- we always set it, because flex may be modified as library
-        -- by add_deps("flex", {kind = "library"})
-        package:addenv("PATH", "bin")
-        if package:is_library() then
-            package:set("kind", "library", {headeronly = true})
-        end
-
         if is_subhost("msys") and xmake:version():ge("2.9.7") then
             package:add("deps", "pacman::flex", {private = true, configs = {msystem = "msys"}})
         end
+
+        if not package:is_cross() then
+            package:addenv("PATH", "bin")
+        end
+        -- https://github.com/Seifert69/DikuMUD3/issues/70#issuecomment-1100932157
+        -- Don't link libfl.so
+        package:add("links", "")
     end)
 
     on_install("@msys", function (package)

--- a/packages/f/flex/xmake.lua
+++ b/packages/f/flex/xmake.lua
@@ -15,6 +15,15 @@ package("flex")
         add_urls("https://github.com/westes/flex/releases/download/v$(version)/flex-$(version).tar.gz")
     end
 
+    on_fetch(function (package)
+        -- If pacman::flex already installed
+        if is_subhost("msys") and package:is_library() then
+            local msys_dir = os.getenv("MINGW_PREFIX")
+            local header = path.join(path.directory(msys_dir), "usr/include/FlexLexer.h")
+            os.trycp(header, package:installdir("include"))
+        end
+    end)
+
     on_load("macosx", "linux", "bsd", "windows", "@msys", function (package)
         if package:is_plat("windows") then
             package:add("deps", "winflexbison", {private = true})

--- a/packages/f/flex/xmake.lua
+++ b/packages/f/flex/xmake.lua
@@ -48,7 +48,7 @@ package("flex")
         os.rm(path.join(package:installdir(), "bin", "bison.exe"))
     end)
 
-    on_install("macosx", "linux", "bsd", "android", "iphoneos", "cross", function (package)
+    on_install("macosx", "linux", "bsd", function (package)
         local configs = {}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))

--- a/packages/f/flex/xmake.lua
+++ b/packages/f/flex/xmake.lua
@@ -37,10 +37,13 @@ package("flex")
         if package:is_library() then
             package:set("kind", "library", {headeronly = true})
         end
+
+        if is_subhost("msys") and xmake:version():ge("2.9.7") then
+            package:add("deps", "pacman::flex", {configs = {msystem = "msys"}})
+        end
     end)
 
     on_install("@msys", function (package)
-        import("package.manager.pacman.install_package")("", {pacmna = "flex"})
         -- https://github.com/msys2/MSYS2-packages/issues/1911
         if package:is_library() then
             local msys_dir = os.getenv("MINGW_PREFIX")

--- a/packages/f/flex/xmake.lua
+++ b/packages/f/flex/xmake.lua
@@ -1,5 +1,5 @@
 package("flex")
-    set_kind("binary")
+    set_kind("library")
     set_homepage("https://github.com/westes/flex/")
     set_license("BSD-2-Clause")
 
@@ -15,11 +15,7 @@ package("flex")
         add_urls("https://github.com/westes/flex/releases/download/v$(version)/flex-$(version).tar.gz")
     end
 
-    if is_subhost("msys") then
-        add_deps("pacman::flex")
-    end
-
-    on_load("macosx", "linux", "bsd", "windows", function (package)
+    on_load("macosx", "linux", "bsd", "windows", "@msys", function (package)
         if package:is_plat("windows") then
             package:add("deps", "winflexbison", {private = true})
         elseif package:is_plat("linux") then
@@ -35,6 +31,13 @@ package("flex")
     end)
 
     on_install("@msys", function (package)
+        os.vrun("pacman -Sy --noconfirm --needed --disable-download-timeout flex")
+        -- https://github.com/msys2/MSYS2-packages/issues/1911
+        if package:is_library() then
+            local msys_dir = os.getenv("MINGW_PREFIX")
+            local header = path.join(path.directory(msys_dir), "usr/include/FlexLexer.h")
+            os.vcp(header, package:installdir("include"))
+        end
     end)
 
     on_install("windows", function (package)

--- a/packages/v/verilator/xmake.lua
+++ b/packages/v/verilator/xmake.lua
@@ -84,7 +84,12 @@ package("verilator")
         end
         cmake.install(package, configs, opt)
 
-        if is_host("windows") then
+        if is_host("linux") then
+            if package:is_debug() then
+                local bindir = package:installdir("bin")
+                os.ln(path.join(bindir, "verilator_bin_debug"), path.join(bindir, "verilator_bin"))
+            end
+        elseif is_host("windows") then
             local bindir = package:installdir("bin")
             local verilator = path.join(bindir, "verilator.exe")
             if not os.isfile(verilator) then

--- a/packages/v/verilator/xmake.lua
+++ b/packages/v/verilator/xmake.lua
@@ -55,12 +55,14 @@ package("verilator")
         local configs = {
             "-DOBJCACHE_ENABLED=OFF",
             "-DDEBUG_AND_RELEASE_AND_COVERAGE=OFF",
-            "-DCMAKE_CXX_STANDARD=20",
         }
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         if package:is_plat("windows") then
             table.insert(configs, "-DCMAKE_COMPILE_PDB_OUTPUT_DIRECTORY=''")
+        end
+        if not is_host("linux") then
+            table.insert(configs, "-DCMAKE_CXX_STANDARD=20")
         end
 
         local opt = {}

--- a/packages/v/verilator/xmake.lua
+++ b/packages/v/verilator/xmake.lua
@@ -65,12 +65,13 @@ package("verilator")
 
         local opt = {}
         opt.envs = cmake.buildenvs(package)
-        if is_host("windows") then
-            local winflexbison = package:dep("winflexbison")
-            if winflexbison then
-                opt.envs.WIN_FLEX_BISON = winflexbison:installdir("include")
-            else
-                local flex = package:dep("flex")
+        local winflexbison = package:dep("winflexbison")
+        if winflexbison then
+            opt.envs.WIN_FLEX_BISON = winflexbison:installdir("include")
+        else
+            local flex = package:dep("flex")
+            -- https://github.com/verilator/verilator/issues/3487
+            if is_subhost("msys") or not flex:is_system() then
                 local includedir = flex:installdir("include")
                 if version and version:lt("5.026") then
                     opt.cxflags = "-I" .. includedir

--- a/packages/v/verilator/xmake.lua
+++ b/packages/v/verilator/xmake.lua
@@ -11,6 +11,14 @@ package("verilator")
 
     add_deps("cmake")
 
+    if on_check then
+        on_check(function (package)
+            if is_subhost("msys") and xmake:version():lt("2.9.7") then
+                raise("package(verilator) requires xmake >= 2.9.7 on msys")
+            end
+        end)
+    end
+
     on_load(function (package)
         if not package:is_precompiled() then
             package:add("deps", "flex", {kind = "library"})

--- a/packages/v/verilator/xmake.lua
+++ b/packages/v/verilator/xmake.lua
@@ -66,9 +66,6 @@ package("verilator")
         }
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if package:is_plat("windows") then
-            table.insert(configs, "-DCMAKE_COMPILE_PDB_OUTPUT_DIRECTORY=''")
-        end
         if not is_host("linux") then
             table.insert(configs, "-DCMAKE_CXX_STANDARD=20")
         end
@@ -107,10 +104,6 @@ package("verilator")
                 end
                 verilator_bin = path.join(bindir, verilator_bin .. ".exe")
                 os.trycp(verilator_bin, verilator)
-            end
-
-            if package:is_plat("windows") and package:is_debug() then
-                os.vcp(path.join(package:buildir(), "**.pdb"), package:installdir("bin"))
             end
         end
     end)

--- a/packages/v/verilator/xmake.lua
+++ b/packages/v/verilator/xmake.lua
@@ -42,6 +42,7 @@ package("verilator")
 
                     if version:lt("5.020") then
                         if is_host("windows") and not package:has_tool("cxx", "cl") then
+                            io.replace("src/CMakeLists.txt", "INTERPROCEDURAL_OPTIMIZATION_RELEASE  TRUE", "", {plain = true})
                             io.replace("src/CMakeLists.txt", "/bigobj", "-Wa,-mbig-obj", {plain = true})
                             io.replace("src/CMakeLists.txt", "YY_NO_UNISTD_H", "", {plain = true})
                             io.replace("src/CMakeLists.txt", "/STACK:10000000", "-Wl,--stack,10000000 -mconsole -lcomctl32 -DWIN_32_LEAN_AND_MEAN", {plain = true})

--- a/packages/v/verilator/xmake.lua
+++ b/packages/v/verilator/xmake.lua
@@ -7,7 +7,7 @@ package("verilator")
     add_urls("https://github.com/verilator/verilator/archive/refs/tags/$(version).tar.gz",
              "https://github.com/verilator/verilator.git")
 
-    add_versions("v5.030", "b9e7e97257ca3825fcc75acbed792b03c3ec411d6808ad209d20917705407eac")
+    add_versions("v5.016", "66fc36f65033e5ec904481dd3d0df56500e90c0bfca23b2ae21b4a8d39e05ef1")
 
     add_deps("cmake")
 

--- a/packages/v/verilator/xmake.lua
+++ b/packages/v/verilator/xmake.lua
@@ -87,7 +87,7 @@ package("verilator")
         if is_host("linux") then
             if package:is_debug() then
                 local bindir = package:installdir("bin")
-                os.ln(path.join(bindir, "verilator_bin_debug"), path.join(bindir, "verilator_bin"))
+                os.ln(path.join(bindir, "verilator_bin_dbg"), path.join(bindir, "verilator_bin"))
             end
         elseif is_host("windows") then
             local bindir = package:installdir("bin")

--- a/packages/v/verilator/xmake.lua
+++ b/packages/v/verilator/xmake.lua
@@ -84,21 +84,24 @@ package("verilator")
         end
         cmake.install(package, configs, opt)
 
-        local bindir = package:installdir("bin")
-        local subfix = (is_host("windows") and ".exe" or "")
-        local verilator = path.join(bindir, "verilator" .. subfix)
-        if not os.isfile(verilator) then
-            local verilator_bin = "verilator_bin"
-            if package:is_debug() then
-                verilator_bin = verilator_bin .. "_dbg"
+        if is_host("windows") then
+            local bindir = package:installdir("bin")
+            local verilator = path.join(bindir, "verilator.exe")
+            if not os.isfile(verilator) then
+                local verilator_bin = "verilator_bin"
+                if package:is_debug() then
+                    verilator_bin = verilator_bin .. "_dbg"
+                end
+                verilator_bin = path.join(bindir, verilator_bin .. ".exe")
+                os.trycp(verilator_bin, verilator)
             end
-            verilator_bin = path.join(bindir, verilator_bin .. subfix)
-            os.trycp(verilator_bin, verilator)
+
+            if package:is_plat("windows") and package:is_debug() then
+                os.vcp(path.join(package:buildir(), "**.pdb"), package:installdir("bin"))
+            end
         end
     end)
 
     on_test(function (package)
-        if not package:is_cross() then
-            os.vrun("verilator --version")
-        end
+        os.vrun("verilator --version")
     end)


### PR DESCRIPTION
A new packaging method: 
We can directly use `pacman::flex/bison` as `xmake::flex/bison` deps on msys2 subhost.

```lua
        if is_subhost("msys") and xmake:version():ge("2.9.7") then
            package:add("deps", "pacman::bison", {configs = {msystem = "msys"}})
        end
```

- flex
  - binary kind by default before, now `set_kind("library", {headeronly = true})`
  - Copy `pacman::flex` header file `usr/include/FlexLexer.h` to `package:installdir("include")`
  - Remove flex links.
- verilator
  - Romove autotools build support.