### PR TITLE
lock scnlib's fast_float dependency to below 7.0.0

### DIFF
--- a/packages/s/scnlib/xmake.lua
+++ b/packages/s/scnlib/xmake.lua
@@ -18,7 +18,7 @@ package("scnlib")
     add_configs("rtti", {description = "Enable rtti", default = true, type = "boolean"})
     add_configs("regex", {description = "Regex backend to use", type = "string", values = {"std", "boost", "re2"}})
 
-    add_deps("fast_float")
+    add_deps("fast_float <7.0.0")
 
     on_check("windows", function (package)
         import("core.tool.toolchain")


### PR DESCRIPTION
Currently, scnlib failed to compile and run with fast_float 7.0.0 and above. See [their issue](https://github.com/eliaskosunen/scnlib/pull/136). We hereby manually limit the version of fast_float in scnlib's dependencies.
