### PR TITLE
Fix syslink missing in webui 2.5.0

### DIFF
--- a/packages/w/webui/xmake.lua
+++ b/packages/w/webui/xmake.lua
@@ -10,7 +10,7 @@ package("webui")
     add_versions("2.3.0", "14be57405b12cf434daade2310178534240866e3169c7213a6fa0e4a6c6f9f27")
 
     if is_plat("windows") then
-        add_syslinks("user32", "advapi32", "shell32")
+        add_syslinks("user32", "advapi32", "shell32", "ws2_32", "ole32")
     elseif is_plat("mingw") then
         add_syslinks("ws2_32")
     elseif is_plat("linux") then
@@ -38,7 +38,7 @@ package("webui")
                 add_headerfiles("include/webui.h", "include/webui.hpp")
                 add_includedirs("include", "src/civetweb")
                 if is_plat("windows") then
-                    add_syslinks("user32", "advapi32", "shell32")
+                    add_syslinks("user32", "advapi32", "shell32", "ws2_32", "ole32")
                 elseif is_plat("mingw") then
                     add_syslinks("ws2_32")
                 elseif is_plat("linux") then


### PR DESCRIPTION
在 [WebUI 2.5.0](https://github.com/webui-dev/webui) 中，在 Windows 上编译 WebUI 需要添加额外的 syslinks：ws2_32, ole32，否则会出错：

```
error: ...xmake\repositories\xmake-repo\packages\w\webui\xmake.lua:52: ...e-cache\core\sandbox\modules\import\core\tool\linker.lua:75: .\.xmake-cache\modules\core\tools\link.lua:175:    Creating library C:\Users\RUNNER~1\AppData\Local\Temp\.xmake\250219\_42B3F84178514750872955E65EB6BE80.lib and object C:\Users\RUNNER~1\AppData\Local\Temp\.xmake\250219\_42B3F84178514750872955E65EB6BE80.exp
webui.lib(webui.c.obj) : error LNK2019: unresolved external symbol __imp_CoTaskMemFree referenced in function TitleChanged_Invoke
C:\Users\RUNNER~1\AppData\Local\Temp\.xmake\250219\_42B3F84178514750872955E65EB6BE80.b : fatal error LNK1120: 1 unresolved externals

stack traceback:
    [C]: in function 'error'
    [.\.xmake-cache\core\base\os.lua:1075]:
    [.\.xmake-cache\modules\core\tools\link.lua:175]: in function 'catch'
    [.\.xmake-cache\core\sandbox\modules\try.lua:123]: in function 'try'
    [.\.xmake-cache\modules\core\tools\link.lua:151]:
    [C]: in function 'xpcall'
    [.\.xmake-cache\core\base\utils.lua:246]:
    [.\.xmake-cache\core\tool\linker.lua:232]: in function 'link'
    [...e-cache\core\sandbox\modules\import\core\tool\linker.lua:73]: in function 'link'
    [.\.xmake-cache\modules\lib\detect\check_cxsnippets.lua:249]:
    [C]: in function 'xpcall'
    [.\.xmake-cache\core\base\utils.lua:246]: in function 'trycall'
    [.\.xmake-cache\core\sandbox\modules\try.lua:117]: in function 'try'
    [.\.xmake-cache\modules\lib\detect\check_cxsnippets.lua:237]:
    [...xmake\repositories\xmake-repo\packages\w\webui\xmake.lua:52]: in function 'script'
    [...che\modules\private\action\require\impl\utils\filter.lua:114]: in function 'call'
    [...che\modules\private\action\require\impl\actions\test.lua:41]:
    [...\modules\private\action\require\impl\actions\install.lua:495]:
    [C]: in function 'xpcall'
    [.\.xmake-cache\core\base\utils.lua:246]: in function 'trycall'
    [.\.xmake-cache\core\sandbox\modules\try.lua:117]: in function 'try'
    [...\modules\private\action\require\impl\actions\install.lua:419]:
    [...modules\private\action\require\impl\install_packages.lua:510]: in function 'jobfunc'
    [.\.xmake-cache\modules\async\runjobs.lua:241]:
    [C]: in function 'xpcall'
    [.\.xmake-cache\core\base\utils.lua:246]: in function 'trycall'
    [.\.xmake-cache\core\sandbox\modules\try.lua:117]: in function 'try'
    [.\.xmake-cache\modules\async\runjobs.lua:224]: in function 'cotask'
    [.\.xmake-cache\core\base\scheduler.lua:406]:

  => install webui nightly .. failed
```
我个人实测实际上只要`add_syslinks("ole32")`就可以正常编译了，不过保险起见还是把两个都加了进来。

详见：https://github.com/webui-dev/webui/blob/main/build.zig
![图片](https://github.com/user-attachments/assets/9020b9cc-d195-4d4a-9467-1caa222ec11f)


