### PR TITLE
Auto-update kahip to v3.17

### DIFF
--- a/packages/k/kahip/xmake.lua
+++ b/packages/k/kahip/xmake.lua
@@ -6,6 +6,7 @@ package("kahip")
 
     add_urls("https://github.com/KaHIP/KaHIP/archive/refs/tags/$(version).tar.gz",
              "https://github.com/KaHIP/KaHIP.git")
+    add_versions("v3.17", "3aa5fedf5a69fd3771ac97b4dbcc40f6f8a45f6c8b64e30d85c95cee124e38c3")
     add_versions("v3.16", "b0ef72a26968d37d9baa1304f7a113b61e925966a15e86578d44e26786e76c75")
     add_versions("v3.15", "20760099370ddf7ecb2f92bfdb727def48f6428001165be6ce504264b9a99a0b")
 


### PR DESCRIPTION
New version of kahip detected (package version: v3.16, last github version: v3.17)