### PR TITLE
Fix GTK package dependency name on Linux

### DIFF
--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -112,7 +112,7 @@ package("opencv")
         end
         if package:is_plat("linux") then
             if package:config("gtk") then
-                package:add("deps", "gtk+3", {optional = true})
+                package:add("deps", "gtk3", {optional = true})
             end
         end
         if not package:is_precompiled() then


### PR DESCRIPTION
Change the GTK package dependency from "gtk+3" to "gtk3" to match the correct package name

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

