### PR TITLE
boost: add `heap`

### DIFF
--- a/packages/b/boost/libs.lua
+++ b/packages/b/boost/libs.lua
@@ -33,7 +33,8 @@ local sorted_libs = {
   "chrono",
   "system",
   "charconv",
-  "atomic"
+  "atomic",
+  "heap"
 }
 
 local libs_dep = {
@@ -149,7 +150,8 @@ local libs_dep = {
     "mpi",
     "random",
     "serialization"
-  }
+  },
+  heap = {}
 }
 
 local header_only_buildable = {
@@ -158,6 +160,7 @@ local header_only_buildable = {
   "exception",
   "regex",
   "math",
+  "heap"
 }
 
 function get_libs()

--- a/packages/b/boost/test.lua
+++ b/packages/b/boost/test.lua
@@ -84,6 +84,15 @@ function _header_only(package, snippets)
             }
         ]]
     )
+    table.insert(snippets,
+        [[
+            #include <boost/heap/fibonacci_heap.hpp>
+            void test() {
+                boost::heap::fibonacci_heap<int> heap;
+                heap.push(1);
+            }
+        ]]
+    )
 end
 
 function main(package)


### PR DESCRIPTION
- add support for the `heap` module

also I'm uncertain if the `sorted_libs` table actually needs to be sorted in some way (if it does there needs to be a comment), but for now I just added `heap` at the end

