### PR TITLE
Auto-update plutosvg to v0.0.3

### DIFF
--- a/packages/p/plutosvg/xmake.lua
+++ b/packages/p/plutosvg/xmake.lua
@@ -6,6 +6,7 @@ package("plutosvg")
     add_urls("https://github.com/sammycage/plutosvg/archive/refs/tags/$(version).tar.gz",
              "https://github.com/sammycage/plutosvg.git")
 
+    add_versions("v0.0.3", "ff44d903aa5faf751624ce797e42375e1f71381b532642b162a7c4e220e9cb97")
     add_versions("v0.0.2", "92f9e74d5b50f485c73192791e3f755023d1573e3e009adf8c7f837e4b318e82")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of plutosvg detected (package version: v0.0.2, last github version: v0.0.3)