### PR TITLE
Auto-update cgraph to v2.6.2

### DIFF
--- a/packages/c/cgraph/xmake.lua
+++ b/packages/c/cgraph/xmake.lua
@@ -7,6 +7,7 @@ package("cgraph")
     add_urls("https://github.com/ChunelFeng/CGraph/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ChunelFeng/CGraph.git")
 
+    add_versions("v2.6.2", "7067ed97b8c4ad118dccc93aca58e739717d87bcd21d6ea937ffe2e2bd45706d")
     add_versions("v2.6.1", "0024854adfa836d424ff38782c926173f2d869af205c39a031cf0dc13c418c84")
     add_versions("v2.6.0", "1b055ee86f0340f2c35b4ed40c4a3b4cc05081b115b0fb634d778671018648f2")
     add_versions("v2.5.4", "fd5a53dc0d7e3fc11050ccc13fac987196ad42184a4e244b9d5e5d698b1cb101")


### PR DESCRIPTION
New version of cgraph detected (package version: v2.6.1, last github version: v2.6.2)