### PR TITLE
emmylua_debugger: add option to skip installing `emmy_tool` and `emmy_hook` on Windows

### DIFF
--- a/packages/e/emmylua_debugger/xmake.lua
+++ b/packages/e/emmylua_debugger/xmake.lua
@@ -16,6 +16,11 @@ package("emmylua_debugger")
     add_configs("luasrc", {description = "Use lua source.", default = true, type = "boolean"})
     add_configs("luaver", {description = "Set lua version.", default = "5.4", type = "string"})
 
+    if is_plat("windows") then
+        add_configs("emmy_tool", {description = "Build emmy_tool", default = false, type = "boolean"})
+        add_configs("emmy_hook", {description = "Build emmy_hook", default = false, type = "boolean"})
+    end
+
     add_deps("cmake")
 
     on_load(function (package)
@@ -44,6 +49,18 @@ package("emmylua_debugger")
         end
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         io.replace("CMakeLists.txt", "set(CMAKE_INSTALL_PREFIX install)", "", {plain = true})
+        if package:is_plat("windows") then
+            if not (package:config("emmy_tool") or package:config("emmy_hook")) then
+                io.replace("CMakeLists.txt", "add_subdirectory(shared)", "", {plain = true})
+            end
+            if not package:config("emmy_tool") then
+                io.replace("CMakeLists.txt", "add_subdirectory(emmy_tool)", "", {plain = true})
+            end
+            if not package:config("emmy_hook") then
+                io.replace("CMakeLists.txt", "add_subdirectory(emmy_hook)", "", {plain = true})
+                io.replace("CMakeLists.txt", "add_subdirectory(third-party/EasyHook)", "", {plain = true})
+            end
+        end
         import("package.tools.cmake").install(package, configs)
     end)
 


### PR DESCRIPTION
The `emmylua_debugger` project includes three main targets: `emmy_core`, `emmy_tool`, and `emmy_hook`.  

Most users primarily use `emmy_core` for debugging Lua code, while `emmy_tool` and `emmy_hook` are specific to Windows and have been unmaintained for a long time. Attempting to build these components may lead to issues such as:  
```
error C1083: Cannot open include file: 'mscoree.h': No such file or directory
```

To avoid unnecessary build errors, this PR introduces an option to opt-out of installing `emmy_tool` and `emmy_hook` by default.