### PR TITLE
Auto-update kokkos-kernels to 4.5.00

### DIFF
--- a/packages/k/kokkos-kernels/xmake.lua
+++ b/packages/k/kokkos-kernels/xmake.lua
@@ -6,6 +6,7 @@ package("kokkos-kernels")
     add_urls("https://github.com/kokkos/kokkos-kernels/archive/refs/tags/$(version).tar.gz",
              "https://github.com/kokkos/kokkos-kernels.git")
 
+    add_versions("4.5.00", "e7d40134097f9a6c4458cb153e3a9b4947429f83e6786ca6b11b376a455265d7")
     add_versions("4.4.00", "6559871c091eb5bcff53bae5a0f04f2298971d1aa1b2c135bd5a2dae3f9376a2")
     add_versions("4.3.01", "749553a6ea715ba1e56fa0b13b42866bb9880dba7a94e343eadf40d08c68fab8")
     add_versions("4.3.00", "03c3226ee97dbca4fa56fe69bc4eefa0673e23c37f2741943d9362424a63950e")


### PR DESCRIPTION
New version of kokkos-kernels detected (package version: 4.4.00, last github version: 4.5.00)