### PR TITLE
antlr4: improve includedirs

### DIFF
--- a/packages/a/antlr4-runtime/xmake.lua
+++ b/packages/a/antlr4-runtime/xmake.lua
@@ -42,15 +42,7 @@ package("antlr4-runtime")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DANTLR_BUILD_SHARED=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DANTLR_BUILD_STATIC=" .. (package:config("shared") and "OFF" or "ON"))
-        if package:is_plat("windows") then
-            table.insert(configs, "-DCMAKE_COMPILE_PDB_OUTPUT_DIRECTORY=''")
-        end
         import("package.tools.cmake").install(package, configs)
-
-        if package:is_plat("windows") and package:is_debug() then
-            local dir = package:installdir(package:config("shared") and "bin" or "lib")
-            os.vcp(path.join(package:buildir(), "runtime/*.pdb"), dir)
-        end
     end)
 
     on_test(function (package)

--- a/packages/a/antlr4/rules/lexer.lua
+++ b/packages/a/antlr4/rules/lexer.lua
@@ -13,7 +13,7 @@ rule("lexer")
                     -- remove parser g4
                     if not sourcefile:lower():find("parser", 1, true) then
                         table.insert(sourcefiles, sourcefile)
-                        table.insert(includedirs, path.join(autogendir, path.directory(sourcefile)))
+                        table.insert(includedirs, path.normalize(path.join(autogendir, path.directory(sourcefile))))
                     end
                 end
                 sourcebatch.sourcefiles = sourcefiles
@@ -29,7 +29,7 @@ rule("lexer")
         table.join2(argv, target:values("antlr4.lexer.flags"))
 
         local autogendir = path.join(target:autogendir(), "rules/antlr4/lexer")
-        local sourcefile_cxx = path.join(autogendir, path.directory(sourcefile_g4), path.basename(sourcefile_g4) .. ".cpp")
+        local sourcefile_cxx = path.normalize(path.join(autogendir, path.directory(sourcefile_g4), path.basename(sourcefile_g4) .. ".cpp"))
         local sourcefile_dir = path.directory(sourcefile_cxx)
 
         batchcmds:mkdir(sourcefile_dir)

--- a/packages/a/antlr4/rules/lexer.lua
+++ b/packages/a/antlr4/rules/lexer.lua
@@ -4,19 +4,23 @@ rule("lexer")
     add_deps("@find_antlr4")
 
     on_config(function (target)
-        -- remove parser g4
+        local includedirs = {}
+        local autogendir = path.join(target:autogendir(), "rules/antlr4/lexer")
         for _, sourcebatch in pairs(target:sourcebatches()) do
             if sourcebatch.rulename == "@antlr4/lexer" then
                 local sourcefiles = {}
                 for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
-                    if not sourcefile:lower():find("parser") then
+                    -- remove parser g4
+                    if not sourcefile:lower():find("parser", 1, true) then
                         table.insert(sourcefiles, sourcefile)
+                        table.insert(includedirs, path.join(autogendir, path.directory(sourcefile)))
                     end
                 end
                 sourcebatch.sourcefiles = sourcefiles
                 break
             end
         end
+        target:add("includedirs", table.unique(includedirs), {public = true})
     end)
 
     before_buildcmd_file(function (target, batchcmds, sourcefile_g4, opt)
@@ -33,8 +37,6 @@ rule("lexer")
         table.insert(argv, autogendir)
         table.insert(argv, "-lib")
         table.insert(argv, sourcefile_dir)
-
-        target:add("includedirs", sourcefile_dir, {public = true})
 
         table.insert(argv, sourcefile_g4)
         batchcmds:show_progress(opt.progress, "${color.build.object}compiling.g4 %s", sourcefile_g4)

--- a/packages/a/antlr4/rules/parser.lua
+++ b/packages/a/antlr4/rules/parser.lua
@@ -13,7 +13,7 @@ rule("parser")
                     -- remove lexer g4
                     if not sourcefile:lower():find("lexer", 1, true) then
                         table.insert(sourcefiles, sourcefile)
-                        table.insert(includedirs, path.join(autogendir, path.directory(sourcefile)))
+                        table.insert(includedirs, path.normalize(path.join(autogendir, path.directory(sourcefile))))
                     end
                 end
                 sourcebatch.sourcefiles = sourcefiles
@@ -36,7 +36,7 @@ rule("parser")
         table.join2(argv, target:values("antlr4.parser.flags"))
 
         local autogendir = path.join(target:autogendir(), "rules/antlr4/parser")
-        local sourcefile_cxx = path.join(autogendir, path.directory(sourcefile_g4), path.basename(sourcefile_g4) .. ".cpp")
+        local sourcefile_cxx = path.normalize(path.join(autogendir, path.directory(sourcefile_g4), path.basename(sourcefile_g4) .. ".cpp"))
         local sourcefile_dir = path.directory(sourcefile_cxx)
 
         batchcmds:mkdir(sourcefile_dir)

--- a/packages/a/antlr4/rules/parser.lua
+++ b/packages/a/antlr4/rules/parser.lua
@@ -4,19 +4,23 @@ rule("parser")
     add_deps("@lexer", {order = true})
 
     on_config(function (target)
-        -- remove lexer g4
+        local includedirs = {}
+        local autogendir = path.join(target:autogendir(), "rules/antlr4/parser")
         for _, sourcebatch in pairs(target:sourcebatches()) do
             if sourcebatch.rulename == "@antlr4/parser" then
                 local sourcefiles = {}
                 for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
-                    if not sourcefile:lower():find("lexer") then
+                    -- remove lexer g4
+                    if not sourcefile:lower():find("lexer", 1, true) then
                         table.insert(sourcefiles, sourcefile)
+                        table.insert(includedirs, path.join(autogendir, path.directory(sourcefile)))
                     end
                 end
                 sourcebatch.sourcefiles = sourcefiles
                 break
             end
         end
+        target:add("includedirs", table.unique(includedirs), {public = true})
     end)
 
     before_buildcmd_file(function (target, batchcmds, sourcefile_g4, opt)
@@ -40,8 +44,6 @@ rule("parser")
         table.insert(argv, autogendir)
         table.insert(argv, "-lib")
         table.insert(argv, sourcefile_dir)
-
-        target:add("includedirs", sourcefile_dir, {public = true})
 
         table.insert(argv, sourcefile_g4)
         batchcmds:show_progress(opt.progress, "${color.build.object}compiling.g4 %s", sourcefile_g4)


### PR DESCRIPTION
- Fix includedirs missing in compile_commadns.json.
- Fix path `xxx/./yyy`.