### PR TITLE
Auto-update libassert to v2.1.3

### DIFF
--- a/packages/l/libassert/xmake.lua
+++ b/packages/l/libassert/xmake.lua
@@ -6,6 +6,7 @@ package("libassert")
     add_urls("https://github.com/jeremy-rifkin/libassert/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jeremy-rifkin/libassert.git")
 
+    add_versions("v2.1.3", "79ababb220d53ba763e3a05557e024a037b611ff94c12dd7f6a4d53fa51b1161")
     add_versions("v2.1.2", "a7220ca354270deca08a7a162b93523c738ba3c8037a4df1a46ababfdc664196")
     add_versions("v2.1.1", "2bdf27523f964f41668d266cfdbd7f5f58988af963d976577195969ed44359d1")
     add_versions("v2.1.0", "e42405b49cde017c44c78aacac35c6e03564532838709031e73d10ab71f5363d")


### PR DESCRIPTION
New version of libassert detected (package version: v2.1.2, last github version: v2.1.3)