### PR TITLE
Auto-update minizip-ng to 4.0.8

### DIFF
--- a/packages/m/minizip-ng/xmake.lua
+++ b/packages/m/minizip-ng/xmake.lua
@@ -1,11 +1,11 @@
 package("minizip-ng")
-
     set_homepage("https://github.com/zlib-ng/minizip-ng")
     set_description("Fork of the popular zip manipulation library found in the zlib distribution.")
     set_license("zlib")
 
     add_urls("https://github.com/zlib-ng/minizip-ng/archive/refs/tags/$(version).tar.gz",
              "https://github.com/zlib-ng/minizip-ng.git")
+
     add_versions("4.0.8", "c3e9ceab2bec26cb72eba1cf46d0e2c7cad5d2fe3adf5df77e17d6bbfea4ec8f")
     add_versions("4.0.7", "a87f1f734f97095fe1ef0018217c149d53d0f78438bcb77af38adc21dff2dfbc")
     add_versions("4.0.6", "e96ed3866706a67dbed05bf035e26ef6b60f408e1381bf0fe9af17fe2c0abebc")
@@ -20,18 +20,19 @@ package("minizip-ng")
     add_configs("zstd",  {description = "Enable zstd comppressression library.", default = false, type = "boolean"})
 
     add_deps("cmake")
+    if is_plat("linux", "android") then
+        add_deps("openssl")
+    end
 
     if is_plat("macosx") then
         add_frameworks("CoreFoundation", "Security")
         add_syslinks("iconv")
-    elseif is_plat("linux", "android") then
-        add_deps("openssl")
     elseif is_plat("windows", "mingw") then
         add_syslinks("crypt32", "advapi32")
     end
 
     on_load(function (package)
-        if package:version():ge("4.0") then
+        if package:version() and package:version():ge("4.0") then
             if package:is_plat("macosx") then
                 package:add("deps", "openssl")
             elseif package:is_plat("windows", "mingw") then
@@ -48,9 +49,15 @@ package("minizip-ng")
     end)
 
     on_install("macosx", "android", "linux", "windows", "mingw", function (package)
-        local configs = {"-DMZ_LIBCOMP=OFF"}
-        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        local configs = {"-DMZ_LIBCOMP=OFF", "-DMZ_FETCH_LIBS=OFF"}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        table.insert(configs, "-DMZ_SANITIZER=" .. (package:config("asan") and "Address" or "OFF"))
+        if package:config("shared") and package:is_plat("windows") then
+            -- https://github.com/zlib-ng/minizip-ng/issues/475
+            table.insert(configs, "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON")
+        end
+
         for name, enabled in pairs(package:configs()) do
             if not package:extraconf("configs", name, "builtin") then
                 table.insert(configs, "-DMZ_" .. name:upper() .. "=" .. (enabled and "ON" or "OFF"))
@@ -60,9 +67,18 @@ package("minizip-ng")
     end)
 
     on_test(function (package)
-        if package:version():ge("4.0") then
-            assert(package:has_cfuncs("zipOpen", {includes = {"minizip/mz.h", "minizip/mz_compat.h"}}))
-        else
-            assert(package:has_cfuncs("zipOpen", {includes = {"mz.h", "mz_compat.h"}}))
+        local includes
+        local version = package:version()
+        if version then
+            if version:ge("4.0") then
+                if version:ge("4.0.8") then
+                    includes = {"minizip/mz.h", "minizip/zip.h"}
+                else
+                    includes = {"minizip/mz.h", "minizip/mz_compat.h"}
+                end
+            else
+                includes = {"mz.h", "mz_compat.h"}
+            end
         end
+        assert(package:has_cfuncs("zipOpen", {includes = includes}))
     end)

--- a/packages/m/minizip-ng/xmake.lua
+++ b/packages/m/minizip-ng/xmake.lua
@@ -6,6 +6,7 @@ package("minizip-ng")
 
     add_urls("https://github.com/zlib-ng/minizip-ng/archive/refs/tags/$(version).tar.gz",
              "https://github.com/zlib-ng/minizip-ng.git")
+    add_versions("4.0.8", "c3e9ceab2bec26cb72eba1cf46d0e2c7cad5d2fe3adf5df77e17d6bbfea4ec8f")
     add_versions("4.0.7", "a87f1f734f97095fe1ef0018217c149d53d0f78438bcb77af38adc21dff2dfbc")
     add_versions("4.0.6", "e96ed3866706a67dbed05bf035e26ef6b60f408e1381bf0fe9af17fe2c0abebc")
     add_versions("4.0.5", "9bb636474b8a4269280d32aca7de4501f5c24cc642c9b4225b4ed7b327f4ee73")


### PR DESCRIPTION
New version of minizip-ng detected (package version: 4.0.7, last github version: 4.0.8)