### PR TITLE
Auto-update libcpuid to v0.7.1

### DIFF
--- a/packages/l/libcpuid/xmake.lua
+++ b/packages/l/libcpuid/xmake.lua
@@ -4,6 +4,7 @@ package("libcpuid")
 
     add_urls("https://github.com/anrieff/libcpuid/archive/refs/tags/$(version).tar.gz",
              "https://github.com/anrieff/libcpuid.git")
+    add_versions("v0.7.1", "c54879ea33b68a2e752c20fb0e3cd04439a9177eab23371f709f15a45df43644")
     add_versions("v0.7.0", "cfd9e6bcda5da3f602273e55f983bdd747cb93dde0b9ec06560e074939314210")
     add_versions("v0.6.5", "4d106d66d211f2bfaf876eb62c84d4b54664e1c2b47eb6138161d3c608c0bc5e")
     add_versions("v0.6.4", "1cbb1a79bfe6c37884a538b56504fa0975e78e492aee7c265a42f654c6056cb3")


### PR DESCRIPTION
New version of libcpuid detected (package version: v0.7.0, last github version: v0.7.1)