### PR TITLE
try to build shared cunit

### DIFF
--- a/packages/c/cunit/xmake.lua
+++ b/packages/c/cunit/xmake.lua
@@ -23,6 +23,8 @@ package("cunit")
         if is_plat("windows") then
             add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
         end
+        io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_DLL", "if 1", {plain = true})
+        io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_BUILD_DLL", "if 1", {plain = true})
         io.replace("CUnit/CMakeLists.txt", "STATIC", "", {plain = true})
         import("package.tools.cmake").install(package, configs)
     end)

--- a/packages/c/cunit/xmake.lua
+++ b/packages/c/cunit/xmake.lua
@@ -17,6 +17,15 @@ package("cunit")
         table.insert(configs, "-DCUNIT_DISABLE_TESTS=TRUE")
         table.insert(configs, "-DCUNIT_DISABLE_EXAMPLES=TRUE")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
+
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+
+        if (package:config("shared")) then
+            io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_DLL", "if 1", {plain = true})
+            io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_BUILD_DLL", "if 1", {plain = true})
+            io.replace("CUnit/CMakeLists.txt", "add_library(cunit STATIC", "add_library(cunit", {plain = true})
+        end
+
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/c/cunit/xmake.lua
+++ b/packages/c/cunit/xmake.lua
@@ -17,7 +17,6 @@ package("cunit")
         table.insert(configs, "-DCUNIT_DISABLE_TESTS=TRUE")
         table.insert(configs, "-DCUNIT_DISABLE_EXAMPLES=TRUE")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
-
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
 
         if (package:config("shared")) then

--- a/packages/c/cunit/xmake.lua
+++ b/packages/c/cunit/xmake.lua
@@ -23,8 +23,10 @@ package("cunit")
         if is_plat("windows") then
             add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
         end
-        io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_DLL", "if 1", {plain = true})
-        io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_BUILD_DLL", "if 1", {plain = true})
+        if package:config("shared") and not is_plat("windows") then
+            io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_DLL", "if 1", {plain = true})
+            io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_BUILD_DLL", "if 1", {plain = true})
+        end
         io.replace("CUnit/CMakeLists.txt", "STATIC", "", {plain = true})
         import("package.tools.cmake").install(package, configs)
     end)

--- a/packages/c/cunit/xmake.lua
+++ b/packages/c/cunit/xmake.lua
@@ -23,7 +23,7 @@ package("cunit")
         if is_plat("windows") then
             add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
         end
-        io.replace("CMakeLists.txt", "STATIC", "", {plain = true})
+        io.replace("CUnit/CMakeLists.txt", "STATIC", "", {plain = true})
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/c/cunit/xmake.lua
+++ b/packages/c/cunit/xmake.lua
@@ -1,33 +1,27 @@
 package("cunit")
     set_homepage("https://gitlab.com/cunity/cunit")
     set_description("CUnit is a lightweight system for writing, administering, and running unit tests in C.")
-
     set_license("LGPL-2.1")
 
     add_urls("https://gitlab.com/cunity/cunit/-/archive/$(version)/cunit-$(version).tar.bz2",
              "https://gitlab.com/cunity/cunit.git")
+
     add_versions("3.4.4", "eda4c24afcb2f689b150dadea790a12efb1a0e5e2eb68df7d6417a3ae70a90c7")
 
-    add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+    if is_plat("windows") then
+        add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+    end
 
     add_deps("cmake")
 
     on_install(function (package)
+        io.replace("CUnit/CMakeLists.txt", "STATIC", "", {plain = true})
         io.replace("CMakeLists.txt", "-Werror -Werror=strict-prototypes", "", {plain = true})
         io.replace("CUnit/CMakeLists.txt", "-Werror -Werror=strict-prototypes", "", {plain = true})
-        local configs = {}
-        table.insert(configs, "-DCUNIT_DISABLE_TESTS=TRUE")
-        table.insert(configs, "-DCUNIT_DISABLE_EXAMPLES=TRUE")
+
+        local configs = {"-DCUNIT_DISABLE_TESTS=TRUE", "-DCUNIT_DISABLE_EXAMPLES=TRUE"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        if is_plat("windows") then
-            add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
-        end
-        if package:config("shared") and not is_plat("windows") then
-            io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_DLL", "if 1", {plain = true})
-            io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_BUILD_DLL", "if 1", {plain = true})
-        end
-        io.replace("CUnit/CMakeLists.txt", "STATIC", "", {plain = true})
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/c/cunit/xmake.lua
+++ b/packages/c/cunit/xmake.lua
@@ -19,7 +19,7 @@ package("cunit")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
 
-        if (package:config("shared")) then
+        if package:config("shared") then
             io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_DLL", "if 1", {plain = true})
             io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_BUILD_DLL", "if 1", {plain = true})
             io.replace("CUnit/CMakeLists.txt", "add_library(cunit STATIC", "add_library(cunit", {plain = true})

--- a/packages/c/cunit/xmake.lua
+++ b/packages/c/cunit/xmake.lua
@@ -19,6 +19,11 @@ package("cunit")
         table.insert(configs, "-DCUNIT_DISABLE_TESTS=TRUE")
         table.insert(configs, "-DCUNIT_DISABLE_EXAMPLES=TRUE")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        if is_plat("windows") then
+            add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+        end
+        io.replace("CMakeLists.txt", "STATIC", "", {plain = true})
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/c/cunit/xmake.lua
+++ b/packages/c/cunit/xmake.lua
@@ -8,6 +8,8 @@ package("cunit")
              "https://gitlab.com/cunity/cunit.git")
     add_versions("3.4.4", "eda4c24afcb2f689b150dadea790a12efb1a0e5e2eb68df7d6417a3ae70a90c7")
 
+    add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+
     add_deps("cmake")
 
     on_install(function (package)
@@ -17,14 +19,6 @@ package("cunit")
         table.insert(configs, "-DCUNIT_DISABLE_TESTS=TRUE")
         table.insert(configs, "-DCUNIT_DISABLE_EXAMPLES=TRUE")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
-        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-
-        if package:config("shared") then
-            io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_DLL", "if 1", {plain = true})
-            io.replace("CUnit/CUnit/CUnit.h.in", "ifdef CU_BUILD_DLL", "if 1", {plain = true})
-            io.replace("CUnit/CMakeLists.txt", "add_library(cunit STATIC", "add_library(cunit", {plain = true})
-        end
-
         import("package.tools.cmake").install(package, configs)
     end)
 


### PR DESCRIPTION
try to build shared cunit
Yet, need create export surface if something missing that needs ```CU_EXPORT``` before function definition. I dont know what exactly could be missing so let me know if that needs, like ```wxWidget.h``` functions or some struct in ```TestDB.h```, hence it is relying over static preprocessor during static lib build, not ```define CU_EXPORT declspec(dllimport)``` but ```define CU_EXPORT```
Since it is already placed where it is expected to be, but yet I do not believe it is good to do so, though just decide to keep it static only or not, any decision is good.

<details><summary>dumpbin /EXPORTS cunit.lib</summary>
<p>

dumpbin /EXPORTS cunit.lib
Microsoft (R) COFF/PE Dumper Version 14.33.31629.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file cunit.lib

File Type: LIBRARY

     Exports

       ordinal    name

                  CCU_automated_add_handlers
                  CCU_basic_add_handlers
                  CU_CI_add_suite
                  CU_CI_add_test
                  CU_CI_args
                  CU_CI_main
                  CU_GetSuiteFilter
                  CU_GetTestFilter
                  CU_SetSuiteFilter
                  CU_SetTestFilter
                  CU_SkipImplementation
                  CU_add_suite
                  CU_add_suite_with_setup_and_teardown
                  CU_add_test
                  CU_assertImplementation
                  CU_automated_enable_junit_xml
                  CU_automated_finish_junit
                  CU_automated_get_junit_filename
                  CU_automated_render_junit
                  CU_automated_run_tests
                  CU_basic_get_mode
                  CU_basic_run_suite
                  CU_basic_run_test
                  CU_basic_run_tests
                  CU_basic_set_mode
                  CU_basic_show_failures
                  CU_cleanup_registry
                  CU_clear_previous_results
                  CU_compare_strings
                  CU_console_run_tests
                  CU_count_all_failures
                  CU_count_all_tests
                  CU_count_suite_failures
                  CU_count_suite_tests
                  CU_count_test_failures
                  CU_create_new_registry
                  CU_destroy_existing_registry
                  CU_get_basename
                  CU_get_current_suite
                  CU_get_current_test
                  CU_get_elapsed_time
                  CU_get_error
                  CU_get_error_action
                  CU_get_error_msg
                  CU_get_fail_on_inactive
                  CU_get_failure_list
                  CU_get_number_of_asserts
                  CU_get_number_of_failure_records
                  CU_get_number_of_failures
                  CU_get_number_of_successes
                  CU_get_number_of_suites_failed
                  CU_get_number_of_suites_inactive
                  CU_get_number_of_suites_run
                  CU_get_number_of_tests_failed
                  CU_get_number_of_tests_inactive
                  CU_get_number_of_tests_run
                  CU_get_registry
                  CU_get_run_results_string
                  CU_get_run_summary
                  CU_get_suite
                  CU_get_suite_at_pos
                  CU_get_suite_by_index
                  CU_get_suite_by_name
                  CU_get_suite_duration
                  CU_get_suite_pos
                  CU_get_suite_pos_by_name
                  CU_get_test
                  CU_get_test_at_pos
                  CU_get_test_by_index
                  CU_get_test_by_name
                  CU_get_test_duration
                  CU_get_test_pos
                  CU_get_test_pos_by_name
                  CU_initialize_junit_result_file
                  CU_initialize_registry
                  CU_is_suite_filtered
                  CU_is_test_filtered
                  CU_is_test_running
                  CU_iterate_test_failures
                  CU_list_tests_to_file
                  CU_number_width
                  CU_print_all_suite_tests
                  CU_print_run_results
                  CU_register_nsuites
                  CU_register_suites
                  CU_registry_initialized
                  CU_run_all_tests
                  CU_run_suite
                  CU_run_test
                  CU_set_all_active
                  CU_set_all_test_complete_handler
                  CU_set_error
                  CU_set_error_action
                  CU_set_fail_on_inactive
                  CU_set_output_filename
                  CU_set_registry
                  CU_set_suite_active
                  CU_set_suite_cleanup_failure_handler
                  CU_set_suite_cleanupfunc
                  CU_set_suite_complete_handler
                  CU_set_suite_init_failure_handler
                  CU_set_suite_initfunc
                  CU_set_suite_name
                  CU_set_suite_skipped_handler
                  CU_set_suite_start_handler
                  CU_set_test_active
                  CU_set_test_complete_handler
                  CU_set_test_func
                  CU_set_test_name
                  CU_set_test_skipped_handler
                  CU_set_test_start_handler
                  CU_sort_suites
                  CU_translate_special_characters
                  CU_translated_strlen
                  CU_trim
                  CU_trim_left
                  CU_trim_right

  Summary

          BD .debug$S
          14 .idata$2
          14 .idata$3
           8 .idata$4
           8 .idata$5
           A .idata$6

</p>
</details> 

<details><summary>dumpbin /EXPORTS cunit.dll</summary>
<p>

dumpbin /EXPORTS cunit.dll
Microsoft (R) COFF/PE Dumper Version 14.33.31629.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file cunit.dll

File Type: DLL

  Section contains the following exports for cunit.dll

    00000000 characteristics
    FFFFFFFF time date stamp
        0.00 version
           1 ordinal base
         117 number of functions
         117 number of names

    ordinal hint RVA      name

          1    0 000017B0 CCU_automated_add_handlers
          2    1 00001000 CCU_basic_add_handlers
          3    2 000038A0 CU_CI_add_suite
          4    3 00003930 CU_CI_add_test
          5    4 00003990 CU_CI_args
          6    5 000039B0 CU_CI_main
          7    6 00006210 CU_GetSuiteFilter
          8    7 00006220 CU_GetTestFilter
          9    8 00006230 CU_SetSuiteFilter
         10    9 00006240 CU_SetTestFilter
         11    A 00006250 CU_SkipImplementation
         12    B 00004580 CU_add_suite
         13    C 000048F0 CU_add_suite_with_setup_and_teardown
         14    D 00004C70 CU_add_test
         15    E 00006330 CU_assertImplementation
         16    F 00001830 CU_automated_enable_junit_xml
         17   10 00002840 CU_automated_finish_junit
         18   11 00001840 CU_automated_get_junit_filename
         19   12 000028D0 CU_automated_render_junit
         20   13 000018B0 CU_automated_run_tests
         21   14 00001070 CU_basic_get_mode
         22   15 00001080 CU_basic_run_suite
         23   16 000010C0 CU_basic_run_test
         24   17 00001120 CU_basic_run_tests
         25   18 00001190 CU_basic_set_mode
         26   19 000011A0 CU_basic_show_failures
         27   1A 00004E20 CU_cleanup_registry
         28   1B 00006550 CU_clear_previous_results
         29   1C 000082B0 CU_compare_strings
         30   1D 000087D0 CU_console_run_tests
         31   1E 00006600 CU_count_all_failures
         32   1F 00006680 CU_count_all_tests
         33   20 000066C0 CU_count_suite_failures
         34   21 00006710 CU_count_suite_tests
         35   22 00006730 CU_count_test_failures
         36   23 00004EA0 CU_create_new_registry
         37   24 00004ED0 CU_destroy_existing_registry
         38   25 00008350 CU_get_basename
         39   26 00006780 CU_get_current_suite
         40   27 00006790 CU_get_current_test
         41   28 000067A0 CU_get_elapsed_time
         42   29 00004150 CU_get_error
         43   2A 00004160 CU_get_error_action
         44   2B 00004170 CU_get_error_msg
         45   2C 000067F0 CU_get_fail_on_inactive
         46   2D 00006800 CU_get_failure_list
         47   2E 00006810 CU_get_number_of_asserts
         48   2F 00006820 CU_get_number_of_failure_records
         49   30 00006830 CU_get_number_of_failures
         50   31 00006840 CU_get_number_of_successes
         51   32 00006850 CU_get_number_of_suites_failed
         52   33 00006860 CU_get_number_of_suites_inactive
         53   34 00006870 CU_get_number_of_suites_run
         54   35 00006880 CU_get_number_of_tests_failed
         55   36 00006890 CU_get_number_of_tests_inactive
         56   37 000068A0 CU_get_number_of_tests_run
         57   38 00005010 CU_get_registry
         58   39 000068B0 CU_get_run_results_string
         59   3A 00006AA0 CU_get_run_summary
         60   3B 00005020 CU_get_suite
         61   3C 000050B0 CU_get_suite_at_pos
         62   3D 00005110 CU_get_suite_by_index
         63   3E 00005170 CU_get_suite_by_name
         64   3F 00006AB0 CU_get_suite_duration
         65   40 00005200 CU_get_suite_pos
         66   41 00005270 CU_get_suite_pos_by_name
         67   42 00005320 CU_get_test
         68   43 000053B0 CU_get_test_at_pos
         69   44 00005440 CU_get_test_by_index
         70   45 000054B0 CU_get_test_by_name
         71   46 00006AD0 CU_get_test_duration
         72   47 00005540 CU_get_test_pos
         73   48 000055C0 CU_get_test_pos_by_name
         74   49 00001B30 CU_initialize_junit_result_file
         75   4A 00005680 CU_initialize_registry
         76   4B 00006AE0 CU_is_suite_filtered
         77   4C 00006B10 CU_is_test_filtered
         78   4D 00006B40 CU_is_test_running
         79   4E 00006B50 CU_iterate_test_failures
         80   4F 00001C00 CU_list_tests_to_file
         81   50 000083E0 CU_number_width
         82   51 00006BA0 CU_print_all_suite_tests
         83   52 00006C10 CU_print_run_results
         84   53 00005740 CU_register_nsuites
         85   54 00005D20 CU_register_suites
         86   55 00005D30 CU_registry_initialized
         87   56 00006C90 CU_run_all_tests
         88   57 00006E40 CU_run_suite
         89   58 00006F80 CU_run_test
         90   59 00005D40 CU_set_all_active
         91   5A 00007520 CU_set_all_test_complete_handler
         92   5B 000041A0 CU_set_error
         93   5C 00004200 CU_set_error_action
         94   5D 00007530 CU_set_fail_on_inactive
         95   5E 00001F20 CU_set_output_filename
         96   5F 00005D90 CU_set_registry
         97   60 00005DF0 CU_set_suite_active
         98   61 00007540 CU_set_suite_cleanup_failure_handler
         99   62 00005E30 CU_set_suite_cleanupfunc
        100   63 00007550 CU_set_suite_complete_handler
        101   64 00007560 CU_set_suite_init_failure_handler
        102   65 00005E70 CU_set_suite_initfunc
        103   66 00005EB0 CU_set_suite_name
        104   67 00007570 CU_set_suite_skipped_handler
        105   68 00007580 CU_set_suite_start_handler
        106   69 00005F40 CU_set_test_active
        107   6A 00007590 CU_set_test_complete_handler
        108   6B 00005F80 CU_set_test_func
        109   6C 00005FC0 CU_set_test_name
        110   6D 000075A0 CU_set_test_skipped_handler
        111   6E 000075B0 CU_set_test_start_handler
        112   6F 00006050 CU_sort_suites
        113   70 00008440 CU_translate_special_characters
        114   71 00008570 CU_translated_strlen
        115   72 00008620 CU_trim
        116   73 000086E0 CU_trim_left
        117   74 00008760 CU_trim_right

  Summary

        4000 .data
        3000 .pdata
       11000 .rdata
        1000 .reloc
        1000 .rsrc
       29000 .text
        1000 _RDATA

</p>
</details> 

If we use ```CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON```

<details><summary>dumpbin /EXPORTS cunit.lib</summary>
<p>

dumpbin /EXPORTS cunit.lib
Microsoft (R) COFF/PE Dumper Version 14.33.31629.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file cunit.lib

File Type: LIBRARY

     Exports

       ordinal    name

                  CCU_MessageHandler_Add
                  CCU_MessageHandler_Clear
                  CCU_MessageHandler_Get
                  CCU_MessageHandler_Run
                  CCU_MessageHandler_Set
                  CCU_automated_add_handlers
                  CCU_basic_add_handlers
                  CU_CI_add_suite
                  CU_CI_add_test
                  CU_CI_args
                  CU_CI_main
                  CU_GetSuiteFilter
                  CU_GetTestFilter
                  CU_SetSuiteFilter
                  CU_SetTestFilter
                  CU_SkipImplementation
                  CU_add_suite
                  CU_add_suite_with_setup_and_teardown
                  CU_add_test
                  CU_assertImplementation
                  CU_automated_enable_junit_xml
                  CU_automated_finish_junit
                  CU_automated_get_junit_filename
                  CU_automated_package_name_get
                  CU_automated_package_name_set
                  CU_automated_render_junit
                  CU_automated_run_tests
                  CU_basic_get_mode
                  CU_basic_run_suite
                  CU_basic_run_test
                  CU_basic_run_tests
                  CU_basic_set_mode
                  CU_basic_show_failures
                  CU_cleanup_registry
                  CU_clear_previous_results
                  CU_compare_strings
                  CU_console_run_tests
                  CU_count_all_failures
                  CU_count_all_tests
                  CU_count_suite_failures
                  CU_count_suite_tests
                  CU_count_test_failures
                  CU_create_new_registry
                  CU_destroy_existing_registry
                  CU_get_basename
                  CU_get_current_suite
                  CU_get_current_test
                  CU_get_elapsed_time
                  CU_get_error
                  CU_get_error_action
                  CU_get_error_msg
                  CU_get_fail_on_inactive
                  CU_get_failure_list
                  CU_get_number_of_asserts
                  CU_get_number_of_failure_records
                  CU_get_number_of_failures
                  CU_get_number_of_successes
                  CU_get_number_of_suites_failed
                  CU_get_number_of_suites_inactive
                  CU_get_number_of_suites_run
                  CU_get_number_of_tests_failed
                  CU_get_number_of_tests_inactive
                  CU_get_number_of_tests_run
                  CU_get_registry
                  CU_get_run_results_string
                  CU_get_run_summary
                  CU_get_suite
                  CU_get_suite_at_pos
                  CU_get_suite_by_index
                  CU_get_suite_by_name
                  CU_get_suite_duration
                  CU_get_suite_pos
                  CU_get_suite_pos_by_name
                  CU_get_test
                  CU_get_test_at_pos
                  CU_get_test_by_index
                  CU_get_test_by_name
                  CU_get_test_duration
                  CU_get_test_pos
                  CU_get_test_pos_by_name
                  CU_initialize_junit_result_file
                  CU_initialize_registry
                  CU_is_suite_filtered
                  CU_is_test_filtered
                  CU_is_test_running
                  CU_iterate_test_failures
                  CU_list_tests_to_file
                  CU_number_width
                  CU_print_all_suite_tests
                  CU_print_run_results
                  CU_register_nsuites
                  CU_register_suites
                  CU_registry_initialized
                  CU_run_all_tests
                  CU_run_suite
                  CU_run_test
                  CU_set_all_active
                  CU_set_all_test_complete_handler
                  CU_set_error
                  CU_set_error_action
                  CU_set_fail_on_inactive
                  CU_set_output_filename
                  CU_set_registry
                  CU_set_suite_active
                  CU_set_suite_cleanup_failure_handler
                  CU_set_suite_cleanupfunc
                  CU_set_suite_complete_handler
                  CU_set_suite_init_failure_handler
                  CU_set_suite_initfunc
                  CU_set_suite_name
                  CU_set_suite_skipped_handler
                  CU_set_suite_start_handler
                  CU_set_test_active
                  CU_set_test_complete_handler
                  CU_set_test_func
                  CU_set_test_name
                  CU_set_test_skipped_handler
                  CU_set_test_start_handler
                  CU_sort_suites
                  CU_translate_special_characters
                  CU_translated_strlen
                  CU_trim
                  CU_trim_left
                  CU_trim_right
                  __local_stdio_printf_options
                  fprintf
                  printf
                  snprintf

  Summary

          BD .debug$S
          14 .idata$2
          14 .idata$3
           8 .idata$4
           8 .idata$5
           A .idata$6

</p>
</details> 

<details><summary>dumpbin /EXPORTS cunit.dll</summary>
<p>

dumpbin /EXPORTS cunit.dll
Microsoft (R) COFF/PE Dumper Version 14.33.31629.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file cunit.dll

File Type: DLL

  Section contains the following exports for cunit.dll

    00000000 characteristics
    FFFFFFFF time date stamp
        0.00 version
           1 ordinal base
         128 number of functions
         128 number of names

    ordinal hint RVA      name

          1    0 00004240 CCU_MessageHandler_Add
          2    1 00004320 CCU_MessageHandler_Clear
          3    2 000043C0 CCU_MessageHandler_Get
          4    3 000043D0 CCU_MessageHandler_Run
          5    4 000044A0 CCU_MessageHandler_Set
          6    5 000017B0 CCU_automated_add_handlers
          7    6 00001000 CCU_basic_add_handlers
          8    7 000038A0 CU_CI_add_suite
          9    8 00003930 CU_CI_add_test
         10    9 00003990 CU_CI_args
         11    A 000039B0 CU_CI_main
         12    B 000062C0 CU_GetSuiteFilter
         13    C 000062D0 CU_GetTestFilter
         14    D 000062E0 CU_SetSuiteFilter
         15    E 000062F0 CU_SetTestFilter
         16    F 00006300 CU_SkipImplementation
         17   10 00004630 CU_add_suite
         18   11 000049A0 CU_add_suite_with_setup_and_teardown
         19   12 00004D20 CU_add_test
         20   13 000063E0 CU_assertImplementation
         21   14 00001830 CU_automated_enable_junit_xml
         22   15 00002840 CU_automated_finish_junit
         23   16 00001840 CU_automated_get_junit_filename
         24   17 00001850 CU_automated_package_name_get
         25   18 00001860 CU_automated_package_name_set
         26   19 000028D0 CU_automated_render_junit
         27   1A 000018B0 CU_automated_run_tests
         28   1B 00001070 CU_basic_get_mode
         29   1C 00001080 CU_basic_run_suite
         30   1D 000010C0 CU_basic_run_test
         31   1E 00001120 CU_basic_run_tests
         32   1F 00001190 CU_basic_set_mode
         33   20 000011A0 CU_basic_show_failures
         34   21 00004ED0 CU_cleanup_registry
         35   22 00006600 CU_clear_previous_results
         36   23 00008360 CU_compare_strings
         37   24 00008880 CU_console_run_tests
         38   25 000066B0 CU_count_all_failures
         39   26 00006730 CU_count_all_tests
         40   27 00006770 CU_count_suite_failures
         41   28 000067C0 CU_count_suite_tests
         42   29 000067E0 CU_count_test_failures
         43   2A 00004F50 CU_create_new_registry
         44   2B 00004F80 CU_destroy_existing_registry
         45   2C 00008400 CU_get_basename
         46   2D 00006830 CU_get_current_suite
         47   2E 00006840 CU_get_current_test
         48   2F 00006850 CU_get_elapsed_time
         49   30 00004150 CU_get_error
         50   31 00004160 CU_get_error_action
         51   32 00004170 CU_get_error_msg
         52   33 000068A0 CU_get_fail_on_inactive
         53   34 000068B0 CU_get_failure_list
         54   35 000068C0 CU_get_number_of_asserts
         55   36 000068D0 CU_get_number_of_failure_records
         56   37 000068E0 CU_get_number_of_failures
         57   38 000068F0 CU_get_number_of_successes
         58   39 00006900 CU_get_number_of_suites_failed
         59   3A 00006910 CU_get_number_of_suites_inactive
         60   3B 00006920 CU_get_number_of_suites_run
         61   3C 00006930 CU_get_number_of_tests_failed
         62   3D 00006940 CU_get_number_of_tests_inactive
         63   3E 00006950 CU_get_number_of_tests_run
         64   3F 000050C0 CU_get_registry
         65   40 00006960 CU_get_run_results_string
         66   41 00006B50 CU_get_run_summary
         67   42 000050D0 CU_get_suite
         68   43 00005160 CU_get_suite_at_pos
         69   44 000051C0 CU_get_suite_by_index
         70   45 00005220 CU_get_suite_by_name
         71   46 00006B60 CU_get_suite_duration
         72   47 000052B0 CU_get_suite_pos
         73   48 00005320 CU_get_suite_pos_by_name
         74   49 000053D0 CU_get_test
         75   4A 00005460 CU_get_test_at_pos
         76   4B 000054F0 CU_get_test_by_index
         77   4C 00005560 CU_get_test_by_name
         78   4D 00006B80 CU_get_test_duration
         79   4E 000055F0 CU_get_test_pos
         80   4F 00005670 CU_get_test_pos_by_name
         81   50 00001B30 CU_initialize_junit_result_file
         82   51 00005730 CU_initialize_registry
         83   52 00006B90 CU_is_suite_filtered
         84   53 00006BC0 CU_is_test_filtered
         85   54 00006BF0 CU_is_test_running
         86   55 00006C00 CU_iterate_test_failures
         87   56 00001C00 CU_list_tests_to_file
         88   57 00008490 CU_number_width
         89   58 00006C50 CU_print_all_suite_tests
         90   59 00006CC0 CU_print_run_results
         91   5A 000057F0 CU_register_nsuites
         92   5B 00005DD0 CU_register_suites
         93   5C 00005DE0 CU_registry_initialized
         94   5D 00006D40 CU_run_all_tests
         95   5E 00006EF0 CU_run_suite
         96   5F 00007030 CU_run_test
         97   60 00005DF0 CU_set_all_active
         98   61 000075D0 CU_set_all_test_complete_handler
         99   62 000041A0 CU_set_error
        100   63 00004200 CU_set_error_action
        101   64 000075E0 CU_set_fail_on_inactive
        102   65 00001F20 CU_set_output_filename
        103   66 00005E40 CU_set_registry
        104   67 00005EA0 CU_set_suite_active
        105   68 000075F0 CU_set_suite_cleanup_failure_handler
        106   69 00005EE0 CU_set_suite_cleanupfunc
        107   6A 00007600 CU_set_suite_complete_handler
        108   6B 00007610 CU_set_suite_init_failure_handler
        109   6C 00005F20 CU_set_suite_initfunc
        110   6D 00005F60 CU_set_suite_name
        111   6E 00007620 CU_set_suite_skipped_handler
        112   6F 00007630 CU_set_suite_start_handler
        113   70 00005FF0 CU_set_test_active
        114   71 00007640 CU_set_test_complete_handler
        115   72 00006030 CU_set_test_func
        116   73 00006070 CU_set_test_name
        117   74 00007650 CU_set_test_skipped_handler
        118   75 00007660 CU_set_test_start_handler
        119   76 00006100 CU_sort_suites
        120   77 000084F0 CU_translate_special_characters
        121   78 00008620 CU_translated_strlen
        122   79 000086D0 CU_trim
        123   7A 00008790 CU_trim_left
        124   7B 00008810 CU_trim_right
        125   7C 00001260 __local_stdio_printf_options
        126   7D 00001760 fprintf
        127   7E 00007670 printf
        128   7F 000040F0 snprintf

  Summary

        4000 .data
        3000 .pdata
       11000 .rdata
        1000 .reloc
        1000 .rsrc
       29000 .text
        1000 _RDATA

</p>
</details> 