### PR TITLE
Auto-update reactiveplusplus to v2.2.1

### DIFF
--- a/packages/r/reactiveplusplus/xmake.lua
+++ b/packages/r/reactiveplusplus/xmake.lua
@@ -7,6 +7,7 @@ package("reactiveplusplus")
     add_urls("https://github.com/victimsnino/ReactivePlusPlus/archive/refs/tags/$(version).tar.gz",
              "https://github.com/victimsnino/ReactivePlusPlus.git")
 
+    add_versions("v2.2.1", "4d44da273a8f7401b8ebf6973ae06246505e204e9c491b435f0e1b223d6841fe")
     add_versions("v2.1.1", "0b962478d7c973a1f74062ce7f8d24c2fdcd2733031b1f014e65d252d59ebe6a",
                  "v2.1.0", "d84a194ef96b92201ea574f81780837c95e8956bbad09b3dc2dc5cef7c2eef98",
                  "v0.2.3", "9542419f8d7da98126ba2c6ae08fab287b4b3798d89cf75ed9bed2a9e3ec1678")


### PR DESCRIPTION
New version of reactiveplusplus detected (package version: v2.1.1, last github version: v2.2.1)