### PR TITLE
tbb: remove alias package

### DIFF
--- a/packages/o/onetbb/xmake.lua
+++ b/packages/o/onetbb/xmake.lua
@@ -1,4 +1,0 @@
-package("onetbb")
-    if set_base then
-        set_base("tbb")
-    end


### PR DESCRIPTION
```console
$ xmake f -c -y
checking for platform ... mingw
checking for architecture ... x86_64
checking for mingw directory ... C:/msys64/mingw64
checking for Microsoft Visual Studio (x64) version ... 2022
checking for Microsoft C/C++ Compiler (x64) version ... 19.42.34435
  => install onetbb 2022.0.0 .. failed

patch(patches/2022.0.0/fix-mingw-compilation.patch): not found!
if you want to get more verbose errors, please see:
  -> C:\Users\star\AppData\Local\.xmake\cache\packages\2412\o\onetbb\2022.0.0\installdir.failed\logs\install.txt
error: install failed!
```