### PR TITLE
Auto-update vulkan-utility-libraries to v1.4.303

### DIFF
--- a/packages/v/vulkan-utility-libraries/xmake.lua
+++ b/packages/v/vulkan-utility-libraries/xmake.lua
@@ -12,6 +12,7 @@ package("vulkan-utility-libraries")
         return version:startswith("v") and version or prefix .. version:gsub("%+", ".")
     end})
 
+    add_versions("v1.4.303", "e9963da555d2888dbd4ac7a292aa61dfd9ace771319efe57ec25024386511093")
     add_versions("v1.3.290", "5173690276d25e51b63132ed6907542b9bc2d64150db0fe057ff59067493e33c")
     add_versions("v1.3.283", "a446616dede2b0168726f4e1b51777ba5c20ec46c475b378e2c07fd4ab4375ee")
     add_versions("v1.3.280", "075e13f2fdeeca3bb6fb39155c8cc345cf216ab93661549b1a33368aa28a9dea")


### PR DESCRIPTION
New version of vulkan-utility-libraries detected (package version: v1.3.290, last github version: v1.4.303)