### PR TITLE
Auto-update onednn to v3.6.1

### DIFF
--- a/packages/o/onednn/xmake.lua
+++ b/packages/o/onednn/xmake.lua
@@ -6,6 +6,7 @@ package("onednn")
 
     add_urls("https://github.com/oneapi-src/oneDNN/archive/refs/tags/$(version).tar.gz",
              "https://github.com/oneapi-src/oneDNN.git")
+    add_versions("v3.6.1", "a370e7f25dbf05c9c151878c53556f27d0cbe7a4f909747db6e4b2d245f533cb")
     add_versions("v3.6", "20c4a92cc0ae0dc19d3d2beca0e357b1d13a5a3af9890a2cc3e41a880e4a0302")
     add_versions("v3.5.3", "ddbc26c75978c5e864050f699dbefbf5bff9c0b8d2af827845708e1376471f17")
     add_versions("v3.5.2", "e6af4a8869c9a06fa0806ed8c93faa8f8a57118ba7a36a93b93a5c2285a3a49f")


### PR DESCRIPTION
New version of onednn detected (package version: v3.6, last github version: v3.6.1)