### PR TITLE
Update libbpf to v1.5.0

### DIFF
--- a/packages/l/libbpf/xmake.lua
+++ b/packages/l/libbpf/xmake.lua
@@ -6,6 +6,9 @@ package("libbpf")
     add_urls("https://github.com/libbpf/libbpf/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libbpf/libbpf.git")
     add_versions("v0.3", "c168d84a75b541f753ceb49015d9eb886e3fb5cca87cdd9aabce7e10ad3a1efc")
+    add_versions("v1.3.4", "236f404707977c4856ad53c58182862cf79671bc244b906ee1137cfd3c7d9688")
+    add_versions("v1.4.7", "15ffcd76eb7277539410b2f72f0acc3571a1c4a32412e57eaf116d7b3cbf7acf")
+    add_versions("v1.5.0", "53492aff6dd47e4da04ef5e672d753b9743848bdb38e9d90eafbe190b7983c44")
 
     add_deps("libelf", "zlib")
 


### PR DESCRIPTION
libbpf has not been updated for a long time. This PR adds the latest 3 releases (latest release of v1.3 v1.4 and v1.5)

I've tested all these 3 versions on x86-Linux machine and passes.