### PR TITLE
Enable Qt6 for macOS arm64

### DIFF
--- a/packages/q/qt6base/xmake.lua
+++ b/packages/q/qt6base/xmake.lua
@@ -22,6 +22,6 @@ package("qt6base")
     add_versions("6.7.2", "dummy")
     add_versions("6.8.0", "dummy")
 
-    on_install("windows|x64", "linux|x86_64", "macosx|x86_64", "mingw|x86_64", function (package)
+    on_install("windows|x64", "linux|x86_64", "macosx", "mingw|x86_64", function (package)
         package:base():script("install")(package)
     end)

--- a/packages/q/qt6lib/xmake.lua
+++ b/packages/q/qt6lib/xmake.lua
@@ -88,7 +88,7 @@ package("qt6lib")
         }
     end)
 
-    on_install("windows|x64", "linux|x86_64", "macosx|x86_64", "mingw|x86_64", function (package)
+    on_install("windows|x64", "linux|x86_64", "macosx", "mingw|x86_64", function (package)
         local qt = package:dep("qt6base"):data("qt")
         assert(qt, "qt6base is required")
     end)


### PR DESCRIPTION
https://github.com/xmake-io/xmake-repo/issues/6189

Tested build on Apple M4:
```sh
checking for platform ... macosx
checking for architecture ... arm64
checking for Xcode directory ... %s
checking for Codesign Identity of Xcode ... no
  => install qt6base 6.8.0 .. ok
  => install qt6core 6.8.0 .. ok
  => install qt6network 6.8.0 .. ok
  => install qt6gui 6.8.0 .. ok
  => install qt6widgets 6.8.0 .. ok
[ 28%]: compiling.qt.moc main_window.hpp
[ 42%]: cache compiling.debug main.cpp
[ 57%]: cache compiling.debug main_window.cpp
[ 71%]: compiling.qt.qrc resources.qrc
[ 85%]: linking.debug qt-app
[100%]: generating.qt.app qt-app.app
create ok!
compile_commands.json updated!
[100%]: build ok, spent 7.001s
```