### PR TITLE
Auto-update toml11 to v4.4.0

### DIFF
--- a/packages/t/toml11/xmake.lua
+++ b/packages/t/toml11/xmake.lua
@@ -7,6 +7,7 @@ package("toml11")
     add_urls("https://github.com/ToruNiina/toml11/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ToruNiina/toml11.git")
 
+    add_versions("v4.4.0", "815bfe6792aa11a13a133b86e7f0f45edc5d71eb78f5fb6686c49c7f792b9049")
     add_versions("v4.3.0", "af95dab1bbb9b05a597e73d529a7269e13f1869e9ca9bd4779906c5cd96e282b")
     add_versions("v4.2.0", "9287971cd4a1a3992ef37e7b95a3972d1ae56410e7f8e3f300727ab1d6c79c2c")
     add_versions("v4.1.0", "fb4c02cc708ae28e6fc3496514e3625e4b6738ed4ce40897710ca4d7a29de4f7")


### PR DESCRIPTION
New version of toml11 detected (package version: v4.3.0, last github version: v4.4.0)