### PR TITLE
asio: fix undefined symbol on MinGW

### DIFF
--- a/packages/a/asio/xmake.lua
+++ b/packages/a/asio/xmake.lua
@@ -15,6 +15,10 @@ package("asio")
     add_versions("sourceforge:1.20.0", "4cd5cd0ad97e752a4075f02778732a3737b587f5eeefab59cd98dc43b0dcadb3")
     add_versions("github:1.20.0", "34a8f07be6f54e3753874d46ecfa9b7ab7051c4e3f67103c52a33dfddaea48e6")
 
+    if is_plat("mingw") then
+        add_syslinks("ws2_32", "bcrypt")
+    end
+
     on_install("!wasm", function (package)
         if os.isdir("asio") then
             os.cp("asio/include/asio.hpp", package:installdir("include"))


### PR DESCRIPTION
MinGW disregards `#pragma comment(lib, "ws2.lib")`, causing link errors like `undefined symbol: __declspec(dllimport) WSACleanup`
Ref: https://github.com/search?q=repo%3Achriskohlhoff%2Fasio++comment%28lib&type=code