### PR TITLE
Auto-update astc-encoder to 5.1.0

### DIFF
--- a/packages/a/astc-encoder/xmake.lua
+++ b/packages/a/astc-encoder/xmake.lua
@@ -6,6 +6,7 @@ package("astc-encoder")
     add_urls("https://github.com/ARM-software/astc-encoder/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ARM-software/astc-encoder.git")
 
+    add_versions("5.1.0", "2e60fc2917e0796bd62429242accdf71c784f99f21fcae6c69159c11332fba40")
     add_versions("4.8.0", "6c12f4656be21a69cbacd9f2c817283405decb514072dc1dcf51fd9a0b659852")
     add_versions("4.7.0", "a57c81f79055aa7c9f8c82ac5464284e3df9bba682895dee09fa35bd1fdbab93")
     add_versions("4.6.1", "a73c7afadb2caba00339a8f715079d43f9b7e75cf57463477e5ac36ef7defd26")


### PR DESCRIPTION
New version of astc-encoder detected (package version: 4.8.0, last github version: 5.1.0)