### PR TITLE
glaze: update to `v4.0.1`

### DIFF
--- a/packages/g/glaze/xmake.lua
+++ b/packages/g/glaze/xmake.lua
@@ -22,6 +22,8 @@ package("glaze")
     add_versions("v2.2.0", "1d6e36029a58bf8c4bdd035819e1ab02b87d8454dd80fa2f5d46c96a1e6d600c")
     add_versions("v1.3.5", "de5d59cb7f31193d45f67f25d8ced1499df50c0d926a1461432b87f2b2368817")
 
+    add_patches("4.0.1", "https://github.com/stephenberry/glaze/commit/8f35df43bcb1210a0c1e07a68b99608e29ecea43.patch", "66eba4c0eea1469c1bf21b2b6ea31cb320391d1095ffe06c5a7ff3dfda796763")
+
     add_deps("cmake")
 
     if on_check then

--- a/packages/g/glaze/xmake.lua
+++ b/packages/g/glaze/xmake.lua
@@ -7,6 +7,7 @@ package("glaze")
     add_urls("https://github.com/stephenberry/glaze/archive/refs/tags/$(version).tar.gz",
              "https://github.com/stephenberry/glaze.git")
 
+    add_versions("v4.0.1", "0026aca33201ee6d3a820fb5926f36ba8c838bfd3120e2e179b0eee62b5bd231")
     add_versions("v3.6.2", "74b14656b7a47c0a03d0a857adf5059e8c2351a7a84623593be0dd16b293216c")
     add_versions("v3.6.0", "d394fed35440bd1cb1a2aec059b967acc43fc04764ecb0915ba24b9f5a9ca0a3")
     add_versions("v3.3.2", "e492d3f662c3c096ce7abac86780af6c84f74c4f19b29223ad92fccc054aafad")
@@ -75,20 +76,18 @@ package("glaze")
 
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
-            #include <glaze/glaze.hpp>
             struct obj_t {
                 double x{};
                 float y{};
             };
             template <>
             struct glz::meta<obj_t> {
-                using T = obj_t;
-                static constexpr auto value = object("x", &T::x);
+                static constexpr auto value = object("x", &obj_t::x, "y", &obj_t::y);
             };
             void test() {
                 std::string buffer{};
                 obj_t obj{};
                 glz::write_json(obj, buffer);
             }
-        ]]}, {configs = {languages = "c++2b"}}))
+        ]]}, {configs = {languages = "c++2b"}, includes = "glaze/glaze.hpp"}))
     end)


### PR DESCRIPTION
- update `glaze` to `v4.0.1`

