### PR TITLE
Auto-update simdjson to v3.11.3

### DIFF
--- a/packages/s/simdjson/xmake.lua
+++ b/packages/s/simdjson/xmake.lua
@@ -6,6 +6,7 @@ package("simdjson")
 
     add_urls("https://github.com/simdjson/simdjson/archive/refs/tags/$(version).tar.gz",
              "https://github.com/simdjson/simdjson.git")
+    add_versions("v3.11.3", "eeb10661047e476aa3b535d14a32af95690691778d7afe0630a344654ff9759a")
     add_versions("v3.11.2", "47a6d78a70c25764386a01b55819af386b98fc421da79ae8de3ae0242cf66d93")
     add_versions("v3.10.1", "1e8f881cb2c0f626c56cd3665832f1e97b9d4ffc648ad9e1067c134862bba060")
     add_versions("v3.10.0", "9c30552f1dd0ee3d0832bb1c6b7b97d813b18d5ef294c10dcb6fc242e5947de8")


### PR DESCRIPTION
New version of simdjson detected (package version: v3.11.2, last github version: v3.11.3)