### PR TITLE
Auto-update cgif to v0.5.0

### DIFF
--- a/packages/c/cgif/xmake.lua
+++ b/packages/c/cgif/xmake.lua
@@ -6,6 +6,7 @@ package("cgif")
     add_urls("https://github.com/dloebl/cgif/archive/refs/tags/$(version).tar.gz",
              "https://github.com/dloebl/cgif.git")
 
+    add_versions("v0.5.0", "d6cb312c7da2c6c9f310811aa3658120c0316ba130c48a012e7baf3698920fe9")
     add_versions("v0.4.1", "8666f9c5f8123d1c22137a6dd714502a330377fb74e2007621926fe4258529d5")
     add_versions("v0.4.0", "130ff8a604f047449e81ddddf818bd0e03826b5f468e989b02726b16b7d4742e")
 


### PR DESCRIPTION
New version of cgif detected (package version: v0.4.1, last github version: v0.5.0)