### PR TITLE
at-spi2-core: add 2.55.90

### DIFF
--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -22,7 +22,8 @@ package("at-spi2-core")
         add_syslinks("dl", "resolv", "pthread")
     end
 
-    add_deps("meson", "ninja", "glib", "pkg-config", "dbus", "libx11", "libxtst", "libxi", "libxml2")
+    add_deps("glib", {system = false})
+    add_deps("meson", "ninja", "pkg-config", "dbus", "libx11", "libxtst", "libxi", "libxml2")
     on_install("linux", function (package)
         io.replace("meson.build", "warning_level=1", "warning_level=3", {plain = true})
         io.replace("meson.build", "subdir('tests')", "", {plain = true})

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -32,7 +32,7 @@ package("at-spi2-core")
         {
             -- try 代码块
             function ()
-                import("package.tools.meson").install(package, configs, {packagedeps = {"glib", "libiconv", "libx11", "libxtst", "libxi", "dbus"}})
+                import("package.tools.meson").install(package, configs, {packagedeps = {"glib", "libxml2", "libxtst", "libxi", "dbus"}})
                 io.cat(path.join(package:buildir(), "meson-logs/meson-log.txt"))
             end,
             -- catch 代码块

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -7,7 +7,10 @@ package("at-spi2-core")
     add_urls("https://gitlab.gnome.org/GNOME/at-spi2-core/-/archive/AT_SPI2_CORE_$(version)/at-spi2-core-AT_SPI2_CORE_$(version).tar.gz", {version = function (version)
         return version:gsub("%.", "_")
     end})
+    add_urls("https://gitlab.gnome.org/GNOME/at-spi2-core/-/archive/$(version)/at-spi2-core-$(version).tar.gz")
+
     add_versions("2.53.90", "6b0a7c15b5fceb69f501e8b6b8bebe9896c35b9edb1ee08fe0b202d488a71363")
+    add_versions("2.55.90", "f99a1dc25a0556c9ec58b7049f8c76f002ee3f50f10aae677fc49ac6c143b2a2")
 
     add_includedirs("include", "include/at-spi-2.0", "include/atk-1.0", "include/at-spi2-atk/2.0")
 

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -32,7 +32,7 @@ package("at-spi2-core")
         local configs = {"-Dintrospection=disabled", "-Ddocs=false"}
         table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
         import("package.tools.meson").install(package, configs, {packagedeps = {"glib", "dbus", "libx11", "libxtst", "libxi", "libxml2"}})
-        io.cat(path.join(package:buildir(), "meson-logs/meson-log.txt"))
+        io.cat("build_*/meson-logs/meson-log.txt")
         local atspi_pkgconfig_dir = package:installdir("lib/pkgconfig/atspi-2.pc")
         io.replace(atspi_pkgconfig_dir, [[-DG_LOG_DOMAIN="dbind"]], [[-DG_LOG_DOMAIN=\"dbind\"]])
     end)

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -20,7 +20,8 @@ package("at-spi2-core")
 
     add_deps("meson", "ninja", "glib", "pkg-config", "dbus", "libx11", "libxtst", "libxi", "libxml2")
     on_install("linux", function (package)
-        local configs = {}
+        io.replace("meson.build", "subdir('tests')", "", {plain = true})
+        local configs = {"-Dintrospection=disabled", "-Ddocs=false"}
         table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
         import("package.tools.meson").install(package, configs, {packagedeps = {"glib", "libiconv", "libx11", "libxtst", "libxi", "dbus"}})
         local atspi_pkgconfig_dir = package:installdir("lib/pkgconfig/atspi-2.pc")

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -14,7 +14,7 @@ package("at-spi2-core")
 
     add_versions("archive_new:2.55.90", "f99a1dc25a0556c9ec58b7049f8c76f002ee3f50f10aae677fc49ac6c143b2a2")
 
-    add_includedirs("include", "include/at-spi-2.0", "include/atk-1.0", "include/at-spi2-atk/2.0")
+    add_includedirs("include", "include/at-spi-2.0", "include/atk-1.0", "include/at-spi2-atk/2.0", "include/at-spi2-atk/2.0")
 
     add_links("atk-bridge-2.0", "atspi", "atk-1.0")
 

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -29,7 +29,21 @@ package("at-spi2-core")
         io.replace("meson.build", "subdir('tests')", "", {plain = true})
         local configs = {"-Dintrospection=disabled", "-Ddocs=false"}
         table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
-        import("package.tools.meson").install(package, configs, {packagedeps = {"glib", "libiconv", "libx11", "libxtst", "libxi", "dbus"}})
+        try
+        {
+            -- try 代码块
+            function ()
+                import("package.tools.meson").install(package, configs, {packagedeps = {"glib", "libiconv", "libx11", "libxtst", "libxi", "dbus"}})
+            end,
+            -- catch 代码块
+            catch
+            {
+                -- 发生异常后，被执行
+                function (errors)
+                    io.cat(path.join(package:buildir(), "meson-logs/meson-log.txt"))
+                end
+            }
+        }
         local atspi_pkgconfig_dir = package:installdir("lib/pkgconfig/atspi-2.pc")
         io.replace(atspi_pkgconfig_dir, [[-DG_LOG_DOMAIN="dbind"]], [[-DG_LOG_DOMAIN=\"dbind\"]])
     end)

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -18,8 +18,13 @@ package("at-spi2-core")
 
     add_links("atk-bridge-2.0", "atspi", "atk-1.0")
 
+    if is_plat("linux") then
+        add_syslinks("dl", "resolv", "pthread")
+    end
+
     add_deps("meson", "ninja", "glib", "pkg-config", "dbus", "libx11", "libxtst", "libxi", "libxml2")
     on_install("linux", function (package)
+        io.replace("meson.build", "warning_level=1", "warning_level=3", {plain = true})
         io.replace("meson.build", "subdir('tests')", "", {plain = true})
         local configs = {"-Dintrospection=disabled", "-Ddocs=false"}
         table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -22,28 +22,14 @@ package("at-spi2-core")
         add_syslinks("dl", "resolv", "pthread")
     end
 
-    add_deps("meson", "ninja", "pkg-config", "dbus", "libx11", "libxtst", "libxi", "libxml2", "glib")
+    add_deps("meson", "ninja", "glib", "pkg-config", "dbus", "libx11", "libxtst", "libxi", "libxml2")
     on_install("linux", function (package)
         io.replace("meson.build", "warning_level=1", "warning_level=3", {plain = true})
         io.replace("meson.build", "subdir('tests')", "", {plain = true})
         local configs = {"-Dintrospection=disabled", "-Ddocs=false"}
         table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
-        try
-        {
-            -- try 代码块
-            function ()
-                import("package.tools.meson").install(package, configs, {packagedeps = {"glib", "libxml2", "libxtst", "libxi", "dbus"}})
-                io.cat(path.join(package:buildir(), "meson-logs/meson-log.txt"))
-            end,
-            -- catch 代码块
-            catch
-            {
-                -- 发生异常后，被执行
-                function (errors)
-                    io.cat(path.join(package:buildir(), "meson-logs/meson-log.txt"))
-                end
-            }
-        }
+        import("package.tools.meson").install(package, configs, {packagedeps = {"glib", "dbus", "libx11", "libxtst", "libxi", "libxml2"}})
+        io.cat(path.join(package:buildir(), "meson-logs/meson-log.txt"))
         local atspi_pkgconfig_dir = package:installdir("lib/pkgconfig/atspi-2.pc")
         io.replace(atspi_pkgconfig_dir, [[-DG_LOG_DOMAIN="dbind"]], [[-DG_LOG_DOMAIN=\"dbind\"]])
     end)

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -4,14 +4,16 @@ package("at-spi2-core")
     set_description("contains the DBus interface definitions for AT-SPI - the core of an accessibility stack for free software systems.")
     set_license("LGPL-2.1")
 
-    add_urls("https://gitlab.gnome.org/GNOME/at-spi2-core/-/archive/AT_SPI2_CORE_$(version)/at-spi2-core-AT_SPI2_CORE_$(version).tar.gz", {alias = "archive", version = function (version)
-        return version:gsub("%.", "_")
-    end})
+    add_urls("https://gitlab.gnome.org/GNOME/at-spi2-core/-/archive/AT_SPI2_CORE_$(version)/at-spi2-core-AT_SPI2_CORE_$(version).tar.gz", {
+        alias = "archive",
+        version = function (version)
+            return version:gsub("%.", "_")
+        end
+    })
 
     add_urls("https://gitlab.gnome.org/GNOME/at-spi2-core/-/archive/$(version)/at-spi2-core-$(version).tar.gz", {alias = "archive_new"})
 
     add_versions("archive:2.53.90", "6b0a7c15b5fceb69f501e8b6b8bebe9896c35b9edb1ee08fe0b202d488a71363")
-
     add_versions("archive_new:2.55.90", "f99a1dc25a0556c9ec58b7049f8c76f002ee3f50f10aae677fc49ac6c143b2a2")
 
     add_includedirs("include", "include/at-spi-2.0", "include/atk-1.0", "include/at-spi2-atk/2.0")
@@ -22,7 +24,8 @@ package("at-spi2-core")
         add_syslinks("dl", "resolv", "pthread")
     end
 
-    add_deps("meson", "ninja", "glib", "pkg-config", "dbus", "libx11", "libxtst", "libxi", "libxml2")
+    add_deps("meson", "ninja", "glib", "pkgconf", "dbus", "libx11", "libxtst", "libxi", "libxml2")
+
     on_install("linux", function (package)
         io.replace("meson.build", "warning_level=1", "warning_level=3", {plain = true})
         io.replace("meson.build", "subdir('tests')", "", {plain = true})

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -31,11 +31,11 @@ package("at-spi2-core")
         os.cp("atk-adaptor/atk-bridge.h", package:installdir("include"))
 
         for _, header in ipairs({"atspi.h", "atspi-accessible.h", "atspi-action.h", "atspi-application.h", "atspi-collection.h", "atspi-component.h", "atspi-constants.h", "atspi-device.h", "atspi-device-a11y-manager.h", "atspi-device-legacy.h", "atspi-device-listener.h", "atspi-document.h", "atspi-editabletext.h", "atspi-event-listener.h", "atspi-gmain.h", "atspi-hyperlink.h", "atspi-hypertext.h", "atspi-image.h", "atspi-matchrule.h", "atspi-misc.h", "atspi-object.h", "atspi-registry.h", "atspi-relation.h", "atspi-selection.h", "atspi-stateset.h", "atspi-table.h", "atspi-table-cell.h", "atspi-text.h", "atspi-types.h", "atspi-value.h", "atspi-device-x11.h"}) do
-            os.cp("atspi/" .. header, path.join(package:installdir("include"), "atspi", header))
+            os.trycp("atspi/" .. header, path.join(package:installdir("include"), "atspi", header))
         end
 
         for _, header in ipairs({"atkaction.h", "atkcomponent.h", "atkdocument.h", "atkeditabletext.h", "atkgobjectaccessible.h", "atkhyperlink.h", "atkhyperlinkimpl.h", "atkhypertext.h", "atkimage.h", "atkmisc.h", "atknoopobject.h", "atknoopobjectfactory.h", "atkobject.h", "atkobjectfactory.h", "atkplug.h", "atkrange.h", "atkregistry.h", "atkrelation.h", "atkrelationtype.h", "atkrelationset.h", "atkselection.h", "atksocket.h", "atkstate.h", "atkstateset.h", "atkstreamablecontent.h", "atktable.h", "atktablecell.h", "atktext.h", "atkutil.h", "atkvalue.h", "atkwindow.h", "atk-autocleanups.h", "atk.h"}) do
-            os.cp("atk/" .. header, path.join(package:installdir("include"), "atk", header))
+            os.trycp("atk/" .. header, path.join(package:installdir("include"), "atk", header))
         end
 
         table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -14,7 +14,7 @@ package("at-spi2-core")
 
     add_versions("archive_new:2.55.90", "f99a1dc25a0556c9ec58b7049f8c76f002ee3f50f10aae677fc49ac6c143b2a2")
 
-    add_includedirs("include", "include/at-spi-2.0", "include/atk-1.0", "include/at-spi2-atk/2.0", "include/at-spi2-atk/2.0")
+    add_includedirs("include", "include/at-spi-2.0", "include/atk-1.0", "include/at-spi2-atk/2.0")
 
     add_links("atk-bridge-2.0", "atspi", "atk-1.0")
 
@@ -22,12 +22,22 @@ package("at-spi2-core")
         add_syslinks("dl", "resolv", "pthread")
     end
 
-    add_deps("glib", {system = false})
-    add_deps("meson", "ninja", "pkg-config", "dbus", "libx11", "libxtst", "libxi", "libxml2")
+    add_deps("meson", "ninja", "pkg-config", "dbus", "libx11", "libxtst", "libxi", "libxml2", "glib")
     on_install("linux", function (package)
         io.replace("meson.build", "warning_level=1", "warning_level=3", {plain = true})
         io.replace("meson.build", "subdir('tests')", "", {plain = true})
         local configs = {"-Dintrospection=disabled", "-Ddocs=false"}
+
+        os.cp("atk-adaptor/atk-bridge.h", package:installdir("include"))
+
+        for _, header in ipairs({"atspi.h", "atspi-accessible.h", "atspi-action.h", "atspi-application.h", "atspi-collection.h", "atspi-component.h", "atspi-constants.h", "atspi-device.h", "atspi-device-a11y-manager.h", "atspi-device-legacy.h", "atspi-device-listener.h", "atspi-document.h", "atspi-editabletext.h", "atspi-event-listener.h", "atspi-gmain.h", "atspi-hyperlink.h", "atspi-hypertext.h", "atspi-image.h", "atspi-matchrule.h", "atspi-misc.h", "atspi-object.h", "atspi-registry.h", "atspi-relation.h", "atspi-selection.h", "atspi-stateset.h", "atspi-table.h", "atspi-table-cell.h", "atspi-text.h", "atspi-types.h", "atspi-value.h", "atspi-device-x11.h"}) do
+            os.cp("atspi/" .. header, path.join(package:installdir("include"), "atspi", header))
+        end
+
+        for _, header in ipairs({"atkaction.h", "atkcomponent.h", "atkdocument.h", "atkeditabletext.h", "atkgobjectaccessible.h", "atkhyperlink.h", "atkhyperlinkimpl.h", "atkhypertext.h", "atkimage.h", "atkmisc.h", "atknoopobject.h", "atknoopobjectfactory.h", "atkobject.h", "atkobjectfactory.h", "atkplug.h", "atkrange.h", "atkregistry.h", "atkrelation.h", "atkrelationtype.h", "atkrelationset.h", "atkselection.h", "atksocket.h", "atkstate.h", "atkstateset.h", "atkstreamablecontent.h", "atktable.h", "atktablecell.h", "atktext.h", "atkutil.h", "atkvalue.h", "atkwindow.h", "atk-autocleanups.h", "atk.h"}) do
+            os.cp("atk/" .. header, path.join(package:installdir("include"), "atk", header))
+        end
+
         table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
         try
         {

--- a/packages/a/at-spi2-core/xmake.lua
+++ b/packages/a/at-spi2-core/xmake.lua
@@ -4,13 +4,15 @@ package("at-spi2-core")
     set_description("contains the DBus interface definitions for AT-SPI - the core of an accessibility stack for free software systems.")
     set_license("LGPL-2.1")
 
-    add_urls("https://gitlab.gnome.org/GNOME/at-spi2-core/-/archive/AT_SPI2_CORE_$(version)/at-spi2-core-AT_SPI2_CORE_$(version).tar.gz", {version = function (version)
+    add_urls("https://gitlab.gnome.org/GNOME/at-spi2-core/-/archive/AT_SPI2_CORE_$(version)/at-spi2-core-AT_SPI2_CORE_$(version).tar.gz", {alias = "archive", version = function (version)
         return version:gsub("%.", "_")
     end})
-    add_urls("https://gitlab.gnome.org/GNOME/at-spi2-core/-/archive/$(version)/at-spi2-core-$(version).tar.gz")
 
-    add_versions("2.53.90", "6b0a7c15b5fceb69f501e8b6b8bebe9896c35b9edb1ee08fe0b202d488a71363")
-    add_versions("2.55.90", "f99a1dc25a0556c9ec58b7049f8c76f002ee3f50f10aae677fc49ac6c143b2a2")
+    add_urls("https://gitlab.gnome.org/GNOME/at-spi2-core/-/archive/$(version)/at-spi2-core-$(version).tar.gz", {alias = "archive_new"})
+
+    add_versions("archive:2.53.90", "6b0a7c15b5fceb69f501e8b6b8bebe9896c35b9edb1ee08fe0b202d488a71363")
+
+    add_versions("archive_new:2.55.90", "f99a1dc25a0556c9ec58b7049f8c76f002ee3f50f10aae677fc49ac6c143b2a2")
 
     add_includedirs("include", "include/at-spi-2.0", "include/atk-1.0", "include/at-spi2-atk/2.0")
 

--- a/packages/d/dbus/xmake.lua
+++ b/packages/d/dbus/xmake.lua
@@ -6,6 +6,7 @@ package("dbus")
 
     add_urls("https://gitlab.freedesktop.org/dbus/dbus/-/archive/dbus-$(version)/dbus-dbus-$(version).tar.gz",
              "https://fossies.org/linux/misc/dbus-$(version).tar.gz")
+    add_versions("1.16.2", "1e8c5190e59f4b622031a134a9b97c9b5afbf5dc4e681504db2ff9dbf4e86d27")
     add_versions("1.14.2", "9ec5aad6310f79149aa04e8c6bd9e5e2cdca47cf3acec2d23ee9fe06ac7e7a62")
     add_versions("1.14.6", "2533742eb324fa7fbb093a3ed0ff436c7eb11861fd6a31e9b857fc4878f01831")
     add_versions("1.14.8", "273718fe5150a1a44fe77abcf442dc64082f7375fdc15fcbd80b84316f897326")

--- a/packages/d/dbus/xmake.lua
+++ b/packages/d/dbus/xmake.lua
@@ -4,7 +4,8 @@ package("dbus")
     set_description("D-Bus is a message bus system, a simple way for applications to talk to one another.")
     set_license("GPL-2.0-or-later")
 
-    add_urls("https://gitlab.freedesktop.org/dbus/dbus/-/archive/dbus-$(version)/dbus-dbus-$(version).tar.gz")
+    add_urls("https://gitlab.freedesktop.org/dbus/dbus/-/archive/dbus-$(version)/dbus-dbus-$(version).tar.gz",
+             "https://fossies.org/linux/misc/dbus-$(version).tar.gz")
     add_versions("1.14.2", "9ec5aad6310f79149aa04e8c6bd9e5e2cdca47cf3acec2d23ee9fe06ac7e7a62")
     add_versions("1.14.6", "2533742eb324fa7fbb093a3ed0ff436c7eb11861fd6a31e9b857fc4878f01831")
     add_versions("1.14.8", "273718fe5150a1a44fe77abcf442dc64082f7375fdc15fcbd80b84316f897326")

--- a/packages/s/stringzilla/xmake.lua
+++ b/packages/s/stringzilla/xmake.lua
@@ -9,6 +9,7 @@ package("stringzilla")
 
     add_configs("cpp", {description = "Enable C++ support.", default = true, type = "boolean"})
 
+    add_versions("v3.12.2", "a9d8518766a29b605bcd3a26c1d12e00d6fcddfc3541687d6adafd4aa7fe1c5f")
     add_versions("v3.12.1", "fcbd53fe4e827fa49eb1153f1116095a719a57fa6fb0a8680ba713088ad29d3e")
     add_versions("v3.11.3", "8ca47c1f1bb8ba67a89c54951fff08483087fa637a43941de1a44fb04a2ba83e")
     add_versions("v3.11.1", "44d2a38ddd610e6e22fc3ed83a5a453f9887b45746dd250d68c4d690b860c8f0")


### PR DESCRIPTION
I don't know why it fails at those two linux CIs ArchLinux/Fedora :(
Meanwhile it is working at another Linux CIs
install at-spi2-core 2.55.90 .. ok
install at-spi2-core#1 2.53.90 .. ok
Maybe sanity check line should not be so long. Any insight?