### PR TITLE
Auto-update stringzilla to v3.10.10

### DIFF
--- a/packages/s/stringzilla/xmake.lua
+++ b/packages/s/stringzilla/xmake.lua
@@ -9,6 +9,7 @@ package("stringzilla")
 
     add_configs("cpp", {description = "Enable C++ support.", default = true, type = "boolean"})
 
+    add_versions("v3.10.10", "7d6098f660395e0b49f4b4a48f41d12a3067981f2cead52aee626bf40912f253")
     add_versions("v3.10.9", "4ad0bf97628176f689aa87030a696ff0e8e20db0b8909b0b1688b06303886342")
     add_versions("v3.10.8", "cafa29d22866e4c7242aee4a00efa41748c10d872c6eda3ae96ad118ccf63377")
     add_versions("v3.10.7", "e9f9081d796718763c06a65bb3a5dabe102b757ad0dff18bd7ac8c08217d7e4c")


### PR DESCRIPTION
New version of stringzilla detected (package version: v3.10.9, last github version: v3.10.10)