### PR TITLE
Auto-update alembic to 1.8.8

### DIFF
--- a/packages/a/alembic/xmake.lua
+++ b/packages/a/alembic/xmake.lua
@@ -6,6 +6,7 @@ package("alembic")
     add_urls("https://github.com/alembic/alembic/archive/refs/tags/$(version).tar.gz",
              "https://github.com/alembic/alembic.git")
 
+    add_versions("1.8.8", "ba1f34544608ef7d3f68cafea946ec9cc84792ddf9cda3e8d5590821df71f6c6")
     add_versions("1.8.7", "6de0b97cd14dcfb7b2d0d788c951b6da3c5b336c47322ea881d64f18575c33da")
     add_versions("1.8.6", "c572ebdea3a5f0ce13774dd1fceb5b5815265cd1b29d142cf8c144b03c131c8c")
     add_versions("1.8.5", "180a12f08d391cd89f021f279dbe3b5423b1db751a9898540c8059a45825c2e9")


### PR DESCRIPTION
New version of alembic detected (package version: 1.8.7, last github version: 1.8.8)