### PR TITLE
Auto-update barkeep to v0.1.4

### DIFF
--- a/packages/b/barkeep/xmake.lua
+++ b/packages/b/barkeep/xmake.lua
@@ -7,6 +7,7 @@ package("barkeep")
     add_urls("https://github.com/oir/barkeep/archive/refs/tags/$(version).tar.gz",
              "https://github.com/oir/barkeep.git")
 
+    add_versions("v0.1.4", "2dc1b2cf6f0e0c0de1a0f18a1d31a97bc698ed0cfdf186780daf5a17aa56dfa2")
     add_versions("v0.1.3", "211425e348b570547b49d11edfb6e3750701d97cc89f073771b16d6012530a66")
 
     add_configs("fmt", {description = "Use fmt format", default = true, type = "boolean"})


### PR DESCRIPTION
New version of barkeep detected (package version: v0.1.3, last github version: v0.1.4)