### PR TITLE
Auto-update grpc to v1.69.0

### DIFF
--- a/packages/g/grpc/xmake.lua
+++ b/packages/g/grpc/xmake.lua
@@ -6,6 +6,7 @@ package("grpc")
     add_urls("https://github.com/grpc/grpc/archive/refs/tags/$(version).zip",
              "https://github.com/grpc/grpc.git")
 
+    add_versions("v1.69.0", "987763312292c8a6088108173ccde2b336a40f35ae22b5b7b3744e44929aaf9f")
     add_versions("v1.51.3", "17720fd0a690e904a468b4b3dae6fa5ec40b0d1f4d418e2ca092e2f92f06fce0")
     add_versions("v1.62.1", "f672a3a3b370f2853869745110dabfb6c13af93e17ffad4676a0b95b5ec204af")
     add_versions("v1.68.2", "2a17adb0d23768413ca85990dbf800a600863d272fcc37a9f67f3b5e34ae9174")


### PR DESCRIPTION
New version of grpc detected (package version: v1.68.2, last github version: v1.69.0)