### PR TITLE
Auto-update aws-checksums to v0.2.2

### DIFF
--- a/packages/a/aws-checksums/xmake.lua
+++ b/packages/a/aws-checksums/xmake.lua
@@ -6,6 +6,7 @@ package("aws-checksums")
     add_urls("https://github.com/awslabs/aws-checksums/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-checksums.git")
 
+    add_versions("v0.2.2", "96acfea882c06acd5571c845e4968892d6ffc0fae81b31a0b1565100049743b2")
     add_versions("v0.2.0", "aae619de7fb5908a52223eae3b80fae70260eed5919ad4c385b2d5a144a641f0")
     add_versions("v0.1.20", "12f80085993662b6d2cbd2d090b49b4350d19396b1d218d52323712cc8dee252")
     add_versions("v0.1.19", "844e5a4f659f454112c559d4f4043b7accfbb134e47a55f4c55f79d9c71bdab1")


### PR DESCRIPTION
New version of aws-checksums detected (package version: v0.2.0, last github version: v0.2.2)