### PR TITLE
Auto-update dispenso to v1.4.0

### DIFF
--- a/packages/d/dispenso/xmake.lua
+++ b/packages/d/dispenso/xmake.lua
@@ -6,6 +6,7 @@ package("dispenso")
     add_urls("https://github.com/facebookincubator/dispenso/archive/refs/tags/$(version).tar.gz",
              "https://github.com/facebookincubator/dispenso.git")
 
+    add_versions("v1.4.0", "d1c84ba77d6d3a0da24010a930c81acb4c149532afd8ab352c9cae54c51b6f72")
     add_versions("v1.3.0", "824afe8d0d36bfd9bc9b1cbe9be89e7f3ed642a3612766d1c99d5f8dfc647c63")
     add_versions("v1.2.0", "a44d9cf2f9234f5cbdbe4050fd26e63f3266b64955731651adf04dbb7f6b31df")
     add_versions("v1.1.0", "581f95c16cd479692bc89448d0648f6ce24162454308c544c4d35bf5e9efe5c8")


### PR DESCRIPTION
New version of dispenso detected (package version: v1.3.0, last github version: v1.4.0)