### PR TITLE
Auto-update cnats to v3.9.2

### DIFF
--- a/packages/c/cnats/patches/3.9.1/fix-cmake-mingw.patch
+++ b/packages/c/cnats/patches/3.9.1/fix-cmake-mingw.patch
@@ -1,0 +1,45 @@
+From 9556761f0479786a1223c78ee4d7bd22a040bbd1 Mon Sep 17 00:00:00 2001
+From: Ivan Kozlovic <ivan@synadia.com>
+Date: Thu, 19 Dec 2024 12:49:08 -0700
+Subject: [PATCH] [FIXED] Build: failure with mingw
+
+Credit goes to @mtmk with the proposed fix and verification that it
+works on mingw.
+
+I have verified that the change still works when building on my Windows
+VM, so I don't expect windows users to have any issue with that.
+
+Resolves #827
+
+Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
+---
+ CMakeLists.txt | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 413e0523..ee12730f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -208,11 +208,16 @@ elseif(WIN32)
+   set(NATS_PLATFORM_INCLUDE "win")
+ 
+   # Warning control.
+-  add_compile_options(/W4) # Set warning level to maximum, then disable:
+-  add_compile_options(/wd4100) # unreferenced formal parameter
+-  add_compile_options(/wd4200) # nonstandard extension used: zero-sized array in struct/union
+-  add_compile_options(/wd4130) # logical operation on address of string constant
+-  add_compile_options(/wd4127) # conditional expression is constant
++  if(MSVC)
++    # Set warning level to maximum, then disable:
++    # /wd4100 unreferenced formal parameter
++    # /wd4200 nonstandard extension used: zero-sized array in struct/union
++    # /wd4130 logical operation on address of string constant
++    # /wd4127 conditional expression is constant
++    add_compile_options(/W4 /wd4100 /wd4200 /wd4130 /wd4127)
++  else()
++    add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-pedantic -Wno-address -Wno-constant-conditional)
++  endif()
+ 
+   if(sodium_USE_STATIC_LIBS)
+     add_definitions(
+ 

--- a/packages/c/cnats/xmake.lua
+++ b/packages/c/cnats/xmake.lua
@@ -9,6 +9,8 @@ package("cnats")
     add_versions("v3.9.2", "28c4f39b88f095d78d653e8d4fe4581163fe96ecde5f9683933f0d82fd889a57")
     add_versions("v3.8.2", "083ee03cf5a413629d56272e88ad3229720c5006c286e8180c9e5b745c10f37d")
 
+    add_patches(">=3.9.0 <=3.9.2", "patches/3.9.1/fix-cmake-mingw.patch", "c437e3451898c1b5bd429484a8a1b1772aa42b421916b2f136fe409562032bec")
+
     add_configs("tls", {description = "Build with TLS support", default = false, type = "boolean"})
     add_configs("sodium", {description = "Build with libsodium", default = false, type = "boolean"})
     add_configs("streaming", {description = "Build NATS Streaming", default = false, type = "boolean"})

--- a/packages/c/cnats/xmake.lua
+++ b/packages/c/cnats/xmake.lua
@@ -6,6 +6,7 @@ package("cnats")
     add_urls("https://github.com/nats-io/nats.c/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nats-io/nats.c.git")
 
+    add_versions("v3.9.2", "28c4f39b88f095d78d653e8d4fe4581163fe96ecde5f9683933f0d82fd889a57")
     add_versions("v3.8.2", "083ee03cf5a413629d56272e88ad3229720c5006c286e8180c9e5b745c10f37d")
 
     add_configs("tls", {description = "Build with TLS support", default = false, type = "boolean"})


### PR DESCRIPTION
New version of cnats detected (package version: v3.8.2, last github version: v3.9.2)