### PR TITLE
Add new package cwt-cucumber 2.5

### DIFF
--- a/packages/c/cwt-cucumber/xmake.lua
+++ b/packages/c/cwt-cucumber/xmake.lua
@@ -17,7 +17,7 @@ package("cwt-cucumber")
     end)
 
     on_check("macosx", function (package)
-        if macos.version():le("13.7") then
+        if macos.version():le("14") then
             raise("package(cwt-cucumber): requires macOS version >= 14.5")
         end
     end)

--- a/packages/c/cwt-cucumber/xmake.lua
+++ b/packages/c/cwt-cucumber/xmake.lua
@@ -25,7 +25,7 @@ package("cwt-cucumber")
         if package:config("shared") and package:is_plat("windows") then
             table.insert(configs, "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON")
         end
-        import("package.tools.cmake").install(package, configs, {cxflags = "-fexperimental-library"})
+        import("package.tools.cmake").install(package, configs, {cxxflags = "-fexperimental-library"})
     end)
 
     on_test(function (package)

--- a/packages/c/cwt-cucumber/xmake.lua
+++ b/packages/c/cwt-cucumber/xmake.lua
@@ -19,7 +19,7 @@ package("cwt-cucumber")
     on_install(function (package)
         local opt = {}
         if package:is_plat("macosx") then
-            opt.cxxflags = "-fexperimental-library"
+            opt.ldflags = "-fexperimental-library"
         end
         io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/examples)", "", {plain = true})
         io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/gtest)", "", {plain = true})

--- a/packages/c/cwt-cucumber/xmake.lua
+++ b/packages/c/cwt-cucumber/xmake.lua
@@ -17,9 +17,6 @@ package("cwt-cucumber")
     end)
 
     on_install(function (package)
-        if package:is_plat("macosx") then
-            package:add("cxxflags", "-fexperimental-library")
-        end
         io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/examples)", "", {plain = true})
         io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/gtest)", "", {plain = true})
         local configs = {}
@@ -28,7 +25,7 @@ package("cwt-cucumber")
         if package:config("shared") and package:is_plat("windows") then
             table.insert(configs, "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON")
         end
-        import("package.tools.cmake").install(package, configs)
+        import("package.tools.cmake").install(package, configs, {cxflags = "-fexperimental-library"})
     end)
 
     on_test(function (package)

--- a/packages/c/cwt-cucumber/xmake.lua
+++ b/packages/c/cwt-cucumber/xmake.lua
@@ -17,6 +17,10 @@ package("cwt-cucumber")
     end)
 
     on_install(function (package)
+        local opt = {}
+        if package:is_plat("macosx") then
+            opt.cxxflags = "-fexperimental-library"
+        end
         io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/examples)", "", {plain = true})
         io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/gtest)", "", {plain = true})
         local configs = {}
@@ -25,7 +29,7 @@ package("cwt-cucumber")
         if package:config("shared") and package:is_plat("windows") then
             table.insert(configs, "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON")
         end
-        import("package.tools.cmake").install(package, configs, {cxxflags = "-fexperimental-library"})
+        import("package.tools.cmake").install(package, configs, opt)
     end)
 
     on_test(function (package)

--- a/packages/c/cwt-cucumber/xmake.lua
+++ b/packages/c/cwt-cucumber/xmake.lua
@@ -8,7 +8,8 @@ package("cwt-cucumber")
 
     add_versions("2.5", "793d07c2f1989a2943befd4344cb8a49f36d39bdc0d596dbebbbc50e25fa3bc5")
 
-    add_deps("cmake", "nlohmann_json")
+    add_deps("cmake")
+    add_deps("nlohmann_json", {configs = {cmake = true}})
 
     on_install(function (package)
         io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/examples)", "", {plain = true})

--- a/packages/c/cwt-cucumber/xmake.lua
+++ b/packages/c/cwt-cucumber/xmake.lua
@@ -23,7 +23,6 @@ package("cwt-cucumber")
         if package:is_plat("macosx") then
             package:add("cxxflags", "-fexperimental-library")
             table.insert(configs, "-DCMAKE_CXX_FLAGS=-fexperimental-library")
-            add_syslinks("libc++experimental")
         end
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))

--- a/packages/c/cwt-cucumber/xmake.lua
+++ b/packages/c/cwt-cucumber/xmake.lua
@@ -1,0 +1,41 @@
+package("cwt-cucumber")
+    set_homepage("https://github.com/ThoSe1990/cwt-cucumber")
+    set_description("A C++ Cucumber interpreter")
+    set_license("MIT")
+
+    add_urls("https://github.com/ThoSe1990/cwt-cucumber/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/ThoSe1990/cwt-cucumber.git")
+
+    add_versions("2.5", "793d07c2f1989a2943befd4344cb8a49f36d39bdc0d596dbebbbc50e25fa3bc5")
+
+    add_deps("cmake", "nlohmann_json")
+
+    on_install(function (package)
+        io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/examples)", "", {plain = true})
+        io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/gtest)", "", {plain = true})
+        local configs = {}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+        struct foo {
+            std::string word;
+            std::string anonymous;
+        };
+        WHEN(word_anonymous_given, "A {word} and {}") {
+            std::string word = CUKE_ARG(1);
+            cuke::context<foo>().word = word;
+            std::string anonymous = CUKE_ARG(2);
+            cuke::context<foo>().anonymous = anonymous;
+        }
+        THEN(word_anonymous_then, "They will match {string} and {string}") {
+            std::string expected_word = CUKE_ARG(1);
+            std::string expected_anonymous = CUKE_ARG(2);
+            cuke::equal(expected_word, cuke::context<foo>().word);
+            cuke::equal(expected_anonymous, cuke::context<foo>().anonymous);
+        }
+        ]]}, {configs = {languages = "c++20"}, includes = {"cwt-cucumber/cucumber.hpp"}}))
+    end)

--- a/packages/c/cwt-cucumber/xmake.lua
+++ b/packages/c/cwt-cucumber/xmake.lua
@@ -23,6 +23,7 @@ package("cwt-cucumber")
         if package:is_plat("macosx") then
             package:add("cxxflags", "-fexperimental-library")
             table.insert(configs, "-DCMAKE_CXX_FLAGS=-fexperimental-library")
+            add_syslinks("c++experimental")
         end
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))

--- a/packages/c/cwt-cucumber/xmake.lua
+++ b/packages/c/cwt-cucumber/xmake.lua
@@ -17,19 +17,19 @@ package("cwt-cucumber")
     end)
 
     on_install(function (package)
-        local opt = {}
-        if package:is_plat("macosx") then
-            opt.ldflags = "-fexperimental-library"
-        end
         io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/examples)", "", {plain = true})
         io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/gtest)", "", {plain = true})
         local configs = {}
+        if package:is_plat("macosx") then
+            package:add("cxxflags", "-fexperimental-library")
+            table.insert(configs, "-DCMAKE_CXX_FLAGS=-fexperimental-library")
+        end
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         if package:config("shared") and package:is_plat("windows") then
             table.insert(configs, "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON")
         end
-        import("package.tools.cmake").install(package, configs, opt)
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/c/cwt-cucumber/xmake.lua
+++ b/packages/c/cwt-cucumber/xmake.lua
@@ -23,7 +23,7 @@ package("cwt-cucumber")
         if package:is_plat("macosx") then
             package:add("cxxflags", "-fexperimental-library")
             table.insert(configs, "-DCMAKE_CXX_FLAGS=-fexperimental-library")
-            add_syslinks("c++experimental")
+            add_syslinks("libc++experimental")
         end
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))

--- a/packages/c/cwt-cucumber/xmake.lua
+++ b/packages/c/cwt-cucumber/xmake.lua
@@ -16,14 +16,16 @@ package("cwt-cucumber")
         assert(ndk and tonumber(ndk) > 22, "package(cwt-cucumber) require ndk version > 22")
     end)
 
+    on_check("macosx", function (package)
+        if macos.version():le("13.7") then
+            raise("package(cwt-cucumber): requires macOS version >= 14.5")
+        end
+    end)
+
     on_install(function (package)
         io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/examples)", "", {plain = true})
         io.replace("CMakeLists.txt", "add_subdirectory(${PROJECT_SOURCE_DIR}/gtest)", "", {plain = true})
         local configs = {}
-        if package:is_plat("macosx") then
-            package:add("cxxflags", "-fexperimental-library")
-            table.insert(configs, "-DCMAKE_CXX_FLAGS=-fexperimental-library")
-        end
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         if package:config("shared") and package:is_plat("windows") then


### PR DESCRIPTION
https://cucumber.io/
```cpp
#include <cwt-cucumber/cucumber.hpp>
```
I kept trying to ```add_cxxflags("clang::-fexperimental-library", {force = true})``` within package scope so macos would succeed.
As last logs showup it is maybe missing link to ```libc++experimental.a```. I do not know good solution there, hence existing CI machine clang++13 macosx maybe miss library ```c++experimental```, as per it is not being specified like syslink/link there https://github.com/MorganCaron/Script/blob/08403631fe52876b3d89fc2fb760ef25a0f6f725/xmake.lua#L13 for some reason.
Maybe https://github.com/orgs/Homebrew/discussions/4429 *However, passing the path to homebrew llvm's own libdir gives the expected results:* could help in this case.
Yet I just decide to avoid that flag and do not support it. https://github.com/macports/macports-ports/blob/fad7f0ab45fdbef10754f400cb00ecbd5018526f/lang/macports-libcxx/Portfile#L72