### PR TITLE
Auto-update double-conversion to v3.3.1

### DIFF
--- a/packages/d/double-conversion/xmake.lua
+++ b/packages/d/double-conversion/xmake.lua
@@ -6,6 +6,7 @@ package("double-conversion")
     add_urls("https://github.com/google/double-conversion/archive/refs/tags/$(version).tar.gz",
              "https://github.com/google/double-conversion.git")
 
+    add_versions("v3.3.1", "fe54901055c71302dcdc5c3ccbe265a6c191978f3761ce1414d0895d6b0ea90e")
     add_versions("v3.3.0", "04ec44461850abbf33824da84978043b22554896b552c5fd11a9c5ae4b4d296e")
     add_versions("v3.1.5", "a63ecb93182134ba4293fd5f22d6e08ca417caafa244afaa751cbfddf6415b13")
 

--- a/packages/d/double-conversion/xmake.lua
+++ b/packages/d/double-conversion/xmake.lua
@@ -13,7 +13,7 @@ package("double-conversion")
     add_deps("cmake")
 
     on_install(function (package)
-        local configs = {"-DBUILD_TESTING=OFF"}
+        local configs = {"-DBUILD_TESTING=OFF", "-DCMAKE_POLICY_DEFAULT_CMP0057=NEW"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)


### PR DESCRIPTION
New version of double-conversion detected (package version: v3.3.0, last github version: v3.3.1)