### PR TITLE
Auto-update libheif to 1.19.5

### DIFF
--- a/packages/l/libheif/xmake.lua
+++ b/packages/l/libheif/xmake.lua
@@ -5,6 +5,7 @@ package("libheif")
     set_license("LGPL-3.0")
 
     add_urls("https://github.com/strukturag/libheif/releases/download/v$(version)/libheif-$(version).tar.gz")
+    add_versions("1.19.5", "d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf")
     add_versions("1.18.2", "c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf")
     add_versions("1.18.0", "3f25f516d84401d7c22a24ef313ae478781b95f235c250b06152701c401055c3")
     add_versions("1.17.6", "8390baf4913eda0a183e132cec62b875fb2ef507ced5ddddc98dfd2f17780aee")


### PR DESCRIPTION
New version of libheif detected (package version: 1.18.2, last github version: 1.19.5)