### PR TITLE
Auto-update quickjs-ng to v0.9.0

### DIFF
--- a/packages/q/quickjs-ng/xmake.lua
+++ b/packages/q/quickjs-ng/xmake.lua
@@ -6,6 +6,7 @@ package("quickjs-ng")
     add_urls("https://github.com/quickjs-ng/quickjs/archive/refs/tags/$(version).tar.gz",
              "https://github.com/quickjs-ng/quickjs.git", {submodules = false})
 
+    add_versions("v0.9.0", "77f9e79b42e2e7cff9517bae612431af47e120730286cb1dcfad0753bc160f10")
     add_versions("v0.8.0", "7e60e1e0dcd07d25664331308a2f4aee2a88d60d85896e828d25df7c3d40204e")
     add_versions("v0.7.0", "46c45cc2ed174474765dac8e41062998d92c4dd5fd779624da4073d6cd430eeb")
     add_versions("v0.6.1", "276edbb30896cdf2eee12a8bdb5b9c1cc2734eac8c898de6d52268ae201e614d")


### PR DESCRIPTION
New version of quickjs-ng detected (package version: v0.8.0, last github version: v0.9.0)