### PR TITLE
libtorch: remove nvtx dependency since v2.5.0

### DIFF
--- a/packages/l/libtorch/xmake.lua
+++ b/packages/l/libtorch/xmake.lua
@@ -62,7 +62,9 @@ package("libtorch")
         end
         if package:config("cuda") then
             package:add("deps", "cuda", {configs = {utils = {"nvrtc", "cudnn", "cufft", "curand", "cublas", "cudart_static"}}})
-            package:add("deps", "nvtx")
+            if package:version():lt("2.5.0") then
+                package:add("deps", "nvtx")
+            end
         end
         if package:config("distributed") then
             package:add("deps", "libuv")


### PR DESCRIPTION
pytorch introduces NVTX3 as a git submodule since pytorch 2.4.1. Therefore, we do not need to add NVTX as deps any more since v2.4.1.

从2.4.1版本开始，pytorch开始将NVTX以Git submodule的形式引入，因此无需再将NVTX作为deps。