### PR TITLE
Auto-update dpp to v10.1.0

### DIFF
--- a/packages/d/dpp/xmake.lua
+++ b/packages/d/dpp/xmake.lua
@@ -6,6 +6,7 @@ package("dpp")
     add_urls("https://github.com/brainboxdotcc/DPP/archive/refs/tags/$(version).tar.gz",
              "https://github.com/brainboxdotcc/DPP.git")
 
+    add_versions("v10.1.0", "c794053b926c019e8f4771523362ecfdf3038a7899bad4400c163bd1e13584e3")
     add_versions("v10.0.31", "3e392868c0dc3d0f13a00cfa190a925a20bde62bea58fd87d4acf14de11062bf")
     add_versions("v10.0.30", "fb7019770bd5c5f0539523536250da387ee1fa9c92e59c0bcff6c9adaf3d77e8")
     add_versions("v10.0.29", "a37e91fbdabee20cb0313700588db4077abf0ebabafe386457d999d22d2d0682")


### PR DESCRIPTION
New version of dpp detected (package version: v10.0.31, last github version: v10.1.0)