### PR TITLE
Auto-update node-api-headers to v1.5.0

### DIFF
--- a/packages/n/node-api-headers/xmake.lua
+++ b/packages/n/node-api-headers/xmake.lua
@@ -6,6 +6,7 @@ package("node-api-headers")
 
     set_urls("https://github.com/nodejs/node-api-headers/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nodejs/node-api-headers.git")
+    add_versions("v1.5.0", "c31ce81b98b034d6daaa2b97112ba83b51b6e4454bea00696bbc7881e851a29c")
     add_versions("v1.4.0", "08a96c351ab5cb0aaac55e292eb3e8b63b0b82324cb8182cc8d6c30d9bade595")
     add_versions("v1.3.0", "40f24f2088868fc564876b04547708e257fe7c445128a0c4f787dc3aa08eac9f")
     add_versions("v1.2.0", "deda1c8536ebae8b0a35c26d8547e23061c7d3cffd05ea70046be1c7c0efc2d0")


### PR DESCRIPTION
New version of node-api-headers detected (package version: v1.4.0, last github version: v1.5.0)