### PR TITLE
Auto-update quantlib to 1.37

### DIFF
--- a/packages/q/quantlib/xmake.lua
+++ b/packages/q/quantlib/xmake.lua
@@ -5,6 +5,7 @@ package("quantlib")
     add_urls("https://github.com/lballabio/QuantLib/releases/download/v$(version)/QuantLib-$(version).tar.gz",
              "https://github.com/lballabio/QuantLib.git")
 
+    add_versions("1.37", "b284e54ef2133c9eccccc23e210ae5b41b2f37c797b3d7257492a391e436ad24")
     add_versions("1.35", "fd83657bbc69d8692065256699b7424d5a606dff03e7136a820b6e9675016c89")
     add_versions("1.34", "eb87aa8ced76550361771e167eba26aace018074ec370f7af49a01aa56b2fe50")
     add_versions("1.33", "4810d789261eb36423c7d277266a6ee3b28a3c05af1ee0d45544ca2e0e8312bd")


### PR DESCRIPTION
New version of quantlib detected (package version: 1.35, last github version: 1.37)