### PR TITLE
add nelib package

### DIFF
--- a/packages/n/nelib/xmake.lua
+++ b/packages/n/nelib/xmake.lua
@@ -1,0 +1,59 @@
+package("nelib")
+    set_kind("library")
+    set_homepage("https://github.com/hexne/nelib")
+    set_description("A commonly used tool collection library")
+
+    add_urls("https://github.com/hexne/NeLib.git")
+    add_versions("2024.11.15", "1c7f4c321f0387abd6520a419122e89ad9a6b918")
+
+    add_configs("modules", {description = "Build with C++20 modules support.", default = false, type = "boolean"})
+    add_configs("header_only", {description = "Build as a headeronly library.", default = false, type = "boolean"})
+    set_policy("package.cmake_generator.ninja", true)
+
+    add_deps("opencv")
+
+
+    on_load(function (package)
+        if not package:config("modules") then
+            package:add("deps", "cmake")
+            if package:config("header_only") then
+                package:set("kind", "library", {headeronly = true})
+            end
+        end
+    end)
+
+    on_install("linux", function (package)
+        if not package:config("modules") then
+            os.cp("*.h", package:installdir("include"))
+            if not package:config("header_only") then
+                io.replace("CMakeLists.txt", "NOT GLM_DISABLE_AUTO_DETECTION", "FALSE")
+                local configs = {"-DGLM_BUILD_TESTS=OFF"}
+                table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+                import("package.tools.cmake").build(package, configs)
+                os.cp("**.pcm", package:installdir("include"))
+                os.cp("**.a", package:installdir("lib"))
+            end
+        else
+            io.writefile("xmake.lua", [[ 
+                add_requires("opencv")
+                target("nelib")
+                    add_packages("opencv")
+                    set_kind("$(kind)")
+                    set_languages("c++23")
+                    add_headerfiles("./**.h", {outputdir = 'nelib'})
+                    add_includedirs(".")
+                    add_files("**.cppm", {public = true})
+            ]])
+            import("package.tools.xmake").install(package)
+        end
+
+    end)
+
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            void test() {
+                ;
+            }
+        ]]}, {configs = {languages = "c++23", includes = "nelib/tools.h"}}))
+    end)

--- a/packages/n/nelib/xmake.lua
+++ b/packages/n/nelib/xmake.lua
@@ -7,7 +7,8 @@ package("nelib")
 
     add_configs("modules", {description = "Build with C++20 modules support.", default = false, type = "boolean"})
     add_configs("header_only", {description = "Build as a headeronly library.", default = false, type = "boolean"})
-    add_deps("opencv")
+    set_policy("package.cmake_generator.ninja", true)
+    add_deps("opencv", "ninja")
 
     on_load(function (package)
         if package:config("modules") then

--- a/packages/n/nelib/xmake.lua
+++ b/packages/n/nelib/xmake.lua
@@ -4,7 +4,7 @@ package("nelib")
     set_description("A commonly used tool collection library")
 
     add_urls("https://github.com/hexne/NeLib.git")
-    add_versions("2024.11.15", "0103d2f84dd1f72498b58eb2fecc7775cc537d55")
+    add_versions("2024.11.15", "ee9195d2b2612da06e0ac4aaa1f6c7cb6c94699a")
 
     add_configs("modules", {description = "Build with C++20 modules support.", default = false, type = "boolean"})
     add_configs("header_only", {description = "Build as a headeronly library.", default = false, type = "boolean"})

--- a/packages/n/nelib/xmake.lua
+++ b/packages/n/nelib/xmake.lua
@@ -1,5 +1,5 @@
 package("nelib")
-    set_kind("library")
+    set_kind("library", {moduleonly = true})
     set_homepage("https://github.com/hexne/nelib")
     set_description("A commonly used tool collection library")
     add_urls("https://github.com/hexne/NeLib.git")

--- a/packages/n/nelib/xmake.lua
+++ b/packages/n/nelib/xmake.lua
@@ -2,16 +2,12 @@ package("nelib")
     set_kind("library")
     set_homepage("https://github.com/hexne/nelib")
     set_description("A commonly used tool collection library")
-
     add_urls("https://github.com/hexne/NeLib.git")
     add_versions("2024.11.15", "ee9195d2b2612da06e0ac4aaa1f6c7cb6c94699a")
-
     add_configs("modules", {description = "Build with C++20 modules support.", default = false, type = "boolean"})
     add_configs("header_only", {description = "Build as a headeronly library.", default = false, type = "boolean"})
     set_policy("package.cmake_generator.ninja", true)
-
     add_deps("opencv")
-
 
     on_load(function (package)
         if not package:config("modules") then
@@ -48,7 +44,6 @@ package("nelib")
         end
 
     end)
-
 
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[

--- a/packages/n/nelib/xmake.lua
+++ b/packages/n/nelib/xmake.lua
@@ -7,7 +7,7 @@ package("nelib")
 
     add_configs("modules", {description = "Build with C++20 modules support.", default = false, type = "boolean"})
     add_configs("header_only", {description = "Build as a headeronly library.", default = false, type = "boolean"})
-
+    set_policy("package.cmake_generator.ninja", true)
     add_deps("opencv")
 
     on_load(function (package)
@@ -27,11 +27,11 @@ package("nelib")
                 add_requires("opencv")
                 target("nelib")
                     add_packages("opencv")
-                    set_kind("moduleonly")
+                    set_kind("$(kind)")
                     set_languages("c++20")
-                    add_headerfiles("./**.h", {outputdir = "nelib"})
+                    add_headerfiles("./**.h")
                     add_includedirs(".")
-                    add_files("**.cppm")
+                    add_files("**.cppm", { public = true })
             ]])
             import("package.tools.xmake").install(package)
         else
@@ -49,11 +49,11 @@ package("nelib")
     end)
 
     on_test(function (package)
-        assert(package:has_cxxincludes("nelib/tools.h"))
+        assert(package:has_cxxincludes("tools.h"))
         -- TODO add module tests
         assert(package:check_cxxsnippets({test = [[
             void test() {
                 ;
             }
-        ]]}, {configs = {languages = "c++20", includes = "nelib/tools.h"}}))
+        ]]}, {configs = {languages = "c++20", includes = "tools.h"}}))
     end)

--- a/packages/n/nelib/xmake.lua
+++ b/packages/n/nelib/xmake.lua
@@ -4,7 +4,7 @@ package("nelib")
     set_description("A commonly used tool collection library")
 
     add_urls("https://github.com/hexne/NeLib.git")
-    add_versions("2024.11.15", "1c7f4c321f0387abd6520a419122e89ad9a6b918")
+    add_versions("2024.11.15", "0103d2f84dd1f72498b58eb2fecc7775cc537d55")
 
     add_configs("modules", {description = "Build with C++20 modules support.", default = false, type = "boolean"})
     add_configs("header_only", {description = "Build as a headeronly library.", default = false, type = "boolean"})
@@ -39,7 +39,7 @@ package("nelib")
                 target("nelib")
                     add_packages("opencv")
                     set_kind("$(kind)")
-                    set_languages("c++23")
+                    set_languages("c++20")
                     add_headerfiles("./**.h", {outputdir = 'nelib'})
                     add_includedirs(".")
                     add_files("**.cppm", {public = true})
@@ -55,5 +55,5 @@ package("nelib")
             void test() {
                 ;
             }
-        ]]}, {configs = {languages = "c++23", includes = "nelib/tools.h"}}))
+        ]]}, {configs = {languages = "c++20", includes = "nelib/tools.h"}}))
     end)

--- a/packages/n/nelib/xmake.lua
+++ b/packages/n/nelib/xmake.lua
@@ -25,7 +25,7 @@ package("nelib")
                 io.replace("CMakeLists.txt", "NOT GLM_DISABLE_AUTO_DETECTION", "FALSE")
                 local configs = {"-DGLM_BUILD_TESTS=OFF"}
                 table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-                import("package.tools.cmake").build(package, configs)
+                import("package.tools.cmake").build(package, {configs , buildir = "build"})
                 os.cp("**.pcm", package:installdir("include"))
                 os.cp("**.a", package:installdir("lib"))
             end

--- a/packages/n/nelib/xmake.lua
+++ b/packages/n/nelib/xmake.lua
@@ -1,16 +1,19 @@
 package("nelib")
-    set_kind("library", {moduleonly = true})
     set_homepage("https://github.com/hexne/nelib")
     set_description("A commonly used tool collection library")
+
     add_urls("https://github.com/hexne/NeLib.git")
     add_versions("2024.11.15", "ee9195d2b2612da06e0ac4aaa1f6c7cb6c94699a")
+
     add_configs("modules", {description = "Build with C++20 modules support.", default = false, type = "boolean"})
     add_configs("header_only", {description = "Build as a headeronly library.", default = false, type = "boolean"})
-    set_policy("package.cmake_generator.ninja", true)
+
     add_deps("opencv")
 
     on_load(function (package)
-        if not package:config("modules") then
+        if package:config("modules") then
+            package:set("kind", "library", {moduleonly = true})
+        else
             package:add("deps", "cmake")
             if package:config("header_only") then
                 package:set("kind", "library", {headeronly = true})
@@ -18,34 +21,36 @@ package("nelib")
         end
     end)
 
-    on_install("linux", function (package)
-        if not package:config("modules") then
+    on_install("linux", "macosx", function (package)
+        if package:config("modules") then
+            io.writefile("xmake.lua", [[
+                add_requires("opencv")
+                target("nelib")
+                    add_packages("opencv")
+                    set_kind("moduleonly")
+                    set_languages("c++20")
+                    add_headerfiles("./**.h", {outputdir = "nelib"})
+                    add_includedirs(".")
+                    add_files("**.cppm")
+            ]])
+            import("package.tools.xmake").install(package)
+        else
             os.cp("*.h", package:installdir("include"))
             if not package:config("header_only") then
                 io.replace("CMakeLists.txt", "NOT GLM_DISABLE_AUTO_DETECTION", "FALSE")
                 local configs = {"-DGLM_BUILD_TESTS=OFF"}
-                table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-                import("package.tools.cmake").build(package, {configs , buildir = "build"})
-                os.cp("**.pcm", package:installdir("include"))
-                os.cp("**.a", package:installdir("lib"))
+                table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
+                table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+                import("package.tools.cmake").build(package, configs)
+                os.cp(path.join(package:buildir(), "**.pcm"), package:installdir("include"))
+                os.cp(path.join(package:buildir(), "**.a"), package:installdir("lib"))
             end
-        else
-            io.writefile("xmake.lua", [[ 
-                add_requires("opencv")
-                target("nelib")
-                    add_packages("opencv")
-                    set_kind("$(kind)")
-                    set_languages("c++20")
-                    add_headerfiles("./**.h", {outputdir = 'nelib'})
-                    add_includedirs(".")
-                    add_files("**.cppm", {public = true})
-            ]])
-            import("package.tools.xmake").install(package)
         end
-
     end)
 
     on_test(function (package)
+        assert(package:has_cxxincludes("nelib/tools.h"))
+        -- TODO add module tests
         assert(package:check_cxxsnippets({test = [[
             void test() {
                 ;

--- a/packages/n/nelib/xmake.lua
+++ b/packages/n/nelib/xmake.lua
@@ -7,7 +7,6 @@ package("nelib")
 
     add_configs("modules", {description = "Build with C++20 modules support.", default = false, type = "boolean"})
     add_configs("header_only", {description = "Build as a headeronly library.", default = false, type = "boolean"})
-    set_policy("package.cmake_generator.ninja", true)
     add_deps("opencv")
 
     on_load(function (package)


### PR DESCRIPTION
This is a commonly used tool collection library.

use:
```
add_rules("mode.release", "mode.debug")

add_repositories("nelib ~/Projects/xmake-repo")

set_languages("c++2b")
add_requires("nelib 2024.11.15", {configs = {modules = true}})

target("test")
    set_kind("binary")
    add_files("src/*.cpp")
    add_packages("nelib")
    set_policy("build.c++.modules", true)
```

```c++
import Image;
int main() {
    nl::Image image("path");
    return 0;
}
```

have module:
- [x] Image
- [x] Camera
- [x] Video
- [x] File
- [x] MultArray
- [x] ProgressBar
- [x] StringEncrypt
- [x] BigNumber
- [x] Time
- [x] TestRunTime
- [ ] Mouse <sup> @TODO, linux版本未实现
- [ ] EventListener <sup> @TODO, linux版本未实现
- [x] ThreadPool
- [x] MemoryPool