### PR TITLE
Auto-update clay to v0.13

### DIFF
--- a/packages/c/clay/xmake.lua
+++ b/packages/c/clay/xmake.lua
@@ -7,6 +7,7 @@ package("clay")
     add_urls("https://github.com/nicbarker/clay/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nicbarker/clay.git")
 
+    add_versions("v0.13", "c4b0e765e1b60cdcbdf25bf2f76a914f9f5dbee40900c261d691ce3fa46d3870")
     add_versions("v0.12", "b36f19352635edeb6d770fe77fab267982d9f206beb541849578de9f0aaff825")
 
     add_configs("renderer", {description = "Enable renderer", default = true, type = "boolean"})


### PR DESCRIPTION
New version of clay detected (package version: v0.12, last github version: v0.13)