### PR TITLE
Auto-update c4core to 0.2.5

### DIFF
--- a/packages/c/c4core/xmake.lua
+++ b/packages/c/c4core/xmake.lua
@@ -6,6 +6,7 @@ package("c4core")
     add_urls("https://github.com/biojppm/c4core/releases/download/v$(version)/c4core-$(version)-src.zip",
              "https://github.com/biojppm/c4core.git")
 
+    add_versions("0.2.5", "3d87765a612d72182d161f0bea401adf6f0df1c65fba54fb7f0727fa8585d0d2")
     add_versions("0.2.2", "5a9508385daa5b2608ed007784d76586af21c5367411efe9ae26d5b4aea03305")
     add_versions("0.2.1", "81ff1c0d15e24da6d76fdd1b6fdd903fa23d0df7c82e564f993147a4dac88773")
 


### PR DESCRIPTION
New version of c4core detected (package version: 0.2.2, last github version: 0.2.5)