### PR TITLE
Auto-update vk-bootstrap to v1.4.307

### DIFF
--- a/packages/v/vk-bootstrap/xmake.lua
+++ b/packages/v/vk-bootstrap/xmake.lua
@@ -6,6 +6,7 @@ package("vk-bootstrap")
     add_urls("https://github.com/charles-lunarg/vk-bootstrap/archive/refs/tags/$(version).tar.gz",
              "https://github.com/charles-lunarg/vk-bootstrap.git")
 
+    add_versions("v1.4.307", "b7d1b0868de16244cb666b0777ab62a38c6d99c29b85ef33be8ce36005cd0732")
     add_versions("v1.3.302", "3b7eb60443cb7c8a334d7a76766e8f703d9e81b43fa8b5bd2983578cbb373970")
     add_versions("v1.3.295", "fff665c8675a7730777279ad9caba8c229d7fc79f35a9dad52873d1fa598b495")
     add_versions("v1.3.292", "0853ab291ab7b19779582ada1d6a245dcd0489c2e346ee1e4275c24d3788077a")


### PR DESCRIPTION
New version of vk-bootstrap detected (package version: v1.3.302, last github version: v1.4.307)