### PR TITLE
new port pffft

### DIFF
--- a/packages/p/pffft/port/xmake.lua
+++ b/packages/p/pffft/port/xmake.lua
@@ -11,8 +11,8 @@ target("pffft")
     if is_kind("shared") then
         add_rules("utils.symbols.export_all")
     end
-    add_files("*.c")
-    add_headerfiles("*.h")
+    add_files("fftpack.c", "pffft.c")
+    add_headerfiles("fftpack.h", "pffft.h")
     if not is_plat("windows") then
         add_syslinks("m")
     else

--- a/packages/p/pffft/port/xmake.lua
+++ b/packages/p/pffft/port/xmake.lua
@@ -1,6 +1,6 @@
 add_rules("mode.debug", "mode.release")
 
-option("nosimd")
+option("simd")
     set_default(false)
     set_description("Build without SIMD support.")
     add_defines("PFFFT_SIMD_DISABLE")

--- a/packages/p/pffft/port/xmake.lua
+++ b/packages/p/pffft/port/xmake.lua
@@ -1,14 +1,11 @@
 add_rules("mode.debug", "mode.release")
 
-option("simd")
-    set_default(false)
-    set_description("Build without SIMD support.")
-    add_defines("PFFFT_SIMD_DISABLE")
-
 target("pffft")
     set_kind("$(kind)")
-    add_options("nosimd")
-    if is_kind("shared") then
+    if not has_config("simd") then
+        add_defines("PFFFT_SIMD_DISABLE")
+    end
+    if is_kind("shared") and is_plat("windows") then
         add_rules("utils.symbols.export_all")
     end
     add_files("fftpack.c", "pffft.c")

--- a/packages/p/pffft/port/xmake.lua
+++ b/packages/p/pffft/port/xmake.lua
@@ -2,6 +2,7 @@ add_rules("mode.debug", "mode.release")
 
 target("pffft")
     set_kind("$(kind)")
+    add_options("simd")
     if not has_config("simd") then
         add_defines("PFFFT_SIMD_DISABLE")
     end

--- a/packages/p/pffft/port/xmake.lua
+++ b/packages/p/pffft/port/xmake.lua
@@ -1,8 +1,9 @@
 add_rules("mode.debug", "mode.release")
 
+option("simd", {default = true, description = "Build with simd"})
+
 target("pffft")
     set_kind("$(kind)")
-    add_options("simd")
     if not has_config("simd") then
         add_defines("PFFFT_SIMD_DISABLE")
     end

--- a/packages/p/pffft/port/xmake.lua
+++ b/packages/p/pffft/port/xmake.lua
@@ -1,0 +1,20 @@
+add_rules("mode.debug", "mode.release")
+
+option("nosimd")
+    set_default(false)
+    set_description("Build without SIMD support.")
+    add_defines("PFFFT_SIMD_DISABLE")
+
+target("pffft")
+    set_kind("$(kind)")
+    add_options("nosimd")
+    if is_kind("shared") then
+        add_rules("utils.symbols.export_all")
+    end
+    add_files("*.c")
+    add_headerfiles("*.h")
+    if not is_plat("windows") then
+        add_syslinks("m")
+    else
+        add_defines("_USE_MATH_DEFINES", {public = true})
+    end

--- a/packages/p/pffft/xmake.lua
+++ b/packages/p/pffft/xmake.lua
@@ -14,6 +14,8 @@ package("pffft")
 
     on_install(function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
+        local configs = {}
+        configs.simd = package:config("simd")
         import("package.tools.xmake").install(package, configs)
     end)
 

--- a/packages/p/pffft/xmake.lua
+++ b/packages/p/pffft/xmake.lua
@@ -4,9 +4,15 @@ package("pffft")
     set_description("PFFFT, a pretty fast Fourier Transform.")
     set_license("BSD-like (FFTPACK license)")
 
-    add_urls("https://bitbucket.org/jpommier/pffft/$(version).tar.gz",
-             "https://bitbucket.org/jpommier/pffft.git")
-    add_versions("02fe7715a5bf8bfd914681c53429600f94e0f536", "9adeb18ac7bb52e9fb921c31c0c6a4e9ae150cc6fcb20a899d4b3a2275176ded")
+    add_urls("https://bitbucket.org/jpommier/pffft/$(version)", {version = function (version)
+        local hash = "02fe7715a5bf8bfd914681c53429600f94e0f536"
+        if version:le("2024+100") then
+            hash = "02fe7715a5bf8bfd914681c53429600f94e0f536"
+        end
+        return "get/" .. hash .. ".tar.gz"
+    end})
+    add_versions("2024+100", "9adeb18ac7bb52e9fb921c31c0c6a4e9ae150cc6fcb20a899d4b3a2275176ded")
+
     add_configs("simd", {description = "Build with SIMD support.", default = true, type = "boolean"})
 
     if not is_plat("windows") then

--- a/packages/p/pffft/xmake.lua
+++ b/packages/p/pffft/xmake.lua
@@ -3,8 +3,10 @@ package("pffft")
     set_homepage("https://bitbucket.org/jpommier/pffft/")
     set_description("PFFFT, a pretty fast Fourier Transform.")
     set_license("BSD-like (FFTPACK license)")
+
     add_urls("https://bitbucket.org/jpommier/pffft.git")
-    add_configs("nosimd", {description = "Build without SIMD support.", default = false, type = "boolean"})
+
+    add_configs("simd", {description = "Build without SIMD support.", default = true, type = "boolean"})
 
     if not is_plat("windows") then
         add_syslinks("m")

--- a/packages/p/pffft/xmake.lua
+++ b/packages/p/pffft/xmake.lua
@@ -6,7 +6,7 @@ package("pffft")
 
     add_urls("https://bitbucket.org/jpommier/pffft.git")
 
-    add_configs("simd", {description = "Build without SIMD support.", default = true, type = "boolean"})
+    add_configs("simd", {description = "Build with SIMD support.", default = true, type = "boolean"})
 
     if not is_plat("windows") then
         add_syslinks("m")

--- a/packages/p/pffft/xmake.lua
+++ b/packages/p/pffft/xmake.lua
@@ -4,7 +4,7 @@ package("pffft")
     set_description("PFFFT, a pretty fast Fourier Transform.")
     set_license("BSD-like (FFTPACK license)")
     add_urls("https://bitbucket.org/jpommier/pffft.git")
-    add_configs("nosimd", {description = "Build without SIMD support.", default = false, type = "boolean"})
+    add_configs("nosimd", {description = "Build without SIMD support.", default = true, type = "boolean"})
 
     if not is_plat("windows") then
         add_syslinks("m")
@@ -12,10 +12,6 @@ package("pffft")
 
     on_install(function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
-        local configs = {}
-        if package:config("nosimd") then
-            table.insert(configs, "-DPFFFT_SIMD_DISABLE=ON")
-        end
         import("package.tools.xmake").install(package, configs)
     end)
 

--- a/packages/p/pffft/xmake.lua
+++ b/packages/p/pffft/xmake.lua
@@ -1,0 +1,28 @@
+package("pffft")
+
+    set_homepage("https://bitbucket.org/jpommier/pffft/")
+    set_description("PFFFT, a pretty fast Fourier Transform.")
+    set_license("BSD-like (FFTPACK license)")
+
+    add_urls("https://bitbucket.org/jpommier/pffft/get/$(version).zip")
+    add_versions("02fe7715a5bf", "81e1b91bad77092681e5ed6c2eef1a3bae7eb2154d3358a10c663867cd947396")
+
+    add_configs("nosimd", {description = "Build without SIMD support.", default = false, type = "boolean"})
+
+    add_deps("cmake")
+    if not is_plat("windows") then
+        add_syslinks("m")
+    end
+
+    on_install(function (package)
+        os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
+        local configs = {}
+        if package:config("nosimd") then
+            table.insert(configs, "-DPFFFT_SIMD_DISABLE=ON")
+        end
+        import("package.tools.xmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("pffft_simd_size", {includes = "pffft.h"}))
+    end)

--- a/packages/p/pffft/xmake.lua
+++ b/packages/p/pffft/xmake.lua
@@ -6,12 +6,12 @@ package("pffft")
 
     add_urls("https://bitbucket.org/jpommier/pffft/$(version)", {version = function (version)
         local hash = "02fe7715a5bf8bfd914681c53429600f94e0f536"
-        if version:le("2024+100") then
+        if version:le("2024.11.29") then
             hash = "02fe7715a5bf8bfd914681c53429600f94e0f536"
         end
         return "get/" .. hash .. ".tar.gz"
     end})
-    add_versions("2024+100", "9adeb18ac7bb52e9fb921c31c0c6a4e9ae150cc6fcb20a899d4b3a2275176ded")
+    add_versions("2024.11.29", "9adeb18ac7bb52e9fb921c31c0c6a4e9ae150cc6fcb20a899d4b3a2275176ded")
 
     add_configs("simd", {description = "Build with SIMD support.", default = true, type = "boolean"})
 

--- a/packages/p/pffft/xmake.lua
+++ b/packages/p/pffft/xmake.lua
@@ -3,13 +3,9 @@ package("pffft")
     set_homepage("https://bitbucket.org/jpommier/pffft/")
     set_description("PFFFT, a pretty fast Fourier Transform.")
     set_license("BSD-like (FFTPACK license)")
-
-    add_urls("https://bitbucket.org/jpommier/pffft/get/$(version).zip")
-    add_versions("02fe7715a5bf", "81e1b91bad77092681e5ed6c2eef1a3bae7eb2154d3358a10c663867cd947396")
-
+    add_urls("https://bitbucket.org/jpommier/pffft.git")
     add_configs("nosimd", {description = "Build without SIMD support.", default = false, type = "boolean"})
 
-    add_deps("cmake")
     if not is_plat("windows") then
         add_syslinks("m")
     end

--- a/packages/p/pffft/xmake.lua
+++ b/packages/p/pffft/xmake.lua
@@ -4,7 +4,7 @@ package("pffft")
     set_description("PFFFT, a pretty fast Fourier Transform.")
     set_license("BSD-like (FFTPACK license)")
     add_urls("https://bitbucket.org/jpommier/pffft.git")
-    add_configs("nosimd", {description = "Build without SIMD support.", default = true, type = "boolean"})
+    add_configs("nosimd", {description = "Build without SIMD support.", default = false, type = "boolean"})
 
     if not is_plat("windows") then
         add_syslinks("m")

--- a/packages/p/pffft/xmake.lua
+++ b/packages/p/pffft/xmake.lua
@@ -4,8 +4,9 @@ package("pffft")
     set_description("PFFFT, a pretty fast Fourier Transform.")
     set_license("BSD-like (FFTPACK license)")
 
-    add_urls("https://bitbucket.org/jpommier/pffft.git")
-
+    add_urls("https://bitbucket.org/jpommier/pffft/$(version).tar.gz",
+             "https://bitbucket.org/jpommier/pffft.git")
+    add_versions("02fe7715a5bf8bfd914681c53429600f94e0f536", "9adeb18ac7bb52e9fb921c31c0c6a4e9ae150cc6fcb20a899d4b3a2275176ded")
     add_configs("simd", {description = "Build with SIMD support.", default = true, type = "boolean"})
 
     if not is_plat("windows") then


### PR DESCRIPTION
[ x ] Im confused how to deal with option here... 
[ ] License itself does not seem into repo. (Like License file is seems to be used to store into conan, and being stored into vcpkg repo itself)...
[ x ] Maybe there is better url to use.
[ ] De-bundle fftpack & if there is need & possible (most likely this is abandoned & modified bundled dependency)? Quite funny to see it still stored there (https://chromium.googlesource.com/chromium/src/+/c1086af075699b05612673ef0005b0d3e0817a04/third_party/pffft/src & here https://healpix.jpl.nasa.gov/html/libfftpack/dirs.html) (Most likely file header stores LICENSE itself.)
If everything is ok feel free to merge, if there is need edit feel free to edit.