### PR TITLE
ffmpeg: improve version parsing logic

### DIFF
--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -76,21 +76,15 @@ package("ffmpeg")
             local result
             for _, name in ipairs({"libavcodec", "libavdevice", "libavfilter", "libavformat", "libavutil", "libpostproc", "libswresample", "libswscale"}) do
                 local pkginfo = package:find_package("pkgconfig::" .. name, opt)
-                if pkginfo then
-                    pkginfo.version = nil
-                    if not result then
-                        result = pkginfo
-                    else
-                        result = result .. pkginfo
-                    end
-                else
+                if not pkginfo then
                     return
                 end
+                result = (result and result .. pkginfo) or pkginfo
             end
-            local ffmpeg = find_tool("ffmpeg", {check = "-help", version = true, command = "-version", parse = "%d+%.?%d+%.?%d+", force = true})
-            if ffmpeg then
-                result.version = ffmpeg.version
-            end
+            result.shared = result.shared and true
+            result.static = result.static and true
+            local ffmpeg = find_tool("ffmpeg", {check = "-help", version = true, command = "-version", parse = "ffmpeg version%s+n*(%S+)", force = true})
+            result.version = ffmpeg and ffmpeg.version
             return result
         end
     end)

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -80,8 +80,6 @@ package("ffmpeg")
                 end
                 result = (result and result .. pkginfo) or pkginfo
             end
-            result.shared = result.shared and true
-            result.static = result.static and true
             local ffmpeg = package:find_tool("ffmpeg", {check = "-help", version = true, command = "-version", parse = "ffmpeg version%s+n*(%S+)", force = true})
             result.version = ffmpeg and ffmpeg.version
             return result

--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -71,7 +71,6 @@ package("ffmpeg")
     end
 
     on_fetch("mingw", "linux", "macosx", function (package, opt)
-        import("lib.detect.find_tool")
         if opt.system then
             local result
             for _, name in ipairs({"libavcodec", "libavdevice", "libavfilter", "libavformat", "libavutil", "libpostproc", "libswresample", "libswscale"}) do
@@ -83,7 +82,7 @@ package("ffmpeg")
             end
             result.shared = result.shared and true
             result.static = result.static and true
-            local ffmpeg = find_tool("ffmpeg", {check = "-help", version = true, command = "-version", parse = "ffmpeg version%s+n*(%S+)", force = true})
+            local ffmpeg = package:find_tool("ffmpeg", {check = "-help", version = true, command = "-version", parse = "ffmpeg version%s+n*(%S+)", force = true})
             result.version = ffmpeg and ffmpeg.version
             return result
         end


### PR DESCRIPTION
This PR attempts to ~~correct the `shared` field and~~ (solved by https://github.com/xmake-io/xmake/commit/4abb777fb6cdca3bfeebfd2ae2b2f4a2d4089dad) improve the version parsing logic. However, since `ffmpeg` does not adhere to a common pattern for version strings, there may still be cases where the version is inaccurate.