### PR TITLE
SFML: update to 3.0.0

### DIFF
--- a/packages/s/sfml/xmake.lua
+++ b/packages/s/sfml/xmake.lua
@@ -268,14 +268,14 @@ package("sfml")
                 sf::Clock c;
                 c.restart();
             }
-        ]]}, {includes = "SFML/System.hpp"}))
+        ]]}, {configs = configs, includes = "SFML/System.hpp"}))
         if package:config("graphics") then
             assert(package:check_cxxsnippets({test = [[
                 void test(const sf::Texture& texture, const sf::Color& color) {
                     sf::Sprite sprite(texture);
                     sprite.setColor(color);
                 }
-            ]]}, {includes = "SFML/Graphics.hpp", configs = configs}))
+            ]]}, {configs = configs, includes = "SFML/Graphics.hpp"}))
         end
         if package:config("window") or package:config("graphics") then
             assert(package:check_cxxsnippets({test = [[
@@ -284,7 +284,7 @@ package("sfml")
 
                     window.close();
                 }
-            ]]}, {includes = "SFML/Window.hpp", configs = configs}))
+            ]]}, {configs = configs, includes = "SFML/Window.hpp"}))
         end
         if package:config("audio") then
             assert(package:check_cxxsnippets({test = [[
@@ -293,7 +293,7 @@ package("sfml")
                     auto res = music.openFromFile("music.ogg");
                     music.play();
                 }
-            ]]}, {includes = "SFML/Audio.hpp", configs = configs}))
+            ]]}, {configs = configs, includes = "SFML/Audio.hpp"}))
         end
         if package:config("network") then
             assert(package:check_cxxsnippets({test = [[
@@ -302,6 +302,6 @@ package("sfml")
                     unsigned short remotePort = 54000;
                     auto status = socket.send(data, 100, remoteAddress, remotePort);
                 }
-            ]]}, {includes = "SFML/Network.hpp", configs = configs}))
+            ]]}, {configs = configs, includes = "SFML/Network.hpp"}))
         end
     end)

--- a/packages/s/sfml/xmake.lua
+++ b/packages/s/sfml/xmake.lua
@@ -245,6 +245,8 @@ package("sfml")
         table.insert(configs, "-DSFML_BUILD_NETWORK=" .. (package:config("network") and "ON" or "OFF"))
         table.insert(configs, "-DWARNINGS_AS_ERRORS=OFF")
         table.insert(configs, "-DSFML_USE_SYSTEM_DEPS=TRUE")
+        if package:version():ge("3.0.0") then table.insert(configs, "-DCMAKE_CXX_STANDARD=17") end
+
         local packagedeps
         if package:config("audio") and package:version():lt("3.0.0") then
             packagedeps = packagedeps or {}
@@ -260,6 +262,7 @@ package("sfml")
     end)
 
     on_test(function (package)
+        local configs = package:version():ge("3.0.0") and {languages = "c++17"} or {}
         assert(package:check_cxxsnippets({test = [[
             void test(int args, char** argv) {
                 sf::Clock c;
@@ -272,7 +275,7 @@ package("sfml")
                     sf::Sprite sprite(texture);
                     sprite.setColor(color);
                 }
-            ]]}, {includes = "SFML/Graphics.hpp"}))
+            ]]}, {includes = "SFML/Graphics.hpp", configs = configs}))
         end
         if package:config("window") or package:config("graphics") then
             assert(package:check_cxxsnippets({test = [[
@@ -281,7 +284,7 @@ package("sfml")
 
                     window.close();
                 }
-            ]]}, {includes = "SFML/Window.hpp"}))
+            ]]}, {includes = "SFML/Window.hpp", configs = configs}))
         end
         if package:config("audio") then
             assert(package:check_cxxsnippets({test = [[
@@ -290,7 +293,7 @@ package("sfml")
                     auto res = music.openFromFile("music.ogg");
                     music.play();
                 }
-            ]]}, {includes = "SFML/Audio.hpp"}))
+            ]]}, {includes = "SFML/Audio.hpp", configs = configs}))
         end
         if package:config("network") then
             assert(package:check_cxxsnippets({test = [[
@@ -299,6 +302,6 @@ package("sfml")
                     unsigned short remotePort = 54000;
                     auto status = socket.send(data, 100, remoteAddress, remotePort);
                 }
-            ]]}, {includes = "SFML/Network.hpp"}))
+            ]]}, {includes = "SFML/Network.hpp", configs = configs}))
         end
     end)

--- a/packages/s/sfml/xmake.lua
+++ b/packages/s/sfml/xmake.lua
@@ -150,7 +150,7 @@ package("sfml")
 
         if package:is_plat("linux") then
             if package:config("window") or package:config("graphics") then
-                package:add("deps", "libx11", "libxcursor", "libxrandr", "libxrender", "libxfixes", "libxext", "eudev")
+                package:add("deps", "libx11", "libxcursor", "libxrandr", "libxrender", "libxfixes", "libxext", "eudev", "libxi")
                 package:add("deps", "opengl", "glx", {optional = true})
             end
         end

--- a/packages/s/sfml/xmake.lua
+++ b/packages/s/sfml/xmake.lua
@@ -203,8 +203,9 @@ package("sfml")
                                 for _, libfile in ipairs(libfiles) do
                                     table.insert(libraries, (libfile:gsub("\\", "/")))
                                 end
+                                local lib_name = package:version():lt("3.0.0") and "Freetype" or "freetype"
                                 local file = io.open("src/SFML/Graphics/CMakeLists.txt", "a")
-                                file:print("target_link_libraries(Freetype INTERFACE " .. table.concat(libraries, " ") .. ")")
+                                file:print(format("target_link_libraries(%s INTERFACE %s)", lib_name, table.concat(libraries, " ")))
                                 file:close()
                             end
                         end


### PR DESCRIPTION
### SFML 3.0.0 Noteworthy Changes
- Raised C++ requirement to C++17
- [Removed OpenAL shared library requirement](https://github.com/SFML/SFML/blob/master/changelog.md#general)
- The default constructors `sf::Sound::Sound()`, `sf::Text::Text()`, and `sf::Sprite::Sprite()` were [removed.](https://github.com/SFML/SFML/blob/master/migration.md#removal-of-default-constructors)
- Changed default library type from shared to static
- When using X11 as the backend on Linux, libxi-dev is a newly [required dependency.](https://www.sfml-dev.org/tutorials/3.0/getting-started/migrate/#linux-dependencies)
