### PR TITLE
Auto-update hlslpp to 3.6

### DIFF
--- a/packages/h/hlslpp/xmake.lua
+++ b/packages/h/hlslpp/xmake.lua
@@ -5,6 +5,7 @@ package("hlslpp")
     set_license("MIT")
 
     add_urls("https://github.com/redorav/hlslpp/archive/refs/tags/$(version).tar.gz")
+    add_versions("3.6", "d23b51e631363e7337e89564014fd5a9b7b12498a0296caddcc8433fb23727b8")
     add_versions("3.5.3", "9be1b0edcd7877da49e5e85473c83eac792ef10dcccd3f1ff18297f2176ac251")
     add_versions("3.5.1", "5f0a89db4b2a8dcf8237463455d6c03e3f9a090117aed2ba07a7309b239bd88c")
     add_versions("3.5", "9553e69181a5cff770fe68c2dc5afcda638b290c2e83dca635ed695e01aa16df")

--- a/packages/h/hlslpp/xmake.lua
+++ b/packages/h/hlslpp/xmake.lua
@@ -4,7 +4,9 @@ package("hlslpp")
     set_description("Math library using hlsl syntax with SSE/NEON support")
     set_license("MIT")
 
-    add_urls("https://github.com/redorav/hlslpp/archive/refs/tags/$(version).tar.gz")
+    add_urls("https://github.com/redorav/hlslpp/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/redorav/hlslpp.git")
+
     add_versions("3.6", "d23b51e631363e7337e89564014fd5a9b7b12498a0296caddcc8433fb23727b8")
     add_versions("3.5.3", "9be1b0edcd7877da49e5e85473c83eac792ef10dcccd3f1ff18297f2176ac251")
     add_versions("3.5.1", "5f0a89db4b2a8dcf8237463455d6c03e3f9a090117aed2ba07a7309b239bd88c")
@@ -13,7 +15,7 @@ package("hlslpp")
     add_versions("3.1", "6f933e43bf8150a41d76a188377e59007897dc87e96be30608e7f2007605d5c4")
     add_versions("3.2.3", "132149d25306cdc56a87c1d6a4a93d3200de4864b5d27d758d235ce4ace64498")
 
-    on_install("linux", "macosx", "bsd", "windows", "android", "iphoneos", function (package)
+    on_install("linux|!arm64", "macosx", "bsd", "windows", "android", "iphoneos", function (package)
         os.cp("include", package:installdir())
     end)
 


### PR DESCRIPTION
New version of hlslpp detected (package version: 3.5.3, last github version: 3.6)