### PR TITLE
Auto-update meshoptimizer to v0.22

### DIFF
--- a/packages/m/meshoptimizer/xmake.lua
+++ b/packages/m/meshoptimizer/xmake.lua
@@ -6,6 +6,7 @@ package("meshoptimizer")
 
     add_urls("https://github.com/zeux/meshoptimizer/archive/refs/tags/$(version).tar.gz",
              "https://github.com/zeux/meshoptimizer.git")
+    add_versions("v0.22", "e296cf0685b6421f84bd8a44d0a3cca82a219500f11c793dfbb6087ec86bb1a3")
     add_versions("v0.18", "f5bc07d7322e6292fe0afce03462b5c394d111386236f926fdc44d2aff3b854b")
     add_versions("v0.20", "cf1077a83958bed3d8da28a841ca53a6a42d871e49023edce64e37002a0f5a48")
     add_versions("v0.21", "050a5438e4644833ff69f35110fcf4e37038a89c5fdc8aed45d8cd848ecb3a20")


### PR DESCRIPTION
New version of meshoptimizer detected (package version: v0.21, last github version: v0.22)