### PR TITLE
Auto-update meson to 1.6.1

### DIFF
--- a/packages/m/meson/xmake.lua
+++ b/packages/m/meson/xmake.lua
@@ -6,6 +6,7 @@ package("meson")
 
     add_urls("https://github.com/mesonbuild/meson/releases/download/$(version)/meson-$(version).tar.gz",
              "https://github.com/mesonbuild/meson.git")
+    add_versions("1.6.1", "1eca49eb6c26d58bbee67fd3337d8ef557c0804e30a6d16bfdf269db997464de")
     add_versions("1.6.0", "999b65f21c03541cf11365489c1fad22e2418bb0c3d50ca61139f2eec09d5496")
     add_versions("1.5.2", "f955e09ab0d71ef180ae85df65991d58ed8430323de7d77a37e11c9ea630910b")
     add_versions("1.5.1", "567e533adf255de73a2de35049b99923caf872a455af9ce03e01077e0d384bed")


### PR DESCRIPTION
New version of meson detected (package version: 1.6.0, last github version: 1.6.1)