### PR TITLE
ufbx: install extra files to includedir

### DIFF
--- a/packages/u/ufbx/xmake.lua
+++ b/packages/u/ufbx/xmake.lua
@@ -28,6 +28,7 @@ package("ufbx")
                 end
         ]])
         import("package.tools.xmake").install(package)
+        os.trycp("extra/*", package:installdir("include"))
     end)
 
     on_test(function (package)


### PR DESCRIPTION
Install the files under the "extra" folder for convenient use in C++ project and others.
