### PR TITLE
Auto-update quill to v7.5.0

### DIFF
--- a/packages/q/quill/xmake.lua
+++ b/packages/q/quill/xmake.lua
@@ -6,6 +6,7 @@ package("quill")
     set_urls("https://github.com/odygrd/quill/archive/refs/tags/$(version).tar.gz",
              "https://github.com/odygrd/quill.git")
 
+    add_versions("v7.5.0", "18846d7c50f2ffe753661b204004fac2df9143e59cf150ecbe77315bc0b232c4")
     add_versions("v7.4.0", "749e6f75ee0889062f7135306832de5ad4d5d2e638b52316b5cd3f9af8671aff")
     add_versions("v7.3.0", "2c8fda7dbf6a095c04a3bbfa00646349e31065f34e8260c1364c6560578ca802")
     add_versions("v7.2.2", "6b44a10c1b553e7236164dbe90e21e999249b51e1cfb6fcf3046b01a2d906fd6")


### PR DESCRIPTION
New version of quill detected (package version: v7.4.0, last github version: v7.5.0)