### PR TITLE
pcl: fix boost version requirement

### DIFF
--- a/packages/p/pcl/xmake.lua
+++ b/packages/p/pcl/xmake.lua
@@ -9,21 +9,27 @@ package("pcl")
     add_versions("1.12.0", "21dfa9a268de9675c1f94d54d9402e4e02120a0aa4215d064436c52b7d5bd48f")
     add_versions("1.12.1", "dc0ac26f094eafa7b26c3653838494cc0a012bd1bdc1f1b0dc79b16c2de0125a")
     add_versions("1.14.0", "de297b929eafcb93747f12f98a196efddf3d55e4edf1b6729018b436d5be594d")
+    add_versions("1.14.1", "5dc5e09509644f703de9a3fb76d99ab2cc67ef53eaf5637db2c6c8b933b28af6")
 
     add_configs("vtk", {description = "Build with vtk.", default = false, type = "boolean"})
     add_configs("cuda", {description = "Build with cuda.", default = false, type = "boolean"})
 
     add_deps("cmake")
-    add_deps("boost", {configs = {filesystem = true, serialization = true, date_time = true, iostreams = true, system = true}})
-    add_deps("eigen", "boost", "lz4", "flann", "zlib", "libpng", "qhull", "glew")
+    add_deps("eigen", "lz4", "flann", "zlib", "libpng", "qhull", "glew")
     on_load("windows", "linux", "macosx", function (package)
         package:add("includedirs", "include/pcl-" .. package:version():major() .. "." .. package:version():minor())
+
+        if package:version():le("1.14.1") then
+            package:add("deps", "boost", {version = "1.85.0", configs = {filesystem = true, serialization = true, date_time = true, iostreams = true, system = true, thread = true, graph = true}})
+        else
+            package:add("deps", "boost", {configs = {asio = true, filesystem = true, serialization = true, date_time = true, iostreams = true, system = true, thread = true, graph = true}})
+        end
+
         if package:config("vtk") then
             package:add("deps", "vtk")
         end
         if package:config("cuda") then
             package:add("deps", "cuda", {system = true})
-            package:add("deps", "optix", {system = true})
         end
     end)
 


### PR DESCRIPTION
PCL uses some internal boost functions and classes. Therefore, some versions of PCL relies on specific boost version.

Seems like that the PCL developers are working with boost 1.87.0 now, but boost 1.87.0 currently does not work with PCL 1.14.1. Maybe this should be changed in the future.