### PR TITLE
Auto-update re-flex to v5.2.2

### DIFF
--- a/packages/r/re-flex/xmake.lua
+++ b/packages/r/re-flex/xmake.lua
@@ -6,6 +6,7 @@ package("re-flex")
     add_urls("https://github.com/Genivia/RE-flex/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Genivia/RE-flex.git")
 
+    add_versions("v5.2.2", "be7f4adb3141dcb9079f5431f36f35ed553d972eb76565e3bb36da635d9aa126")
     add_versions("v5.0.1", "b74430fe63a6e3e665676d23601e332fcf12714efb798661bf307cb7a230ca4f")
     add_versions("v4.5.0", "30a503087c4ea7c2f81ef8b7f1c54ea10c3f26ab3a372d2c874273ee5e643472")
     add_versions("v4.4.0", "3b34d0c88f91db6b5387355a64a84bfa6464d90fb182aab05c367605db28d2e8")


### PR DESCRIPTION
New version of re-flex detected (package version: v5.0.1, last github version: v5.2.2)