### PR TITLE
Auto-update portable_build_tools to v2.10

### DIFF
--- a/packages/p/portable_build_tools/xmake.lua
+++ b/packages/p/portable_build_tools/xmake.lua
@@ -5,6 +5,7 @@ package("portable_build_tools")
 
     add_urls("https://github.com/Data-Oriented-House/PortableBuildTools/releases/download/$(version)/PortableBuildTools.exe")
 
+    add_versions("v2.10", "1435bc69b725d51168a3403ec4b25dfffe8ce09b942f8be0184adb61638238f8")
     add_versions("v2.9.2", "d2e432cba14ec405460b0a7d3950d16df9d1cc9e64b48c03fa6e324c96b1105b")
     add_versions("v2.8.1", "5663660d0e61cdc7e57a74a8dfc30337895a1cd56d345fe62556bcdb6b896d84")
     add_versions("v2.8", "d3a419be62856ab8896004f91af58f5928ce7c536954398d02a8b99202c4808f")


### PR DESCRIPTION
New version of portable_build_tools detected (package version: v2.9.2, last github version: v2.10)