### PR TITLE
ffmpeg: Fix build on msys2

### DIFF
--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -225,6 +225,11 @@ package("ffmpeg")
                 if package:is_arch("arm", "arm64") then
                     envs.PATH = path.join(os.programdir(), "scripts") .. path.envsep() .. envs.PATH
                 end
+                if package:is_cross() then
+                    -- The makedef script always assumes that the AR environment variable is gnu ar
+                    -- @see https://github.com/microsoft/vcpkg/issues/42365
+                    envs.AR = nil
+                end
                 autoconf.install(package, configs, {envs = envs})
             else
                 import("core.base.option")

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -314,9 +314,14 @@ package("ffmpeg")
             local cflags   = table.join(table.wrap(package:config("cxflags")), table.wrap(package:config("cflags")), table.wrap(get_config("cxflags")), get_config("cflags"))
             local cxxflags = table.join(table.wrap(package:config("cxflags")), table.wrap(package:config("cxxflags")), table.wrap(get_config("cxflags")), get_config("cxxflags"))
             assert(os.isdir(sysroot), "we do not support old version ndk!")
+
+            local ndkver = tonumber(ndk:config("ndkver"))
             if package:is_arch("arm64-v8a") then
-                table.insert(cflags, "-mfpu=neon")
-                table.insert(cflags, "-mfloat-abi=hard")
+                -- https://github.com/llvm/llvm-project/issues/74361
+                if ndkver < 27 then
+                    table.insert(cflags, "-mfpu=neon")
+                    table.insert(cflags, "-mfloat-abi=hard")
+                end
             else
                 table.insert(cflags, "-mfpu=neon")
                 table.insert(cflags, "-mfloat-abi=soft")

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -221,14 +221,14 @@ package("ffmpeg")
                     envs.PATH = os.getenv("PATH") -- we need to reserve PATH on msys2
                     envs = os.joinenvs(envs, msvc:runenvs())
                 end
+                if package:config("shared") and package:is_cross() then
+                    -- The makedef script always assumes that the AR environment variable is gnu ar
+                    -- @see https://github.com/microsoft/vcpkg/issues/42365#issuecomment-2567009409
+                    envs.AR = nil
+                end
                 -- add gas-preprocessor to PATH
                 if package:is_arch("arm", "arm64") then
                     envs.PATH = path.join(os.programdir(), "scripts") .. path.envsep() .. envs.PATH
-                end
-                if package:is_cross() then
-                    -- The makedef script always assumes that the AR environment variable is gnu ar
-                    -- @see https://github.com/microsoft/vcpkg/issues/42365
-                    envs.AR = nil
                 end
                 autoconf.install(package, configs, {envs = envs})
             else

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -216,6 +216,11 @@ package("ffmpeg")
             if path.cygwin then -- xmake 2.8.9
                 import("package.tools.autoconf")
                 local envs = autoconf.buildenvs(package, {packagedeps = "libiconv"})
+                if not envs.PATH then -- Fix in xmake 2.9.8
+                    local msvc = package:toolchain("msvc") or toolchain.load("msvc", {plat = package:plat(), arch = package:arch()})
+                    envs.PATH = os.getenv("PATH") -- we need to reserve PATH on msys2
+                    envs = os.joinenvs(envs, msvc:runenvs())
+                end
                 -- add gas-preprocessor to PATH
                 if package:is_arch("arm", "arm64") then
                     envs.PATH = path.join(os.programdir(), "scripts") .. path.envsep() .. envs.PATH

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -167,7 +167,7 @@ package("ffmpeg")
             table.insert(configs, "--enable-dxva2")
             table.insert(configs, "--enable-mediafoundation")
             table.insert(configs, "--toolchain=msvc")
-            table.insert(configs, "--extra-cflags=-" .. package:config("runtimes"))
+            table.insert(configs, "--extra-cflags=-" .. package:runtimes())
         elseif package:is_plat("mingw") then
             if package:is_arch("x86", "i386", "i686") then
                 table.insert(configs, "--target-os=mingw32")


### PR DESCRIPTION
- Fix msys2 make build.
- Fix msvc ucrt.
- Remove unsupported flags for android r27.
- Fix windows cross-compilation