### PR TITLE
define IMGUI_DEFINE_MATH_OPERATORS before include imgui.h

### DIFF
--- a/packages/i/imguizmo/xmake.lua
+++ b/packages/i/imguizmo/xmake.lua
@@ -31,6 +31,7 @@ package("imguizmo")
 
             target("imguizmo")
                 set_kind("static")
+                add_defines("IMGUI_DEFINE_MATH_OPERATORS")
                 add_files("*.cpp")
                 add_headerfiles("*.h")
                 add_packages("imgui")


### PR DESCRIPTION
When I install imguizmo, I am prompted to define the IMGUI_DEFINE_MATH_OPERATORS macro and include the header file imgui.h, otherwise the compilation will fail.
