### PR TITLE
Auto-update libdeflate to v1.23

### DIFF
--- a/packages/l/libdeflate/xmake.lua
+++ b/packages/l/libdeflate/xmake.lua
@@ -6,6 +6,7 @@ package("libdeflate")
     add_urls("https://github.com/ebiggers/libdeflate/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ebiggers/libdeflate.git")
 
+    add_versions("v1.23", "1ab18349b9fb0ce8a0ca4116bded725be7dcbfa709e19f6f983d99df1fb8b25f")
     add_versions("v1.22", "7f343c7bf2ba46e774d8a632bf073235e1fd27723ef0a12a90f8947b7fe851d6")
     add_versions("v1.21", "50827d312c0413fbd41b0628590cd54d9ad7ebf88360cba7c0e70027942dbd01")
     add_versions("v1.20", "ed1454166ced78913ff3809870a4005b7170a6fd30767dc478a09b96847b9c2a")


### PR DESCRIPTION
New version of libdeflate detected (package version: v1.22, last github version: v1.23)