### PR TITLE
Auto-update fast_float to v7.0.0

### DIFF
--- a/packages/f/fast_float/xmake.lua
+++ b/packages/f/fast_float/xmake.lua
@@ -6,6 +6,7 @@ package("fast_float")
 
     add_urls("https://github.com/fastfloat/fast_float/archive/refs/tags/$(version).tar.gz",
              "https://github.com/fastfloat/fast_float.git")
+    add_versions("v7.0.0", "d2a08e722f461fe699ba61392cd29e6b23be013d0f56e50c7786d0954bffcb17")
     add_versions("v3.4.0", "a242877d2fae81ca412033f5ebf5dbc43cb029c56b4af78e33106b9a69f8f58e")
     add_versions("v3.5.1", "8558bf9c66ccd2f7d03c94461a107f49ad9cf6e4f6c0c84e148fec0aa32b4dd9")
     add_versions("v3.10.1", "d162c21c1dc538dbc6b3bb6d1317a7808f2eccef78638445630533f5bed902ee")


### PR DESCRIPTION
New version of fast_float detected (package version: v6.1.6, last github version: v7.0.0)