### PR TITLE
Auto-update tree-sitter to v0.24.6

### DIFF
--- a/packages/t/tree-sitter/xmake.lua
+++ b/packages/t/tree-sitter/xmake.lua
@@ -6,6 +6,7 @@ package("tree-sitter")
     add_urls("https://github.com/tree-sitter/tree-sitter/archive/refs/tags/$(version).zip",
              "https://github.com/tree-sitter/tree-sitter.git")
 
+    add_versions("v0.24.6", "e0c657c1dfc09297a9277c346f2d8c56912c99c2ad6ec58c31a202d55ba1f1fe")
     add_versions("v0.24.5", "d4646ea3ac5bb5db0ac1eb6ca4dcfe1fb47615adc22ee840048de97cc688c72f")
     add_versions("v0.24.4", "b014d853193482c72e3eca12d98dddde57840ae73a8f6a6155605531e180be54")
     add_versions("v0.24.3", "2bbcd5c0303d6a46fa822351848bf38b7c3cd59d7209d407df1c88e4a1958157")


### PR DESCRIPTION
New version of tree-sitter detected (package version: v0.24.5, last github version: v0.24.6)