### PR TITLE
libxml2: use if statement instead of assert

### DIFF
--- a/packages/l/libxml2/xmake.lua
+++ b/packages/l/libxml2/xmake.lua
@@ -79,7 +79,7 @@ package("libxml2")
             package:add("deps", "readline")
         end
         if package:config("python") then
-            if package:config("shared") then
+            if not package:config("shared") then
                 raise("package(libxml2) python interface require shared lib")
             end
             if package:is_cross() then

--- a/packages/l/libxml2/xmake.lua
+++ b/packages/l/libxml2/xmake.lua
@@ -79,7 +79,9 @@ package("libxml2")
             package:add("deps", "readline")
         end
         if package:config("python") then
-            assert(package:config("shared"), "package(libxml2) python interface require shared lib")
+            if package:config("shared") then
+                raise("package(libxml2) python interface require shared lib")
+            end
             if package:is_cross() then
                 raise("libxml2 python interface does not support cross-compilation")
             end


### PR DESCRIPTION
Using `xrepo info itstool` throws "`error: package(libxml2) python interface require shared lib`"

![itstool](https://github.com/user-attachments/assets/f2c8c7da-1a5a-4e37-8d26-5ca9f353e98e)

