### PR TITLE
Auto-update zxing-cpp to v2.3.0

### DIFF
--- a/packages/z/zxing-cpp/xmake.lua
+++ b/packages/z/zxing-cpp/xmake.lua
@@ -6,6 +6,7 @@ package("zxing-cpp")
     add_urls("https://github.com/zxing-cpp/zxing-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/zxing-cpp/zxing-cpp.git")
 
+    add_versions("v2.3.0", "64e4139103fdbc57752698ee15b5f0b0f7af9a0331ecbdc492047e0772c417ba")
     add_versions("v2.2.1", "02078ae15f19f9d423a441f205b1d1bee32349ddda7467e2c84e8f08876f8635")
 
     add_configs("c_api", {description = "Build C API", default = false, type = "boolean"})


### PR DESCRIPTION
New version of zxing-cpp detected (package version: v2.2.1, last github version: v2.3.0)