### PR TITLE
✨ feat: OpenSSL3 add md2

### DIFF
--- a/packages/o/openssl3/xmake.lua
+++ b/packages/o/openssl3/xmake.lua
@@ -20,7 +20,7 @@ package("openssl3")
     on_fetch("fetch")
 
     -- https://security.stackexchange.com/questions/173425/how-do-i-calculate-md2-hash-with-openssl
-    add_configs("enable_md2", {description = "Enable MD2 on OpenSSl3 or not", default = false, type = "boolean"})
+    add_configs("md2", {description = "Enable MD2 on OpenSSl3 or not", default = false, type = "boolean"})
 
     on_load(function (package)
         if not package:is_precompiled() then
@@ -78,7 +78,7 @@ package("openssl3")
         table.insert(configs, "--prefix=" .. package:installdir())
         table.insert(configs, "--openssldir=" .. package:installdir())
         
-        if package:config("enable_md2") then
+        if package:config("md2") then
             table.insert(configs, "enable-md2")
         end
 
@@ -109,7 +109,7 @@ package("openssl3")
         table.insert(configs, "--prefix=" .. installdir)
         table.insert(configs, "--openssldir=" .. installdir)
         
-        if package:config("enable_md2") then
+        if package:config("md2") then
             table.insert(configs, "enable-md2")
         end
 
@@ -141,7 +141,7 @@ package("openssl3")
             table.insert(configs, "--debug")
         end
         
-        if package:config("enable_md2") then
+        if package:config("md2") then
             table.insert(configs, "enable-md2")
         end
 
@@ -183,7 +183,7 @@ package("openssl3")
                          "--openssldir=" .. package:installdir():gsub("\\", "/"),
                          "--prefix=" .. package:installdir():gsub("\\", "/")}
         
-        if package:config("enable_md2") then
+        if package:config("md2") then
             table.insert(configs, "enable-md2")
         end
 
@@ -205,3 +205,4 @@ package("openssl3")
     on_test(function (package)
         assert(package:has_cfuncs("SSL_new", {includes = "openssl/ssl.h"}))
     end)
+

--- a/packages/o/openssl3/xmake.lua
+++ b/packages/o/openssl3/xmake.lua
@@ -19,6 +19,9 @@ package("openssl3")
 
     on_fetch("fetch")
 
+    -- https://security.stackexchange.com/questions/173425/how-do-i-calculate-md2-hash-with-openssl
+    add_configs("enable_md2", {description = "Enable MD2 on OpenSSl3 or not", default = false, type = "boolean"})
+
     on_load(function (package)
         if not package:is_precompiled() then
             if package:is_plat("windows") then
@@ -74,6 +77,11 @@ package("openssl3")
         table.insert(configs, package:config("shared") and "shared" or "no-shared")
         table.insert(configs, "--prefix=" .. package:installdir())
         table.insert(configs, "--openssldir=" .. package:installdir())
+        
+        if package:config("enable_md2") then
+            table.insert(configs, "enable-md2")
+        end
+
         if jom then
             table.insert(configs, "no-makedepend")
             table.insert(configs, "/FS")
@@ -100,6 +108,11 @@ package("openssl3")
         end
         table.insert(configs, "--prefix=" .. installdir)
         table.insert(configs, "--openssldir=" .. installdir)
+        
+        if package:config("enable_md2") then
+            table.insert(configs, "enable-md2")
+        end
+
         local buildenvs = import("package.tools.autoconf").buildenvs(package)
         buildenvs.RC = package:build_getenv("mrc")
         if is_subhost("msys") then
@@ -127,6 +140,11 @@ package("openssl3")
         if package:debug() then
             table.insert(configs, "--debug")
         end
+        
+        if package:config("enable_md2") then
+            table.insert(configs, "enable-md2")
+        end
+
         os.vrunv("./config", configs, {envs = buildenvs})
         local makeconfigs = {CFLAGS = buildenvs.CFLAGS, ASFLAGS = buildenvs.ASFLAGS}
         import("package.tools.make").build(package, makeconfigs)
@@ -164,6 +182,11 @@ package("openssl3")
                          "no-threads",
                          "--openssldir=" .. package:installdir():gsub("\\", "/"),
                          "--prefix=" .. package:installdir():gsub("\\", "/")}
+        
+        if package:config("enable_md2") then
+            table.insert(configs, "enable-md2")
+        end
+
         local buildenvs = import("package.tools.autoconf").buildenvs(package)
         if package:is_cross() and package:is_plat("android") and is_subhost("windows") then
             buildenvs.CFLAGS = buildenvs.CFLAGS:gsub("\\", "/")
@@ -182,4 +205,3 @@ package("openssl3")
     on_test(function (package)
         assert(package:has_cfuncs("SSL_new", {includes = "openssl/ssl.h"}))
     end)
-


### PR DESCRIPTION
关联 https://github.com/xmake-io/xmake-repo/issues/5773
为 OpenSSL3 添加一个config：“enable_md2”,默认值是 false，如果用户在引入时设置为 true，会在 ./config 时传递一个“enable-md2”（就是中横线，不是写错了）。

添加这个config的来源见 https://security.stackexchange.com/questions/173425/how-do-i-calculate-md2-hash-with-openssl


