### PR TITLE
Auto-update entt to v3.14.0

### DIFF
--- a/packages/e/entt/xmake.lua
+++ b/packages/e/entt/xmake.lua
@@ -6,6 +6,7 @@ package("entt")
 
     set_urls("https://github.com/skypjack/entt/archive/$(version).tar.gz",
              "https://github.com/skypjack/entt.git")
+    add_versions("v3.14.0", "e31f6e95a30e2977a50449ef9a607a9ff40febe6f9da2a8144a183f8606f7719")
     add_versions("v3.13.2", "cb556aa543d01177b62de41321759e02d96078948dda72705b3d7fe68af88489")
     add_versions("v3.13.1", "a4f290b601a70333126abd2cec7b0c232c74a4f85dcf1e04d969e8122dae8652")
     add_versions("v3.13.0", "dc0ab3ee136a1fe7f92df8898ff215dff1fe4d05d81b60144c7c0468446540a9")

--- a/packages/e/entt/xmake.lua
+++ b/packages/e/entt/xmake.lua
@@ -24,6 +24,9 @@ package("entt")
     add_versions("v3.7.0", "39ad5c42acf3434f8c37e0baa18a8cb562c0845383a6b4da17fdbacc9f0a7695")
     add_versions("v3.6.0", "94b7dc874acd0961cfc28cf6b0342eeb0b7c58250ddde8bdc6c101e84b74c190")
 
+    -- https://github.com/skypjack/entt/issues/1188
+    add_patches("v3.14.0", "https://github.com/skypjack/entt/commit/0a3c2cc4006157241665c6ccefc8b9676c1c752e.patch", "3f059d322244d64233ff2f37e9c80c8b28d92bf5b1bbef39e95cbc4d9ef0b132")
+
     add_deps("cmake")
     
     if is_plat("mingw") and is_subhost("msys") then

--- a/packages/e/entt/xmake.lua
+++ b/packages/e/entt/xmake.lua
@@ -4,8 +4,9 @@ package("entt")
     set_description("Gaming meets modern C++ - a fast and reliable entity component system (ECS) and much more.")
     set_license("MIT")
 
-    set_urls("https://github.com/skypjack/entt/archive/$(version).tar.gz",
+    set_urls("https://github.com/skypjack/entt/archive/refs/tags/$(version).tar.gz",
              "https://github.com/skypjack/entt.git")
+
     add_versions("v3.14.0", "e31f6e95a30e2977a50449ef9a607a9ff40febe6f9da2a8144a183f8606f7719")
     add_versions("v3.13.2", "cb556aa543d01177b62de41321759e02d96078948dda72705b3d7fe68af88489")
     add_versions("v3.13.1", "a4f290b601a70333126abd2cec7b0c232c74a4f85dcf1e04d969e8122dae8652")
@@ -31,6 +32,15 @@ package("entt")
     
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::entt")
+    end
+
+    if on_check then
+        on_check("android", function (package)
+            if package:version():ge("3.14.0") then
+                local ndk = package:toolchain("ndk"):config("ndkver")
+                assert(ndk and tonumber(ndk) > 22, "package(entt) require ndk version > 22")
+            end
+        end)
     end
 
     on_install(function (package)


### PR DESCRIPTION
New version of entt detected (package version: v3.13.2, last github version: v3.14.0)