### PR TITLE
Auto-update tinycbor to v0.6.1

### DIFF
--- a/packages/t/tinycbor/port/xmake.lua
+++ b/packages/t/tinycbor/port/xmake.lua
@@ -33,6 +33,9 @@ target("tinycbor")
     if not has_config("enable_float") then
         add_defines("CBOR_NO_FLOATING_POINT")
     end
+    if is_plat("mingw") and is_arch("i386") then
+        add_vectorexts("all")
+    end
 
     if is_plat("windows") and is_kind("shared") then
         add_defines("CBOR_API=__declspec(dllexport)")

--- a/packages/t/tinycbor/port/xmake.lua
+++ b/packages/t/tinycbor/port/xmake.lua
@@ -1,0 +1,41 @@
+add_rules("mode.debug", "mode.release")
+
+option("enable_float", {default = true, showmenu = true})
+
+option("HAS_OPEN_MEMSTREAM")
+    add_cfuncs("open_memstream")
+    add_cincludes("stdio.h")
+    add_defines("_GNU_SOURCE")
+
+option("HAS_FOPENCOOKIE")
+    add_cfuncs("fopencookie")
+    add_cincludes("stdio.h")
+    add_defines("_GNU_SOURCE")
+
+option("HAS_FUNOPEN")
+    add_cfuncs("funopen")
+    add_cincludes("stdio.h")
+    add_defines("_GNU_SOURCE")
+
+target("tinycbor")
+    set_kind("$(kind)")
+    add_files("src/cbor*.c")
+    add_includedirs("src")
+
+    if not has_config("HAS_OPEN_MEMSTREAM") then
+        if has_config("HAS_FOPENCOOKIE") and has_config("HAS_FUNOPEN") then
+            add_files("src/open_memstream.c")
+        else
+            add_defines("WITHOUT_OPEN_MEMSTREAM")
+        end
+    end
+
+    if not has_config("enable_float") then
+        add_defines("CBOR_NO_FLOATING_POINT")
+    end
+
+    if is_plat("windows") and is_kind("shared") then
+        add_defines("CBOR_API=__declspec(dllexport)")
+    end
+
+    add_headerfiles("src/cbor.h", "src/cborjson.h", "src/tinycbor-version.h")

--- a/packages/t/tinycbor/xmake.lua
+++ b/packages/t/tinycbor/xmake.lua
@@ -19,6 +19,11 @@ package("tinycbor")
                 package:add("defines", "CBOR_STATIC_DEFINE")
             end
         end
+        if package:is_plat("mingw") and package:is_arch("i386") then
+            -- Only work with gcc >= 14
+            package:config_set("float", false)
+            wprint("package(tinycbor) disable config(float) on mingw/i386")
+        end
     end)
 
     on_install(function (package)

--- a/packages/t/tinycbor/xmake.lua
+++ b/packages/t/tinycbor/xmake.lua
@@ -6,6 +6,7 @@ package("tinycbor")
 
     add_urls("https://github.com/intel/tinycbor/archive/refs/tags/$(version).tar.gz",
              "https://github.com/intel/tinycbor.git")
+    add_versions("v0.6.1", "0f9944496d1143935e9c996bc6233ca0dd5451299def33ef400a409942f8f34b")
     add_versions("v0.6.0", "512e2c9fce74f60ef9ed3af59161e905f9e19f30a52e433fc55f39f4c70d27e4")
 
     add_configs("float", {description = "Enable floating point data type.", default = true, type = "boolean"})

--- a/packages/t/tinycbor/xmake.lua
+++ b/packages/t/tinycbor/xmake.lua
@@ -1,56 +1,43 @@
 package("tinycbor")
-
     set_homepage("https://github.com/intel/tinycbor")
     set_description("Concise Binary Object Representation (CBOR) Library")
     set_license("MIT")
 
     add_urls("https://github.com/intel/tinycbor/archive/refs/tags/$(version).tar.gz",
              "https://github.com/intel/tinycbor.git")
+
     add_versions("v0.6.1", "0f9944496d1143935e9c996bc6233ca0dd5451299def33ef400a409942f8f34b")
     add_versions("v0.6.0", "512e2c9fce74f60ef9ed3af59161e905f9e19f30a52e433fc55f39f4c70d27e4")
 
     add_configs("float", {description = "Enable floating point data type.", default = true, type = "boolean"})
+    add_configs("cmake", {description = "Use cmake build system", default = false, type = "boolean"})
+
+    on_load(function (package)
+        if (package:gitref() or package:version():gt("0.6.1")) and package:config("cmake") then
+            package:add("deps", "cmake")
+            if not package:config("shared") then
+                package:add("defines", "CBOR_STATIC_DEFINE")
+            end
+        end
+    end)
 
     on_install(function (package)
-        io.writefile("xmake.lua", [[
-            add_rules("mode.debug", "mode.release")
-            option("enable_float", {default = true, showmenu = true})
-            option("HAS_OPEN_MEMSTREAM")
-                add_cfuncs("open_memstream")
-                add_cincludes("stdio.h")
-                add_defines("_GNU_SOURCE")
-            option("HAS_FOPENCOOKIE")
-                add_cfuncs("fopencookie")
-                add_cincludes("stdio.h")
-                add_defines("_GNU_SOURCE")
-            option("HAS_FUNOPEN")
-                add_cfuncs("funopen")
-                add_cincludes("stdio.h")
-                add_defines("_GNU_SOURCE")
-            target("tinycbor")
-                set_kind("$(kind)")
-                add_files("src/cbor*.c")
-                if not has_config("HAS_OPEN_MEMSTREAM") then
-                    if has_config("HAS_FOPENCOOKIE") and has_config("HAS_FUNOPEN") then
-                        add_files("src/open_memstream.c")
-                    else
-                        add_defines("WITHOUT_OPEN_MEMSTREAM")
-                    end
-                end
-                if not has_config("enable_float") then
-                    add_defines("CBOR_NO_FLOATING_POINT")
-                end
-                if is_plat("windows") and is_kind("shared") then
-                    add_defines("CBOR_API=__declspec(dllexport)")
-                end
-                add_headerfiles("src/cbor.h", "src/cborjson.h", "src/tinycbor-version.h")
-                after_build(function (target)
-                    if target:is_plat("windows") and target:is_shared() then
-                        io.replace("src/cbor.h", "#define CBOR_API", "define CBOR_API __declspec(dllimport)", {plain = true})
-                    end
-                end)
-        ]])
-        import("package.tools.xmake").install(package, {enable_float = package:config("float")})
+        local configs = {}
+        if package:config("cmake") then
+            io.replace("CMakeLists.txt", "add_subdirectory(tests)", "", {plain = true})
+            io.replace("CMakeLists.txt", "include(PackageConfig)", "", {plain = true})
+
+            table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
+            table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+            import("package.tools.cmake").install(package, configs)
+        else
+            os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
+            import("package.tools.xmake").install(package, {enable_float = package:config("float")})
+
+            if package:is_plat("windows") and package:config("shared") then
+                io.replace(path.join(package:installdir("include"), "cbor.h"), "define CBOR_API", "define CBOR_API __declspec(dllimport)", {plain = true})
+            end
+        end
     end)
 
     on_test(function (package)


### PR DESCRIPTION
New version of tinycbor detected (package version: v0.6.0, last github version: v0.6.1)