### PR TITLE
Auto-update cppfront to v0.8.1

### DIFF
--- a/packages/c/cppfront/xmake.lua
+++ b/packages/c/cppfront/xmake.lua
@@ -5,6 +5,7 @@ package("cppfront")
 
     add_urls("https://github.com/hsutter/cppfront/archive/refs/tags/$(version).tar.gz")
     add_urls("https://github.com/hsutter/cppfront.git")
+    add_versions("v0.8.1", "aff7c8106c1022d74dcd2e66452f8e7cbafeeecb61679f7116a383a1100cc4b5")
     add_versions("v0.8.0", "7fb573599960bc0a46a71ed103ff97adbf938d4a0df754dc952a44fdcacfc571")
     add_versions("v0.7.4", "028f44cc0cad26b51829e4abf7c5aedf8a31f852ab5dfbad54bb232f0a1d7447")
     add_versions("v0.7.2", "fb44c6a65fa19b185ddf385dd3bfea05afe0bc8260382b7a8e3c75b3c9004cd6")


### PR DESCRIPTION
New version of cppfront detected (package version: v0.8.0, last github version: v0.8.1)