### PR TITLE
update LIEF to 0.16

### DIFF
--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -91,7 +91,7 @@ package("lief")
                 table.insert(configs, "-DLIEF_" .. name:upper() .. "=" .. (enabled and "ON" or "OFF"))
             end
         end
-        import("package.tools.cmake").install(package, configs, {packagedeps = {"tl_expected", "utfcpp", "mbedtls", "tcb-span", "frozen", "nlohmann_json", "spdlog", "fmt"}})
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -34,7 +34,7 @@ package("lief")
     add_deps("cmake")
     add_deps("spdlog", {configs = {fmt_external = false, noexcept = true, header_only = false, fmt_external_ho = true}})
     add_deps("nlohmann_json", {configs = {cmake = true}})
-    add_deps("tl_expected", "utfcpp", "mbedtls <3.6.0", "tcb-span", "frozen") --, "fmt"
+    add_deps("tl_expected", "utfcpp", "mbedtls <3.6.0", "tcb-span", "frozen")
 
     if on_check then
         on_check(function (package)

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -57,11 +57,13 @@ package("lief")
             package:add("defines", "LIEF_IMPORT")
         end
 
+        os.rm("third_party")
+
         io.replace("CMakeLists.txt", "target_link_libraries(LIB_LIEF PRIVATE utf8cpp)", "target_link_libraries(LIB_LIEF PRIVATE utf8cpp::utf8cpp)", {plain = true})
-        
+
         io.replace("CMakeLists.txt", "target_link_libraries(LIB_LIEF PRIVATE lief_spdlog)", "find_package(spdlog CONFIG REQUIRED)\ntarget_link_libraries(LIB_LIEF PRIVATE spdlog::spdlog)", {plain = true})
         io.replace("CMakeLists.txt", "TARGETS LIB_LIEF lief_spdlog", "TARGETS LIB_LIEF", {plain = true})
-        
+
         local configs = {
             "-DLIEF_C_API=ON",
             "-DLIEF_PYTHON_API=OFF",

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -57,12 +57,12 @@ package("lief")
             package:add("defines", "LIEF_IMPORT")
         end
 
-        --os.tryrm("third-party/spdlog/fmt/bundled/args.h")
-
         io.replace("CMakeLists.txt", "target_link_libraries(LIB_LIEF PRIVATE utf8cpp)", "target_link_libraries(LIB_LIEF PRIVATE utf8cpp::utf8cpp)", {plain = true})
+        
         io.replace("CMakeLists.txt", "target_link_libraries(LIB_LIEF PRIVATE lief_spdlog)", "find_package(fmt CONFIG REQUIRED)\nfind_package(spdlog CONFIG REQUIRED)\ntarget_link_libraries(LIB_LIEF PRIVATE fmt::fmt spdlog::spdlog)", {plain = true})
         io.replace("CMakeLists.txt", "TARGETS LIB_LIEF lief_spdlog", "TARGETS LIB_LIEF", {plain = true})
         io.replace("src/logging.cpp", "#include \"spdlog/fmt/bundled/args.h\"", "#include <fmt/args.h>", {plain = true})
+        
         local configs = {
             "-DLIEF_C_API=ON",
             "-DLIEF_PYTHON_API=OFF",

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -32,7 +32,7 @@ package("lief")
     end
 
     add_deps("cmake")
-    add_deps("spdlog", {configs = {fmt_external = false, noexcept = true, header_only = false, fmt_external_ho = true}})
+    add_deps("spdlog", {configs = {header_only = false, noexcept = true}})
     add_deps("nlohmann_json", {configs = {cmake = true}})
     add_deps("tl_expected", "utfcpp", "mbedtls <3.6.0", "tcb-span", "frozen")
 
@@ -59,7 +59,7 @@ package("lief")
 
         io.replace("CMakeLists.txt", "target_link_libraries(LIB_LIEF PRIVATE utf8cpp)", "target_link_libraries(LIB_LIEF PRIVATE utf8cpp::utf8cpp)", {plain = true})
         
-        io.replace("CMakeLists.txt", "target_link_libraries(LIB_LIEF PRIVATE lief_spdlog)", "find_package(fmt CONFIG REQUIRED)\nfind_package(spdlog CONFIG REQUIRED)\ntarget_link_libraries(LIB_LIEF PRIVATE fmt::fmt spdlog::spdlog)", {plain = true})
+        io.replace("CMakeLists.txt", "target_link_libraries(LIB_LIEF PRIVATE lief_spdlog)", "find_package(spdlog CONFIG REQUIRED)\ntarget_link_libraries(LIB_LIEF PRIVATE spdlog::spdlog)", {plain = true})
         io.replace("CMakeLists.txt", "TARGETS LIB_LIEF lief_spdlog", "TARGETS LIB_LIEF", {plain = true})
         io.replace("src/logging.cpp", "#include \"spdlog/fmt/bundled/args.h\"", "#include <fmt/args.h>", {plain = true})
         

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -14,7 +14,7 @@ package("lief")
     add_versions("0.14.1", "92916dcb3178353d863aef4f409186889983c56e025b774741d5316a72ec3a7d")
 
     add_patches("0.15.1", "patches/0.15.1/algorithm.patch", "3e110539c3db037b2b24cd32f97ad8cc6241b1f69d4a65dab9fd6c84e482bbd9")
-    add_patches("0.16.0", "https://github.com/lief-project/LIEF/commit/41166332a2435fdb7d2bdc5c73f9ff9b442c5459.patch", "41166332a2435fdb7d2bdc5c73f9ff9b442c5459")
+    add_patches("0.16.0", "https://github.com/lief-project/LIEF/commit/41166332a2435fdb7d2bdc5c73f9ff9b442c5459.patch", "b1431e0b809ab74fc21f491872b339d3f4c3eac3203b7db6d681a78ecd182769")
     
     add_configs("elf",    {description = "Enable ELF module.", default = true, type = "boolean"})
     add_configs("pe",     {description = "Enable PE module.", default = true, type = "boolean"})

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -57,7 +57,7 @@ package("lief")
             package:add("defines", "LIEF_IMPORT")
         end
 
-        os.rm("third_party")
+        os.rm("third-party")
 
         io.replace("CMakeLists.txt", "target_link_libraries(LIB_LIEF PRIVATE utf8cpp)", "target_link_libraries(LIB_LIEF PRIVATE utf8cpp::utf8cpp)", {plain = true})
 

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -14,7 +14,7 @@ package("lief")
     add_versions("0.14.1", "92916dcb3178353d863aef4f409186889983c56e025b774741d5316a72ec3a7d")
 
     add_patches("0.15.1", "patches/0.15.1/algorithm.patch", "3e110539c3db037b2b24cd32f97ad8cc6241b1f69d4a65dab9fd6c84e482bbd9")
-    add_patches("0.16.0", "https://github.com/lief-project/LIEF/commit/41166332a2435fdb7d2bdc5c73f9ff9b442c5459.patch", "b1431e0b809ab74fc21f491872b339d3f4c3eac3203b7db6d681a78ecd182769")
+    add_patches("0.16.0", "https://github.com/lief-project/LIEF/commit/41166332a2435fdb7d2bdc5c73f9ff9b442c5459.patch", "e42e5dd7e4c7a24bf712c1a7c9efa19c9daf835fc85dd35c8ab4b81d1807d833")
     
     add_configs("elf",    {description = "Enable ELF module.", default = true, type = "boolean"})
     add_configs("pe",     {description = "Enable PE module.", default = true, type = "boolean"})

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -61,7 +61,6 @@ package("lief")
         
         io.replace("CMakeLists.txt", "target_link_libraries(LIB_LIEF PRIVATE lief_spdlog)", "find_package(spdlog CONFIG REQUIRED)\ntarget_link_libraries(LIB_LIEF PRIVATE spdlog::spdlog)", {plain = true})
         io.replace("CMakeLists.txt", "TARGETS LIB_LIEF lief_spdlog", "TARGETS LIB_LIEF", {plain = true})
-        io.replace("src/logging.cpp", "#include \"spdlog/fmt/bundled/args.h\"", "#include <fmt/args.h>", {plain = true})
         
         local configs = {
             "-DLIEF_C_API=ON",

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -6,14 +6,16 @@ package("lief")
     set_urls("https://github.com/lief-project/LIEF/archive/refs/tags/$(version).tar.gz",
              "https://github.com/lief-project/LIEF.git")
 
+    add_versions("0.16.0", "532be16c49539aa98156a9f59c0cd8e7ad6f6b93afbfc6346ad6cb95edf246c2")
     add_versions("0.15.1", "28653b59afc8b8b255251f21a0f3cbfbdec05dd988fb3f473e22dde28f427ad8")
     add_versions("0.10.1", "6f30c98a559f137e08b25bcbb376c0259914b33c307b8b901e01ca952241d00a")
     add_versions("0.11.5", "6d6d57304a56850958e4ce54f3da2ea2b9eb856ccbab61c6cde9cba15d7c9da5")
     add_versions("0.14.0", "400804e38cb5ce8d15fb52a4db6345f02da7b2e5cb773665712283001482b808")
     add_versions("0.14.1", "92916dcb3178353d863aef4f409186889983c56e025b774741d5316a72ec3a7d")
 
-    add_patches("<=0.15.1", "patches/0.15.1/algorithm.patch", "3e110539c3db037b2b24cd32f97ad8cc6241b1f69d4a65dab9fd6c84e482bbd9")
-
+    add_patches("0.15.1", "patches/0.15.1/algorithm.patch", "3e110539c3db037b2b24cd32f97ad8cc6241b1f69d4a65dab9fd6c84e482bbd9")
+    add_patches("0.16.0", "https://github.com/lief-project/LIEF/commit/41166332a2435fdb7d2bdc5c73f9ff9b442c5459.patch", "41166332a2435fdb7d2bdc5c73f9ff9b442c5459")
+    
     add_configs("elf",    {description = "Enable ELF module.", default = true, type = "boolean"})
     add_configs("pe",     {description = "Enable PE module.", default = true, type = "boolean"})
     add_configs("macho",  {description = "Enable MachO module.", default = true, type = "boolean"})


### PR DESCRIPTION
Possible issue is dealing with repeated fmt library symbols of fmtlib_bundled.obj....
Yet it looks like it need some refactor or change so let me know.
