### PR TITLE
fix: syslink missing on linux in webui.

### DIFF
--- a/packages/w/webui/xmake.lua
+++ b/packages/w/webui/xmake.lua
@@ -17,13 +17,7 @@ package("webui")
         add_syslinks("pthread", "dl")
     end
 
-    if on_check then
-        on_check("mingw", function (package)
-            assert(package:is_arch("x86_64"), "package(webui/mingw) only suport x86_64 arch")
-        end)
-    end
-
-    on_install("windows", "linux", "macosx", "mingw", "msys", "android", "cross", function (package)
+    on_install("windows", "linux", "macosx", "mingw|x86_64", "msys", "android", "cross", function (package)
         if package:is_plat("android") and package:is_arch("armeabi-v7a") then
             import("core.tool.toolchain")
             local ndk = toolchain.load("ndk", {plat = package:plat(), arch = package:arch()})

--- a/packages/w/webui/xmake.lua
+++ b/packages/w/webui/xmake.lua
@@ -41,6 +41,8 @@ package("webui")
                     add_syslinks("user32", "advapi32", "shell32")
                 elseif is_plat("mingw") then
                     add_syslinks("ws2_32")
+                elseif is_plat("linux") then
+                    add_syslinks("pthread", "dl")
                 end
         ]])
         import("package.tools.xmake").install(package)

--- a/packages/w/webui/xmake.lua
+++ b/packages/w/webui/xmake.lua
@@ -13,6 +13,8 @@ package("webui")
         add_syslinks("user32", "advapi32", "shell32")
     elseif is_plat("mingw") then
         add_syslinks("ws2_32")
+    elseif is_plat("linux") then
+        add_syslinks("pthread", "dl")
     end
 
     on_install("windows", "linux", "macosx", "mingw", "msys", "android", "cross", function (package)

--- a/packages/w/webui/xmake.lua
+++ b/packages/w/webui/xmake.lua
@@ -17,6 +17,12 @@ package("webui")
         add_syslinks("pthread", "dl")
     end
 
+    if on_check then
+        on_check("mingw", function (package)
+            assert(package:is_arch("x86_64"), "package(webui/mingw) only suport x86_64 arch")
+        end)
+    end
+
     on_install("windows", "linux", "macosx", "mingw", "msys", "android", "cross", function (package)
         if package:is_plat("android") and package:is_arch("armeabi-v7a") then
             import("core.tool.toolchain")


### PR DESCRIPTION
WebUI 在 Linux 上需要链接 pthread 和 libdl，这些在高版本 gcc 上会自动链接，但在低版本 gcc(<=8) 上需要手动链接。

