### PR TITLE
Qt: enhance cross-compilation support for desktop platforms

### DIFF
--- a/packages/q/qt-tools/xmake.lua
+++ b/packages/q/qt-tools/xmake.lua
@@ -1,8 +1,12 @@
-package("qt6base")
-    set_kind("phony")
+package("qt-tools")
+    set_kind("binary")
     set_base("qtbase")
 
-    -- Sync with qt6lib and qt-tools
+    -- Sync with qt5base and qt5lib
+    add_versions("5.15.2", "dummy")
+    add_versions("5.12.5", "dummy")
+
+    -- Sync with qt6base and qt6lib
     add_versions("6.3.0", "dummy")
     add_versions("6.3.1", "dummy")
     add_versions("6.3.2", "dummy")
@@ -23,14 +27,6 @@ package("qt6base")
     add_versions("6.7.2", "dummy")
     add_versions("6.8.0", "dummy")
 
-    on_install("windows|x64,linux|x86_64,macosx,mingw|x86_64@windows,linux,macosx", function (package)
-        package:base():script("install")(package)
-    end)
-
-    on_install("android|arm64-v8a,armeabi-v7a,armeabi,x86_64,x86@windows,linux,macosx", function (package)
-        package:base():script("install")(package)
-    end)
-
-    on_install("iphoneos,wasm@windows,linux,macosx", function (package)
+    on_install("windows", "linux", "macosx", function (package)
         package:base():script("install")(package)
     end)

--- a/packages/q/qt6lib/xmake.lua
+++ b/packages/q/qt6lib/xmake.lua
@@ -37,6 +37,11 @@ package("qt6lib")
         if not qt then
             return
         end
+        for _, dep in ipairs(package:orderdeps()) do
+            if not dep:fetch() then
+                return
+            end
+        end
 
         local libname = assert(package:data("libname"), "this package must not be used directly")
 

--- a/packages/q/qt6lib/xmake.lua
+++ b/packages/q/qt6lib/xmake.lua
@@ -7,6 +7,7 @@ package("qt6lib")
     add_configs("shared", {description = "Download shared binaries.", default = true, type = "boolean", readonly = true})
     add_configs("vs_runtime", {description = "Set vs compiler runtime.", default = "MD", readonly = true})
 
+    -- Sync with qt6base and qt-tools
     add_versions("6.3.0", "dummy")
     add_versions("6.3.1", "dummy")
     add_versions("6.3.2", "dummy")
@@ -88,7 +89,17 @@ package("qt6lib")
         }
     end)
 
-    on_install("windows|x64", "linux|x86_64", "macosx", "mingw|x86_64", function (package)
+    on_install("windows|x64,linux|x86_64,macosx,mingw|x86_64@windows,linux,macosx", function (package)
+        local qt = package:dep("qt6base"):data("qt")
+        assert(qt, "qt6base is required")
+    end)
+
+    on_install("android|arm64-v8a,armeabi-v7a,armeabi,x86_64,x86@windows,linux,macosx", function (package)
+        local qt = package:dep("qt6base"):data("qt")
+        assert(qt, "qt6base is required")
+    end)
+
+    on_install("iphoneos,wasm@windows,linux,macosx", function (package)
         local qt = package:dep("qt6base"):data("qt")
         assert(qt, "qt6base is required")
     end)

--- a/packages/q/qt6lib/xmake.lua
+++ b/packages/q/qt6lib/xmake.lua
@@ -37,8 +37,9 @@ package("qt6lib")
         if not qt then
             return
         end
-        for _, dep in ipairs(package:orderdeps()) do
-            if not dep:fetch() then
+        -- Ensure all direct dependencies are fetched
+        for _, dep in ipairs(package:plaindeps()) do
+            if not dep:fetch() and dep:parents(package:name()) then
                 return
             end
         end

--- a/packages/q/qtbase/xmake.lua
+++ b/packages/q/qtbase/xmake.lua
@@ -6,11 +6,66 @@ package("qtbase")
 
     add_configs("shared", {description = "Download shared binaries.", default = true, type = "boolean", readonly = true})
     add_configs("runtimes", {description = "Set compiler runtimes.", default = "MD", readonly = true})
+    add_configs("exact_version", {description = "Require exact version match if Qt is system-installed.", default = false, type = "boolean"})
+    add_configs("tools_only", {description = "Install only SDK tools, primarily for cross-compilation scenarios.", default = false, type = "boolean"})
 
     add_deps("aqt")
 
+    if on_check then
+        on_check(function (package)
+            local version = package:version()
+            -- Chech for 32bits support removal in Qt6
+            if package:is_plat("windows", "mingw") and version then
+                if version:ge("6.0") and package:is_arch("x86", "i386") then
+                    raise("package(qt6base): 32bits support was removed in Qt6")
+                end
+            end
+            -- Check for Visual Studio version requirements
+            if package:is_plat("windows") and version then
+                local vs = package:toolchain("msvc"):config("vs")
+                if version:ge("6.8") and tonumber(vs) < 2022 then
+                    raise("package(qt6base): Qt 6.8+ requires Visual Studio 2022")
+                elseif version:ge("6.0") and tonumber(vs) < 2019 then
+                    raise("package(qt6base): Qt 6.0+ requires Visual Studio 2019")
+                end
+            end
+            -- Check for symbolic link creation issues when cross-compiling on Windows
+            if is_host("windows") and package:is_plat("linux") then
+                wprint("It seems that you are installing Qt SDK on Windows for a non-Windows platform. If you encounter issues related to symbolic link creation, " ..
+                       "please try enabling Developer Mode in Windows Settings or run xmake with administrator privileges.")
+            end
+            -- Check for WASM support
+            if package:is_plat("wasm") and version then
+                -- For more information on WASM support, visit:
+                -- https://doc.qt.io/qt-6/wasm.html
+                -- https://aqtinstall.readthedocs.io/en/latest/getting_started.html#installing-qt-for-wasm
+                if version:ge("6.8") then
+                    -- TODO: Update this check when aqtinstall supports Qt 6.8+ for WASM
+                    raise("package(qt6base): Qt 6.8+ for WASM is not supported by aqtinstall yet")
+                elseif (version:ge("6.0") and version:lt("6.2")) or version:lt("5.13") then
+                    raise("package(qtbase): WASM support requires Qt 5.13+ or Qt 6.2+")
+                end
+            end
+            -- Check for ARM64 support
+            if package:is_arch("arm64.*", "aarch64") and package:is_plat("windows", "mingw", "linux") and version then
+                if package:is_plat("windows", "mingw") and version:lt("6.8") then
+                    raise("package(qt6base): Windows on ARM64 support was added in Qt 6.8")
+                elseif package:is_plat("linux") and version:lt("6.7") then
+                    raise("package(qt6base): Linux on ARM64 support was added in Qt 6.7")
+                end
+            end
+        end)
+    end
+
     on_load(function (package)
         package:addenv("PATH", "bin")
+        if package:is_cross() then
+            local host_qt_depname = "qt-tools"
+            if package:version() then
+                host_qt_depname = host_qt_depname .. " " .. package:version():shortstr()
+            end
+            package:add("deps", host_qt_depname, {configs = {tools_only = true, exact_version = true}})
+        end
     end)
 
     on_fetch(function (package, opt)
@@ -27,14 +82,40 @@ package("qtbase")
             sdkdir = package:installdir()
         end
 
-        local qt = find_qt(sdkdir, {force = opt.force})
+        local qt
+        local version = package:version()
+        local find_opt = {force = opt.force}
+        if package:config("exact_version") and version then
+            find_opt.version = version:shortstr()
+        end
+        if not package:is_cross() then
+            qt = find_qt(sdkdir, find_opt)
+        else
+            local host_qt = package:dep("qt-tools")
+            if not host_qt then
+                return
+            end
+            local host_qt_data = host_qt:data("qt") or find_qt(nil, {version = host_qt:version() and host_qt:version():shortstr()})
+            if not host_qt_data then
+                return
+            end
+            qt = find_qt(sdkdir, table.join(find_opt, {sdkdir_host = host_qt_data.sdkdir}))
+            if qt then
+                -- Avoid mistakenly identifying "host_qt" as the target SDK
+                if host_qt_data.sdkdir and host_qt_data.sdkdir == qt.sdkdir then
+                    return
+                end
+            end
+        end
         if not qt then
             return
         end
 
         local qtversion = semver.new(qt.sdkver)
-        if not qtversion:ge(package:version()) then
-            return
+        if version and not qtversion:eq(version) then
+            if package:config("exact_version") or not qtversion:ge(version) then
+                return
+            end
         end
         qt.version = qt.sdkver
         package:data_set("qt", qt)
@@ -49,15 +130,39 @@ package("qtbase")
         local version = package:version()
         local versionstr = version:shortstr()
 
-        local host
-        if is_host("windows") or package:is_plat("mingw") then
-            host = "windows"
-        elseif is_host("linux") then
-            host = "linux"
-        elseif is_host("macosx") then
-            host = "mac"
+        -- Usage of `aqtinstall`: aqt install-qt <host> <target> <Qt version> [<arch>]
+        -- <host> options: {linux, linux_arm64, mac, windows, windows_arm64}
+        -- <target> options: {desktop, winrt, android, ios}
+        --
+        -- The `pseudo_host` variable (used as <host>) is determined based on the target platform
+        --
+        -- Behavior:
+        -- 1. No cross-compilation (package:plat() == os.host()):
+        --    - Downloads Qt libraries and SDK tools specific to the host platform.
+        --
+        -- 2. Cross-compilation (package:plat() ~= os.host()):
+        --    - Downloads Qt libraries and incompatible SDK tools.
+        --    - Usable SDK tools are retrieved from package:dep("qt-tools") or the "qt_host" configuration.
+
+        local pseudo_host
+        local platform_map = {windows = "windows", mingw = "windows", linux = "linux", macosx = "mac"}
+        if package:is_plat("windows", "mingw", "linux", "macosx") then
+            pseudo_host = platform_map[package:plat()]
+        elseif package:is_plat("android") then
+            pseudo_host = platform_map[os.host()]
+        elseif package:is_plat("iphoneos") then
+            pseudo_host = "mac"
+        elseif package:is_plat("wasm") then
+            if version:ge("6.8") then
+                pseudo_host = "all_os"
+            else
+                pseudo_host = platform_map[os.host()]
+            end
         else
-            raise("unhandled host " .. os.host())
+            raise("unhandled platform " .. package:plat())
+        end
+        if package:is_arch("arm64.*", "aarch64") and package:is_plat("windows", "mingw", "linux") then
+            pseudo_host = pseudo_host .. "_arm64"
         end
 
         local target
@@ -67,6 +172,12 @@ package("qtbase")
             target = "android"
         elseif package:is_plat("iphoneos") then
             target = "ios"
+        elseif package:is_plat("wasm") then
+            if version:ge("6.8") then
+                target = "wasm"
+            else
+                target = "desktop"
+            end
         else
             raise("unhandled plat " .. package:plat())
         end
@@ -87,10 +198,12 @@ package("qtbase")
                 local vs = package:toolchain("msvc"):config("vs")
                 if version:ge("6.8") then
                     compiler_version = "msvc2022"
-                elseif tonumber(vs) >= 2019 or version:ge("6.0") then
+                elseif tonumber(vs) >= 2019 and version:ge("5.15") then
                     compiler_version = "msvc2019"
-                elseif vs == "2017" or vs == "2015" then
-                    compiler_version = "msvc" .. vs
+                elseif tonumber(vs) >= 2017 then
+                    compiler_version = "msvc2017"
+                elseif tonumber(vs) >= 2015 then
+                    compiler_version = "msvc2015"
                 else
                     raise("unhandled msvc version " .. vs)
                 end
@@ -118,7 +231,9 @@ package("qtbase")
             end
             arch = "win" .. winarch .. "_" .. compiler_version
         elseif package:is_plat("linux") then
-            if version:ge("6.7.0") then
+            if package:is_arch("arm64.*", "aarch64") then
+                arch = "linux_gcc_arm64"
+            elseif version:ge("6.7.0") then
                 arch = "linux_gcc_64"
             else
                 arch = "gcc_64"
@@ -141,133 +256,69 @@ package("qtbase")
             else
                 arch = "android"
             end
+        elseif package:is_plat("iphoneos") then
+            arch = "ios"
+        elseif package:is_plat("wasm") then
+            if version:lt("6.5") then
+                arch = "wasm_32"
+            else
+                arch = "wasm_multithread" -- "wasm_singlethread" is also available as an option.
+            end
         end
 
         local installdir = package:installdir()
-        os.vrunv("aqt", {"install-qt", "-O", installdir, host, target, versionstr, arch})
+        local aqt_args = {"install-qt", "-O", installdir, pseudo_host, target, versionstr, arch}
+
+        if package:config("tools_only") then
+            -- Attempt to reduce the installation size by specifying only the required archives
+            local archives = {
+                "qtbase",        -- For qmake, moc, rcc, uic, windeployqt, androiddeployqt
+                "qttools",       -- For lupdate, lrelease
+                "qtdeclarative"  -- For qml
+            }
+            if is_host("linux") then
+                table.join2(archives, {"icu"})
+            end
+            local available_archives = try {
+                function()
+                    return os.iorunv("aqt", {"list-qt", pseudo_host, target, "--archives", versionstr, arch}):split(" ")
+                end
+            } or {}
+            local specify_archives = true
+            for _, archive in ipairs(archives) do
+                if not table.contains(available_archives, archive) then
+                    specify_archives = false
+                    break
+                end
+            end
+            if specify_archives then
+                table.insert(aqt_args, "--archives")
+                table.join2(aqt_args, archives)
+            end
+        end
+
+        os.vrunv("aqt", aqt_args)
 
         -- move files to root
         os.mv(path.join(installdir, versionstr, "*", "*"), installdir)
         os.rmdir(path.join(installdir, versionstr))
 
-        -- special case for cross-compilation since we need binaries we can run on the host
-        if package:is_cross() then
-            local runhost
-            if is_host("windows") then
-                runhost = "windows"
-            elseif is_host("linux") then
-                runhost = "linux"
-            elseif is_host("macosx") then
-                runhost = "mac"
-            else
-                raise("unhandled host " .. os.host())
-            end
-
-            local hostarch
-            if is_host("windows") then
-                local winarch
-                if os.arch():find("64", 1, true) then
-                    winarch = "64"
-                else
-                    winarch = "32"
-                end
-
-                local compiler_version
-                local vs = package:toolchain("msvc"):config("vs")
-                if version:ge("6.8") then
-                    compiler_version = "msvc2022"
-                elseif tonumber(vs) >= 2019 or version:ge("6.0") then
-                    compiler_version = "msvc2019"
-                elseif vs == "2017" or vs == "2015" then
-                    compiler_version = "msvc" .. vs
-                else
-                    raise("unhandled msvc version " .. vs)
-                end
-
-                if os.arch() == "x64" then
-                    compiler_version = compiler_version .. "_64"
-                elseif os.arch() == "arm64" then
-                    compiler_version = compiler_version .. "_arm64"
-                end
-                hostarch = "win" .. winarch .. "_" .. compiler_version
-            elseif is_host("linux") then
-                if version:ge("6.7.0") then
-                    arch = "linux_gcc_64"
-                else
-                    arch = "gcc_64"
-                end
-            elseif is_host("macosx") then
-                hostarch = "clang_64"
-            end
-
-            -- download qtbase to bin_host folder
-            os.vrunv("aqt", {"install-qt", "-O", path.join(installdir, "bin_host"), runhost, "desktop", versionstr, hostarch})
-
-            -- add symbolic links for useful tools
-            local tool_folders = {}
-            if version:ge("6.0") then
-                tool_folders.bin = {
-                    qmake = true,
-                    qmake6 = true
-                }
-
-                tool_folders.libexec = {
-                    moc = true,
-                    rcc = true,
-                    uic = true
-                }
-            else
-                tool_folders.bin = {
-                    qmake = true,
-                    moc = true,
-                    rcc = true,
-                    uic = true
-                }
-            end
-
-            for folder, tools in pairs(tool_folders) do
-                for _, file in ipairs(os.files(path.join(installdir, "bin_host", versionstr, "*", folder, "*"))) do
-                    local filename = path.filename(file)
-                    if tools[filename] then
-                        local targetpath = path.join(installdir, folder, filename)
-                        os.rm(targetpath)
-                        if is_host("windows") then
-                            os.cp(file, targetpath)
-                        else
-                            os.ln(file, targetpath)
-                        end
-
-                        -- some tools like CMake will try to run moc.exe even on Linux, trick them (ln bin/moc.exe => bin_host/bin/moc)
-                        if package:is_plat("mingw") then
-                            os.rm(targetpath .. ".exe")
-                            if is_host("windows") then
-                                os.cp(file, targetpath .. ".exe")
-                            else
-                                os.ln(file, targetpath .. ".exe")
-                            end
-                        end
-                    end
-                end
-            end
-        end
     end)
 
     on_test(function (package)
+        import("lib.detect.find_file")
+
         local qt = assert(package:data("qt"))
 
+        local search_dirs = {}
+        if qt.bindir_host then table.insert(search_dirs, qt.bindir_host) end
+        if qt.bindir then table.insert(search_dirs, qt.bindir) end
+        if qt.libexecdir_host then table.insert(search_dirs, qt.libexecdir_host) end
+        if qt.libexecdir then table.insert(search_dirs, qt.libexecdir) end
+
         local function getbin(name)
-            if is_host("windows") then
-                name = name .. ".exe"
-            end
-            local exec = path.join(qt.bindir, name)
-            if not os.isexec(exec) and qt.libexecdir then
-                exec = path.join(qt.libexecdir, name)
-            end
-            if not os.isexec(exec) and qt.libexecdir_host then
-                exec = path.join(qt.libexecdir_host, name)
-            end
-            assert(os.isexec(exec), name .. " not found!")
-            return exec
+            name = name .. (is_host("windows") and ".exe" or "")
+            return assert(find_file(name, search_dirs), name .. " not found!")
         end
 
         os.vrun(getbin("qmake") .. " -v")


### PR DESCRIPTION
This PR improves cross-compilation workflows by introducing a new `qt-tools` package, which provides the essential host tools required for building Qt applications in cross-compilation environments.

#### Example Usage

For a simple Qt Widgets application created using the command:

```bash
xmake create -l c++ -t qt.widgetapp
```

Update the `xmake.lua` file as follows:

```diff
add_rules("mode.debug", "mode.release")
+ add_requires("qt6widgets")

target("test")
    add_rules("qt.widgetapp")
+   add_packages("qt6widgets")

    add_headerfiles("src/*.h")
    add_files("src/*.cpp")
    add_files("src/mainwindow.ui")
    -- Add files with Q_OBJECT meta (only for qt.moc)
    add_files("src/mainwindow.h")
```

To build the project for MinGW on Linux, run:

```bash
xmake f -c -vD -p mingw
```

This command will automatically install all required packages, including `qt6base`, `qt6core`, `qt6gui`, and `qt-tools`.

Alternatively, we can specify a host Qt SDK using the `--qt_host` option:

```bash
xmake f -c -vD -p mingw --qt_host=<host Qt>
```

- If the host Qt SDK version matches the target Qt SDK version, the host tools will be used directly.
- If the versions differ, the `qt-tools` package will be installed to ensure compatibility.