### PR TITLE
Auto-update glaze to v4.4.2

### DIFF
--- a/packages/g/glaze/xmake.lua
+++ b/packages/g/glaze/xmake.lua
@@ -7,6 +7,7 @@ package("glaze")
     add_urls("https://github.com/stephenberry/glaze/archive/refs/tags/$(version).tar.gz",
              "https://github.com/stephenberry/glaze.git")
 
+    add_versions("v4.4.2", "5f9c8efe35491f90755ef7a9d392ddd2ac395fd2e005e3ca61b5daf54ebfc9de")
     add_versions("v4.2.2", "965e32de67e60d185402e8cfe684c6d40c1f018a4fa5e781b11b0cac0817edb9")
     add_versions("v4.0.1", "0026aca33201ee6d3a820fb5926f36ba8c838bfd3120e2e179b0eee62b5bd231")
     add_versions("v3.6.2", "74b14656b7a47c0a03d0a857adf5059e8c2351a7a84623593be0dd16b293216c")


### PR DESCRIPTION
New version of glaze detected (package version: v4.2.2, last github version: v4.4.2)