### PR TITLE
Auto-update cutlass to v3.6.0

### DIFF
--- a/packages/c/cutlass/xmake.lua
+++ b/packages/c/cutlass/xmake.lua
@@ -7,6 +7,7 @@ package("cutlass")
     add_urls("https://github.com/NVIDIA/cutlass/archive/refs/tags/$(version).tar.gz",
              "https://github.com/NVIDIA/cutlass.git")
 
+    add_versions("v3.6.0", "7576f3437b90d0de5923560ccecebaa1357e5d72f36c0a59ad77c959c9790010")
     add_versions("v3.5.1", "20b7247cda2d257cbf8ba59ba3ca40a9211c4da61a9c9913e32b33a2c5883a36")
     add_versions("v3.5.0", "ef6af8526e3ad04f9827f35ee57eec555d09447f70a0ad0cf684a2e426ccbcb6")
     add_versions("v3.4.1", "aebd4f9088bdf2fd640d65835de30788a6c7d3615532fcbdbc626ec3754becd4")


### PR DESCRIPTION
New version of cutlass detected (package version: v3.5.1, last github version: v3.6.0)