### PR TITLE
update vulkan related libraries to v1.3.296

### DIFF
--- a/packages/g/glslang/xmake.lua
+++ b/packages/g/glslang/xmake.lua
@@ -19,6 +19,7 @@ package("glslang")
     add_versions("1.3.280+0", "ee2f5d09eaf8f4e8d0d598bd2172fce290d4ca60")
     add_versions("1.3.283+0", "e8dd0b6903b34f1879520b444634c75ea2deedf5")
     add_versions("1.3.290+0", "fa9c3deb49e035a8abcabe366f26aac010f6cbfb")
+    add_versions("1.3.296+0", "46ef757e048e760b46601e6e77ae0cb72c97bd2f")
 
     add_patches("1.3.246+1", "https://github.com/KhronosGroup/glslang/commit/1e4955adbcd9b3f5eaf2129e918ca057baed6520.patch", "47893def550f1684304ef7c49da38f0a8fe35c190a3452d3bf58370b3ee7165d")
 

--- a/packages/s/spirv-headers/xmake.lua
+++ b/packages/s/spirv-headers/xmake.lua
@@ -25,6 +25,7 @@ package("spirv-headers")
     add_versions("1.3.280+0", "a00906b6bddaac1e37192eff2704582f82ce2d971f1aacee4d51d9db33b0f772")
     add_versions("1.3.283+0", "a68a25996268841073c01514df7bab8f64e2db1945944b45087e5c40eed12cb9")
     add_versions("1.3.290+0", "1b9ff8a33e07814671dee61fe246c67ccbcfc9be6581f229e251784499700e24")
+    add_versions("1.3.296+0", "1423d58a1171611d5aba2bf6f8c69c72ef9c38a0aca12c3493e4fda64c9b2dc6")
 
     add_patches("1.3.261+1", "https://github.com/KhronosGroup/SPIRV-Headers/commit/c43effd54686240d8b13762279d5392058d10e27.patch", "b97a05c35c00620519a5f3638a974fc2a01f062bf6e86b74b49a234f82cc55ce")
 

--- a/packages/s/spirv-reflect/xmake.lua
+++ b/packages/s/spirv-reflect/xmake.lua
@@ -15,6 +15,7 @@ package("spirv-reflect")
     add_versions("1.3.280+0", "8406f76dcf6cca11fe430058c4f0ed4b846f3be4")
     add_versions("1.3.283+0", "ee5b57fba6a986381f998567761bbc064428e645")
     add_versions("1.3.290+0", "b4dc70d8e6ac30c719a2d05b8ad05e1d277c92b4")
+    add_versions("1.3.296+0", "8542f37bd9bb202e6c49dc6a9da364c58c34d2a4")
 
     add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
 

--- a/packages/s/spirv-tools/xmake.lua
+++ b/packages/s/spirv-tools/xmake.lua
@@ -19,6 +19,7 @@ package("spirv-tools")
     add_versions("1.3.280+0", "vulkan-sdk-1.3.280.0")
     add_versions("1.3.283+0", "vulkan-sdk-1.3.283.0")
     add_versions("1.3.290+0", "vulkan-sdk-1.3.290.0")
+    add_versions("1.3.296+0", "vulkan-sdk-1.3.296.0")
 
     add_deps("cmake >=3.17.2")
     add_deps("python 3.x", {kind = "binary"})

--- a/packages/v/vk-bootstrap/xmake.lua
+++ b/packages/v/vk-bootstrap/xmake.lua
@@ -7,6 +7,7 @@ package("vk-bootstrap")
              "https://github.com/charles-lunarg/vk-bootstrap.git")
 
     add_versions("v1.3.302", "3b7eb60443cb7c8a334d7a76766e8f703d9e81b43fa8b5bd2983578cbb373970")
+    add_versions("v1.3.296", "fbff2746134459648a488588a71609d11e6e00f591ac4a3cc6683a131bf31a53")
     add_versions("v1.3.295", "fff665c8675a7730777279ad9caba8c229d7fc79f35a9dad52873d1fa598b495")
     add_versions("v1.3.292", "0853ab291ab7b19779582ada1d6a245dcd0489c2e346ee1e4275c24d3788077a")
     add_versions("v1.3.290", "225f61c850f4d2e242121249418db2f54b09cd799922547bdb3f6d9c00738fa8")

--- a/packages/v/volk/xmake.lua
+++ b/packages/v/volk/xmake.lua
@@ -24,6 +24,7 @@ package("volk")
     add_versions("1.3.280+0", "af9c98d09284eef29f6826bb1620bfe551a91a864fce707416b83c255efe3c25")
     add_versions("1.3.283+0", "872035f1f26c53b218632a3a8dbccbd276710aaabafb9bb1bc1a6c0633ee6aab")
     add_versions("1.3.290+0", "bb6a6d616c0f2bbd5d180da982a6d92a0948581cec937de69f17883980c6ca06")
+    add_versions("1.3.296+0", "8ffd0e81e29688f4abaa39e598937160b098228f37503903b10d481d4862ab85")
 
     add_deps("vulkan-headers")
 

--- a/packages/v/vulkan-headers/xmake.lua
+++ b/packages/v/vulkan-headers/xmake.lua
@@ -16,6 +16,7 @@ package("vulkan-headers")
     add_configs("modules", {description = "Build with C++20 modules support.", default = false, type = "boolean"})
 
     -- when adding a new sdk version, please also update vulkan-hpp, vulkan-loader, vulkan-utility-libraries, spirv-headers, spirv-reflect, glslang and volk packages
+    add_versions("1.3.296+0", "1e872a0be3890784bbe68dcd89b7e017fed77ba95820841848718c98bda6dc33")
     add_versions("1.3.290+0", "5b186e1492d97c44102fe858fb9f222b55524a8b6da940a8795c9e326ae6d722")
     add_versions("1.3.283+0", "cf54a812911b4e3e4ff15716c222a8fb9a87c2771c0b86060cb0ca2570ea55a9")
     add_versions("1.3.280+0", "14caa991988be6451755ad1c81df112f4b6f2bea05f0cf2888a52d4d0f0910f6")

--- a/packages/v/vulkan-hpp/xmake.lua
+++ b/packages/v/vulkan-hpp/xmake.lua
@@ -28,7 +28,6 @@ package("vulkan-hpp")
     add_versions("v1.3.282", "4bf2835dd1a530291cd2b340a58dd7e369d5c86c")
     add_versions("v1.3.283", "2fbc146feefa43b8201af4b01eb3570110f9fa32")
     add_versions("v1.3.290", "e3b0737d57e81875361bf1943f083eac902dacb7")
-    add_versions("v1.3.296", "e3b0737d57e81875361bf1943f083eac902dacb7")
 
     add_configs("modules", {description = "Build with C++20 modules support.", default = false, type = "boolean"})
 

--- a/packages/v/vulkan-hpp/xmake.lua
+++ b/packages/v/vulkan-hpp/xmake.lua
@@ -28,6 +28,7 @@ package("vulkan-hpp")
     add_versions("v1.3.282", "4bf2835dd1a530291cd2b340a58dd7e369d5c86c")
     add_versions("v1.3.283", "2fbc146feefa43b8201af4b01eb3570110f9fa32")
     add_versions("v1.3.290", "e3b0737d57e81875361bf1943f083eac902dacb7")
+    add_versions("v1.3.296", "e3b0737d57e81875361bf1943f083eac902dacb7")
 
     add_configs("modules", {description = "Build with C++20 modules support.", default = false, type = "boolean"})
 

--- a/packages/v/vulkan-loader/xmake.lua
+++ b/packages/v/vulkan-loader/xmake.lua
@@ -10,6 +10,7 @@ package("vulkan-loader")
         end
          return prefix .. version:gsub("%+", ".")
     end})
+
     add_versions("1.3.296+0", "924b439421c30513f59dfd360cb1309639c1522de28608eb64c9d79581e44c72")
     add_versions("1.3.290+0", "0cd31fdb9b576e432a85ad4d555fac4f4e5ede22ca37ff534ab67c71cd172644")
     add_versions("1.3.283+0", "59151a3cdbf8dcfe9c2ce4b5bf33358255a197f48d8d0ee8a1d8642ed9ace80f")

--- a/packages/v/vulkan-loader/xmake.lua
+++ b/packages/v/vulkan-loader/xmake.lua
@@ -10,7 +10,7 @@ package("vulkan-loader")
         end
          return prefix .. version:gsub("%+", ".")
     end})
-
+    add_versions("1.3.296+0", "924b439421c30513f59dfd360cb1309639c1522de28608eb64c9d79581e44c72")
     add_versions("1.3.290+0", "0cd31fdb9b576e432a85ad4d555fac4f4e5ede22ca37ff534ab67c71cd172644")
     add_versions("1.3.283+0", "59151a3cdbf8dcfe9c2ce4b5bf33358255a197f48d8d0ee8a1d8642ed9ace80f")
     add_versions("1.3.280+0", "f9317667a180257381dcbc74726083af581189f51e10e0246adaa86df075fe16")

--- a/packages/v/vulkan-utility-libraries/xmake.lua
+++ b/packages/v/vulkan-utility-libraries/xmake.lua
@@ -12,6 +12,7 @@ package("vulkan-utility-libraries")
         return version:startswith("v") and version or prefix .. version:gsub("%+", ".")
     end})
 
+    add_versions("v1.3.296", "bea13c5f25756a9b20bc53cfbfb1a87b4a8e07ddfb7ebcdf9e173c4461d55685")
     add_versions("v1.3.290", "5173690276d25e51b63132ed6907542b9bc2d64150db0fe057ff59067493e33c")
     add_versions("v1.3.283", "a446616dede2b0168726f4e1b51777ba5c20ec46c475b378e2c07fd4ab4375ee")
     add_versions("v1.3.280", "075e13f2fdeeca3bb6fb39155c8cc345cf216ab93661549b1a33368aa28a9dea")

--- a/packages/v/vulkan-validationlayers/xmake.lua
+++ b/packages/v/vulkan-validationlayers/xmake.lua
@@ -18,6 +18,7 @@ package("vulkan-validationlayers")
             end
         end})
 
+        add_versions("1.3.296+0", "dea290d614c71eeb512452dff1555f907a405a5a21baefcf41b5548d5d0fe157")
         add_versions("1.3.290+0", "eb26b4bf1f031e57d1624c53d489279076b893b0383fddccc79de7ee2caaa128")
         add_versions("1.3.275+0", "6e22fb13601c1e780c44a17497a3c999cc5207e52a09819e7c32ecd8439eff7a")
         add_versions("1.2.198+0", "5436e974d6b3133b3454edf1910f76b9f869db8bbe086859b2abe32fdb539cbc")

--- a/packages/v/vulkan-validationlayers/xmake.lua
+++ b/packages/v/vulkan-validationlayers/xmake.lua
@@ -18,7 +18,7 @@ package("vulkan-validationlayers")
             end
         end})
 
-        add_versions("1.3.296+0", "dea290d614c71eeb512452dff1555f907a405a5a21baefcf41b5548d5d0fe157")
+        add_versions("1.3.296+0", "9d80d82b75e1fbdea610e71debcc35a2b3cb8365ad0dbe1a76079b78b77fc900")
         add_versions("1.3.290+0", "eb26b4bf1f031e57d1624c53d489279076b893b0383fddccc79de7ee2caaa128")
         add_versions("1.3.275+0", "6e22fb13601c1e780c44a17497a3c999cc5207e52a09819e7c32ecd8439eff7a")
         add_versions("1.2.198+0", "5436e974d6b3133b3454edf1910f76b9f869db8bbe086859b2abe32fdb539cbc")
@@ -32,6 +32,7 @@ package("vulkan-validationlayers")
             return version:startswith("v") and version or prefix .. version:gsub("%+", ".")
         end})
 
+        add_versions("1.3.296+0", "dea290d614c71eeb512452dff1555f907a405a5a21baefcf41b5548d5d0fe157")
         add_versions("1.3.290+0", "59be2c0a5bdbfdbdebdcda48bd65ffa3b219f681c73a90fc683cd4708c1b79de")
         add_versions("1.3.275+0", "acfd84039109220129624b0ecb69980bbc3a858978c62b556dbe16efd0f26755")
         add_versions("1.2.198+0", "4a70cc5da26baf873fcf69b081eeeda545515dd66e5904f18fee32b4d275593a")


### PR DESCRIPTION
Its too confusing. I maybe have mistaken. I did not find Vulkan-hpp.
If SHA-s correct, we need port this https://github.com/xkbcommon/libxkbcommon/blob/bf03b4b5a46e3bfef7c567f227e5f8c2077e9d0b/meson.build#L384 (either whole or either split into one module as it usually prefered) 
```
Dependencies for libxkbregistry:
- libxkbregistry is a sublibrary of libxkbcommon and cannot be built without
  building libxbkcommon. The files produced are otherwise independent.
```

or gather it from apt like this ?
```lua
add_extsources("apt::libxkbregistry0")
```
for 
```lua
package("vulkan-loader")
```