### PR TITLE
fix ormpp

### DIFF
--- a/packages/o/ormpp/xmake.lua
+++ b/packages/o/ormpp/xmake.lua
@@ -18,6 +18,8 @@ package("ormpp")
     on_load(function (package)
         local iguana_vers = {
             ["0.1.3"] = "1.0.5",
+            ["v0.1.2"] = "1.0.5",
+            ["v0.1.1"] = "1.0.5",
         }
         package:add("deps", "iguana " .. iguana_vers[package:version_str()])
         local configs = {

--- a/packages/o/ormpp/xmake.lua
+++ b/packages/o/ormpp/xmake.lua
@@ -15,7 +15,7 @@ package("ormpp")
     add_configs("postgresql", {description = "Using postgresql", default = false, type = "boolean"})
     add_configs("sqlite3", {description = "Using sqlite3", default = false, type = "boolean"})
 
-    add_deps("iguana <=1.0.5")
+    add_deps("iguana")
 
     on_load(function(package) 
         local configs = {

--- a/packages/o/ormpp/xmake.lua
+++ b/packages/o/ormpp/xmake.lua
@@ -36,6 +36,7 @@ package("ormpp")
         else
             os.vcp("ormpp/*", package:installdir("include"))
             os.vcp("iguana", package:installdir("include"))
+            os.vcp("frozen", package:installdir("include"))
         end
     end)
 

--- a/packages/o/ormpp/xmake.lua
+++ b/packages/o/ormpp/xmake.lua
@@ -21,7 +21,12 @@ package("ormpp")
             ["v0.1.2"] = "1.0.5",
             ["v0.1.1"] = "1.0.5",
         }
-        package:add("deps", "iguana " .. iguana_vers[package:version_str()])
+        if package:gitref() then
+            package:add("deps", "iguana")
+        else
+            package:add("deps", "iguana " .. iguana_vers[package:version_str()])
+        end
+
         local configs = {
             mysql = "ORMPP_ENABLE_MYSQL",
             postgresql = "ORMPP_ENABLE_PG",
@@ -50,16 +55,33 @@ package("ormpp")
             languages = "c++20"
         end
 
-        assert(package:check_cxxsnippets({test = [[
-            #include <algorithm>
-            #include <dbng.hpp>
-            using namespace ormpp;
-            struct person {
-              std::string name;
-              int age;
-              int id;
-            };
-            REGISTER_AUTO_KEY(person, id)
-            YLT_REFL(person, id, name, age)
-        ]]}, {configs = {languages = languages}}))
+        local snippets
+        if package:gitref() or package:version():gt("0.1.3") then
+            snippets = [[
+                #include <algorithm>
+                #include <dbng.hpp>
+                using namespace ormpp;
+                struct person {
+                    std::string name;
+                    int age;
+                    int id;
+                };
+                REGISTER_AUTO_KEY(person, id)
+                YLT_REFL(person, id, name, age)
+            ]]
+        else
+            snippets = [[
+                #include <algorithm>
+                #include <dbng.hpp>
+                using namespace ormpp;
+                struct student {
+                    std::string name;
+                    int age;
+                    int id;
+                };
+                REGISTER_AUTO_KEY(student, id)
+                REFLECTION_WITH_NAME(student, "t_student", id, name, age)
+            ]]
+        end
+        assert(package:check_cxxsnippets({test = snippets}, {configs = {languages = languages}}))
     end)

--- a/packages/o/ormpp/xmake.lua
+++ b/packages/o/ormpp/xmake.lua
@@ -15,7 +15,11 @@ package("ormpp")
     add_configs("postgresql", {description = "Using postgresql", default = false, type = "boolean"})
     add_configs("sqlite3", {description = "Using sqlite3", default = false, type = "boolean"})
 
-    on_load(function(package) 
+    on_load(function (package)
+        local iguana_vers = {
+            ["0.1.3"] = "1.0.5",
+        }
+        package:add("deps", "iguana " .. iguana_vers[package:version_str()])
         local configs = {
             mysql = "ORMPP_ENABLE_MYSQL",
             postgresql = "ORMPP_ENABLE_PG",
@@ -35,8 +39,6 @@ package("ormpp")
             os.vcp("include/*", package:installdir("include"))
         else
             os.vcp("ormpp/*", package:installdir("include"))
-            os.vcp("iguana", package:installdir("include"))
-            os.vcp("frozen", package:installdir("include"))
         end
     end)
 

--- a/packages/o/ormpp/xmake.lua
+++ b/packages/o/ormpp/xmake.lua
@@ -54,12 +54,12 @@ package("ormpp")
             #include <algorithm>
             #include <dbng.hpp>
             using namespace ormpp;
-            struct student {
-                std::string name;
-                int age;
-                int id;
+            struct person {
+              std::string name;
+              int age;
+              int id;
             };
-            REGISTER_AUTO_KEY(student, id)
-            REFLECTION_WITH_NAME(student, "t_student", id, name, age)
+            REGISTER_AUTO_KEY(person, id)
+            YLT_REFL(person, id, name, age)
         ]]}, {configs = {languages = languages}}))
     end)

--- a/packages/o/ormpp/xmake.lua
+++ b/packages/o/ormpp/xmake.lua
@@ -15,8 +15,6 @@ package("ormpp")
     add_configs("postgresql", {description = "Using postgresql", default = false, type = "boolean"})
     add_configs("sqlite3", {description = "Using sqlite3", default = false, type = "boolean"})
 
-    add_deps("iguana")
-
     on_load(function(package) 
         local configs = {
             mysql = "ORMPP_ENABLE_MYSQL",
@@ -37,6 +35,7 @@ package("ormpp")
             os.vcp("include/*", package:installdir("include"))
         else
             os.vcp("ormpp/*", package:installdir("include"))
+            os.vcp("iguana", package:installdir("include"))
         end
     end)
 


### PR DESCRIPTION
ormpp依赖的iguana一直在更新，但是包描述限制了版本
不能限制为低版本
![image](https://github.com/user-attachments/assets/a0d39cdc-e85c-4cbe-9ee5-d22e3041e2e7)

```
PS C:\Users\Administrator\temp\testormpp> xp
checking for Microsoft Visual Studio (x64) version ... 2022
checking for Microsoft C/C++ Compiler (x64) version ... 19.43.34808
note: install or modify (m) these packages (pass -y to skip confirm)?
in xmake-repo:
  -> ormpp master [sqlite3:y, license:Apache-2.0]
please input: y (y/n/m)

  => install ormpp master .. failed  

_89303FD41CCF4E6CBE77701F1E9260BF.cpp
C:\Users\Administrator\AppData\Local\.xmake\packages\o\ormpp\master\e6e18d1f40294cb4b21bb6b0e269e756\include\utility.hpp(104): error C2039: "ylt_refletable_v": 不是 "iguana" 的成员
C:\Users\Administrator\AppData\Local\.xmake\packages\i\iguana\1.0.5\8ac4b37c6eaa441ea9eccf393ede2ccd\include\iguana/util.hpp(21): note: 参见“iguana”的声明
C:\Users\Administrator\AppData\Local\.xmake\packages\o\ormpp\master\e6e18d1f40294cb4b21bb6b0e269e756\include\utility.hpp(104): error C2065: “ylt_refletable_v”: 未声明的标识符
C:\Users\Administrator\AppData\Local\.xmake\packages\o\ormpp\master\e6e18d1f40294cb4b21bb6b0e269e756\include\utility.hpp(104): error C2988: 不可识别的模板声明/定义
C:\Users\Administrator\AppData\Local\.xmake\packages\o\ormpp\master\e6e18d1f40294cb4b21bb6b0e269e756\include\utility.hpp(104): error C2059: 语法错误:“,”
C:\Users\Administrator\AppData\Local\.xmake\packages\o\ormpp\master\e6e18d1f40294cb4b21bb6b0e269e756\include\utility.hpp(104): error C2143: 语法错误: 缺少“;”(在“{”的前面)
C:\Users\Administrator\AppData\Local\.xmake\packages\o\ormpp\master\e6e18d1f40294cb4b21bb6b0e269e756\include\utility.hpp(104): error C2447: “{”: 缺少函数标题(是否是老式的形式表?)
C:\Users\Administrator\AppData\Local\.xmake\packages\o\ormpp\master\e6e18d1f40294cb4b21bb6b0e269e756\include\utility.hpp(109): error C2039: "non_ylt_refletable_v": 不是 "iguana" 的成员
C:\Users\Administrator\AppData\Local\.xmake\packages\i\iguana\1.0.5\8ac4b37c6eaa441ea9eccf393ede2ccd\include\iguana/util.hpp(21): note: 参见“iguana”的声明
C:\Users\Administrator\AppData\Local\.xmake\packages\o\ormpp\master\e6e18d1f40294cb4b21bb6b0e269e756\include\utility.hpp(109): error C2065: “non_ylt_refletable_v”: 未声明的标识符
C:\Users\Administrator\AppData\Local\.xmake\packages\o\ormpp\master\e6e18d1f40294cb4b21bb6b0e269e756\include\utility.hpp(109): error C2988: 不可识别的模板声明/定义
C:\Users\Administrator\AppData\Local\.xmake\packages\o\ormpp\master\e6e18d1f40294cb4b21bb6b0e269e756\include\utility.hpp(109): error C2059: 语法错误:“,”
C:\Users\Administrator\AppData\Local\.xmake\packages\o\ormpp\master\e6e18d1f40294cb4b21bb6b0e269e756\include\utility.hpp(110): error C2143: 语法错误: 缺少“;”(在“{”的前面)
C:\Users\Administrator\AppData\Local\.xmake\packages\o\ormpp\master\e6e18d1f40294cb4b21bb6b0e269e756\include\utility.hpp(110): error C2447: “{”: 缺少函数标题(是否是老式的形式表?)
C:\Users\ADMINI~1\AppData\Local\Temp\.xmake\250307\_89303FD41CCF4E6CBE77701F1E9260BF.cpp(12): error C2059: 语法错误:“常数”
C:\Users\ADMINI~1\AppData\Local\Temp\.xmake\250307\_89303FD41CCF4E6CBE77701F1E9260BF.cpp(12): error C2061: 语法错误: 标识符“add_auto_key_field”
```