### PR TITLE
Auto-update libmodbus to v3.1.11

### DIFF
--- a/packages/l/libmodbus/xmake.lua
+++ b/packages/l/libmodbus/xmake.lua
@@ -5,6 +5,7 @@ package("libmodbus")
 
     add_urls("https://github.com/stephane/libmodbus/archive/refs/tags/$(version).tar.gz",
              "https://github.com/stephane/libmodbus.git")
+    add_versions("v3.1.11", "8a750452ef86a53de6cec6fbca67bd5be08d0a1e87278a422fbce3003fd42d99")
     add_versions("v3.1.10", "e93503749cd89fda4c8cf1ee6371a3a9cc1f0a921c165afbbc4fd96d4813fa1a")
 
     if is_plat("mingw") and is_subhost("msys") then


### PR DESCRIPTION
New version of libmodbus detected (package version: v3.1.10, last github version: v3.1.11)