### PR TITLE
Add paul_thread_pool git repo

### DIFF
--- a/packages/p/paul_thread_pool/xmake.lua
+++ b/packages/p/paul_thread_pool/xmake.lua
@@ -5,6 +5,7 @@ package("paul_thread_pool")
     set_license("MIT")
 
     add_urls("https://github.com/DeveloperPaul123/thread-pool/archive/refs/tags/$(version).zip")
+    add_urls("https://github.com/DeveloperPaul123/thread-pool.git")
     add_versions("0.6.2", "a2b722560449da53faf4753288a5fb2074d88b1fa9bba257c85425b3e48ecb2c")
 
     on_install("windows", "linux", "macosx", "mingw", function (package)


### PR DESCRIPTION
The paul_thread_pool library hasn't updated its tags in over a year, add the Git URL to manually specify a specific commit.