### PR TITLE
fix: bypass verilator root check

### DIFF
--- a/packages/v/verilator/xmake.lua
+++ b/packages/v/verilator/xmake.lua
@@ -8,6 +8,8 @@ package("verilator")
              "https://github.com/verilator/verilator.git")
 
     add_versions("v5.016", "66fc36f65033e5ec904481dd3d0df56500e90c0bfca23b2ae21b4a8d39e05ef1")
+    add_versions("v5.024", "88b04c953e7165c670d6a700f202cef99c746a0867b4e2efe1d7ea789dee35f3")
+    add_versions("v5.032", "5a262564b10be8bdb31ff4fb67d77bcf5f52fc1b4e6c88d5ca3264fb481f1e41")
 
     add_deps("cmake")
 
@@ -38,6 +40,10 @@ package("verilator")
 
         local version = package:version()
         if version then
+            if version:ge("5.024") then
+                io.replace("bin/verilator", "$verilator_root ne realpath($ENV{VERILATOR_ROOT})", "true")
+            end
+            
             if version:ge("5.030") then
                 io.replace("src/CMakeLists.txt", "MSVC_RUNTIME_LIBRARY MultiThreaded$<IF:$<CONFIG:Release>,,DebugDLL>", "", {plain = true})
             else

--- a/packages/v/verilator/xmake.lua
+++ b/packages/v/verilator/xmake.lua
@@ -8,7 +8,6 @@ package("verilator")
              "https://github.com/verilator/verilator.git")
 
     add_versions("v5.016", "66fc36f65033e5ec904481dd3d0df56500e90c0bfca23b2ae21b4a8d39e05ef1")
-    add_versions("v5.024", "88b04c953e7165c670d6a700f202cef99c746a0867b4e2efe1d7ea789dee35f3")
     add_versions("v5.032", "5a262564b10be8bdb31ff4fb67d77bcf5f52fc1b4e6c88d5ca3264fb481f1e41")
 
     add_deps("cmake")


### PR DESCRIPTION
添加 verilator v5.024 和 v5.032 支持

https://github.com/verilator/verilator/commit/f56f3182176c967d9f14861e38563177ab2295f0 添加了 VERILATOR_ROOT  环境变量的检查，如果与脚本所在目录不符合会报错，将条件替换为 true 跳过检查
