### PR TITLE
Auto-update arduinojson to v7.3.0

### DIFF
--- a/packages/a/arduinojson/xmake.lua
+++ b/packages/a/arduinojson/xmake.lua
@@ -7,6 +7,7 @@ package("arduinojson")
     add_urls("https://github.com/bblanchon/ArduinoJson/archive/refs/tags/$(version).tar.gz",
              "https://github.com/bblanchon/ArduinoJson.git")
 
+    add_versions("v7.3.0", "e2b6739a00c64813169cbcea2d0884cbd63efe2223c0b1307de4e655d87730d8")
     add_versions("v7.2.1", "2780504927533d64cf4256c57de51412b835b327ef4018c38d862b0664d36d4f")
     add_versions("v7.2.0", "d20aefd14f12bd907c6851d1dfad173e4fcd2d993841fa8c91a1d8ab5a71188b")
     add_versions("v7.1.0", "74bc745527a274bcab85c6498de77da749627113c4921ccbcaf83daa7ac35dee")


### PR DESCRIPTION
New version of arduinojson detected (package version: v7.2.1, last github version: v7.3.0)