### PR TITLE
Limit ImGui <=1.90.4 to Polyscope > 2.2.0

### DIFF
--- a/packages/p/polyscope/xmake.lua
+++ b/packages/p/polyscope/xmake.lua
@@ -24,7 +24,7 @@ package("polyscope")
     add_deps("glad", "glfw", "glm", "nlohmann_json", "stb")
     on_load("windows", "macosx", "linux", function (package)
         if package:version():ge("2.2.0") then
-            package:add("deps", "imgui", {configs = {glfw = true, opengl3 = true}})
+            package:add("deps", "imgui <=1.90.4", {configs = {glfw = true, opengl3 = true}})
         else
             package:add("deps", "happly")
             package:add("deps", "imgui <=1.86", {configs = {glfw = true, opengl3 = true}})


### PR DESCRIPTION
Polyscope Officially Support ImGui Version is 1.90.4
It has Compilation Error When Using Latest ImGui=1.91.6
So, In this Commit, Limit ImGui Version to 1.90.4 For Polyscope > 2.2.0
![Snipaste_2024-12-29_14-37-23](https://github.com/user-attachments/assets/0f5d77d6-18e9-4ef1-bf70-65a1b66699bc)

