### PR TITLE
Auto-update emmylua_debugger to 1.8.3

### DIFF
--- a/packages/e/emmylua_debugger/xmake.lua
+++ b/packages/e/emmylua_debugger/xmake.lua
@@ -6,6 +6,7 @@ package("emmylua_debugger")
     add_urls("https://github.com/EmmyLua/EmmyLuaDebugger/archive/refs/tags/$(version).tar.gz",
              "https://github.com/EmmyLua/EmmyLuaDebugger.git")
 
+    add_versions("1.8.3", "a2803b4eec21400ca61691824e9e7689c1f14735470081a3ef0c5234aa4e590f")
     add_versions("1.8.2", "2ce5adbfad4055072d39302dccf794ec45800e84a5f3ba4784b373078a9dff8c")
     add_versions("1.8.1", "0dbbfefe798425323bd1f531463675460fce3418d73ef29b495e7369f8c76475")
     add_versions("1.8.0", "21e5ba1c82e4386cd8ad4f8c76511d70319b899b414d29ecdaba35649325d2ee")


### PR DESCRIPTION
New version of emmylua_debugger detected (package version: 1.8.2, last github version: 1.8.3)