### PR TITLE
Auto-update sol2 to v3.3.1

### DIFF
--- a/packages/s/sol2/xmake.lua
+++ b/packages/s/sol2/xmake.lua
@@ -6,6 +6,7 @@ package("sol2")
     set_urls("https://github.com/ThePhD/sol2/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ThePhD/sol2.git")
 
+    add_versions("v3.3.1", "ad121461047d52b449aa84234a6b578fa3ed95d67d1a0703902eba72417f61bb")
     add_versions("v3.3.0", "b82c5de030e18cb2bcbcefcd5f45afd526920c517a96413f0b59b4332d752a1e")
     add_versions("v3.2.3", "f74158f92996f476786be9c9e83f8275129bb1da2a8d517d050421ac160a4b9e")
     add_versions("v3.2.2", "141790dae0c1821dd2dbac3595433de49ba72545845efc3ec7d88de8b0a3b2da")


### PR DESCRIPTION
New version of sol2 detected (package version: v3.3.0, last github version: v3.3.1)