### PR TITLE
Auto-update boost_ut to v2.3.0

### DIFF
--- a/packages/b/boost_ut/xmake.lua
+++ b/packages/b/boost_ut/xmake.lua
@@ -6,6 +6,7 @@ package("boost_ut")
 
     add_urls("https://github.com/boost-ext/ut/archive/refs/tags/$(version).tar.gz")
     add_urls("https://github.com/boost-ext/ut.git")
+    add_versions("v2.3.0", "9c07a2b7947cc169fc1713ad462ccc43a704076447893a1fd25bdda5eec4aab6")
     add_versions("v2.1.1", "016ac5ece1808cd1100be72f90da4fa59ea41de487587a3283c6c981381cc216")
     add_versions("v2.1.0", "1c9c35c039ad3a9795a278447db6da0a4ec1a1d223bf7d64687ad28f673b7ae8")
     add_versions("v1.1.9", "1a666513157905aa0e53a13fac602b5673dcafb04a869100a85cd3f000c2ed0d")


### PR DESCRIPTION
New version of boost_ut detected (package version: v2.1.1, last github version: v2.3.0)