### PR TITLE
Auto-update highfive to v2.10.1

### DIFF
--- a/packages/h/highfive/xmake.lua
+++ b/packages/h/highfive/xmake.lua
@@ -7,6 +7,7 @@ package("highfive")
     add_urls("https://github.com/BlueBrain/HighFive/archive/refs/tags/$(version).tar.gz",
              "https://github.com/BlueBrain/HighFive.git")
 
+    add_versions("v2.10.1", "60d66ba1315730494470afaf402bb40300a39eb6ef3b9d67263335a236069cce")
     add_versions("v2.10.0", "c29e8e1520e7298fabb26545f804e35bb3af257005c1c2df62e39986458d7c38")
     add_versions("v2.9.0", "6301def8ceb9f4d7a595988612db288b448a3c0546f6c83417dab38c64994d7e")
     add_versions("v2.6.1", "b5002c1221cf1821e02fb2ab891b0160bac88b43f56655bd844a472106ca3397")


### PR DESCRIPTION
New version of highfive detected (package version: v2.10.0, last github version: v2.10.1)