### PR TITLE
protobuf-cpp: fix for MinGW and Clang on Windows

### DIFF
--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -48,7 +48,7 @@ package("protobuf-cpp")
         add_links("protoc", "protobuf", "utf8_range", "utf8_validity")
     end
 
-    if is_plat("linux", "bsd") then
+    if is_plat("linux", "bsd", "mingw") then
         add_syslinks("m", "pthread")
     end
 
@@ -116,6 +116,9 @@ package("protobuf-cpp")
         io.replace("CMakeLists.txt", "set(CMAKE_PDB_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)", "", {plain = true})
         if version:ge("26.1") then
             io.replace("cmake/abseil-cpp.cmake", "BUILD_SHARED_LIBS AND MSVC", "FALSE", {plain = true})
+        end
+        if package:is_plat("windows", "mingw") then
+            io.replace("src/google/protobuf/port_def.inc", "#define PROTOBUF_DESCRIPTOR_WEAK_MESSAGES_ALLOWED", "", {plain = true})
         end
 
         local configs = {


### PR DESCRIPTION
- Fixed `undefined symbol: __start_pb_defaults` when compiling with Clang (MinGW) on Windows by undefining PROTOBUF_DESCRIPTOR_WEAK_MESSAGES_ALLOWED. [#16844](https://github.com/protocolbuffers/protobuf/issues/16844)
- Fixed `undefined symbol: pthread_setspecific` by adding pthread to system link dependencies.