### PR TITLE
Auto-update vcpkg to 2024.11.16

### DIFF
--- a/packages/v/vcpkg/xmake.lua
+++ b/packages/v/vcpkg/xmake.lua
@@ -5,6 +5,7 @@ package("vcpkg")
     set_license("MIT")
 
     add_urls("https://github.com/microsoft/vcpkg/archive/refs/tags/$(version).tar.gz")
+    add_versions("2024.11.16", "ec932ad758fb2b3aefc0d712d4bde8d913cd97ad2a0067d52f23d05c31b42aa0")
     add_versions("2024.10.21", "879ff57284d0bdcab127315a994cf571de4c1c72a0f7a80b770c3e3714d1649b")
     add_versions("2024.09.30", "02a8f2e70e61d02401ec9f04906996549c270f6bdc788a82f830e0a87768543e")
     add_versions("2024.08.23", "d5c63c3ebaa715de71349e08c2af547e164c971f8acfaf62f7ee0fa6c1933f8d")


### PR DESCRIPTION
New version of vcpkg detected (package version: 2024.10.21, last github version: 2024.11.16)