### PR TITLE
Auto-update aws-c-common to v0.11.3

### DIFF
--- a/packages/a/aws-c-common/xmake.lua
+++ b/packages/a/aws-c-common/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-common")
     add_urls("https://github.com/awslabs/aws-c-common/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-common.git")
 
+    add_versions("v0.11.3", "efcd2fb20f3149752fed87fa7901e933f3b1a64dfa4ac989f869ded87891bb3c")
     add_versions("v0.11.1", "b442cc59f507fbe232c0ae433c836deff83330270a58fa13bf360562efda368a")
     add_versions("v0.10.6", "d0acbabc786035d41791c3a2f45dbeda31d9693521ee746dc1375d6380eb912b")
     add_versions("v0.10.3", "15cc7282cfe4837fdaf1c3bb44105247da712ae97706a8717866f8e73e1d4fd9")


### PR DESCRIPTION
New version of aws-c-common detected (package version: v0.11.1, last github version: v0.11.3)