### PR TITLE
Abseil: use cxx_standard in on_test

### DIFF
--- a/packages/a/abseil/xmake.lua
+++ b/packages/a/abseil/xmake.lua
@@ -96,5 +96,5 @@ package("abseil")
                 auto a = absl::SimpleAtoi("123", &result);
                 std::cout << "Joined string: " << s << "\\n";
             }
-        ]]}, {configs = {languages = "cxx17"}}))
+        ]]}, {configs = {languages = "cxx" .. package:config("cxx_standard")}}))
     end)


### PR DESCRIPTION
Use package's `cxx_standard` version in `on_test` since it fails with `cxx_standard=20` because of `<compare>` (`std::partial_ordering`, `std::weak_ordering`, and so on)

Logs of failed `on_test`:
```
> checking for c++ snippet(test)
checkinfo: ...amdir/core/sandbox/modules/import/core/tool/compiler.lua:84: @programdir/modules/core/tools/gcc.lua:966: In file included from /tmp/.xmake1000/250315/_655EF772B73E4B43A7AB303658501B4D.cpp:4:
In file included from /home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/strings/numbers.h:50:
In file included from /home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/numeric/int128.h:41:
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:60:12: error: no member named 'partial_ordering' in namespace 'std'
   60 | using std::partial_ordering;
      |       ~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:61:12: error: no member named 'strong_ordering' in namespace 'std'
   61 | using std::strong_ordering;
      |       ~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:62:12: error: no member named 'weak_ordering' in namespace 'std'
   62 | using std::weak_ordering;
      |       ~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:455:56: error: no type named 'weak_ordering' in namespace 'absl'
  455 | constexpr bool compare_result_as_less_than(const absl::weak_ordering r) {
      |                                                  ~~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:470:17: error: no type named 'weak_ordering' in namespace 'absl'
  470 | constexpr absl::weak_ordering compare_result_as_ordering(const Int c) {
      |           ~~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:471:24: error: no member named 'weak_ordering' in namespace 'absl'
  471 |   return c < 0 ? absl::weak_ordering::less
      |                  ~~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:472:33: error: no member named 'weak_ordering' in namespace 'absl'
  472 |                : c == 0 ? absl::weak_ordering::equivalent
      |                           ~~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:473:33: error: no member named 'weak_ordering' in namespace 'absl'
  473 |                         : absl::weak_ordering::greater;
      |                           ~~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:475:17: error: no type named 'weak_ordering' in namespace 'absl'
  475 | constexpr absl::weak_ordering compare_result_as_ordering(
      |           ~~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:476:17: error: no type named 'weak_ordering' in namespace 'absl'
  476 |     const absl::weak_ordering c) {
      |           ~~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:485:17: error: no type named 'weak_ordering' in namespace 'absl'
  485 | constexpr absl::weak_ordering do_three_way_comparison(const Compare &compare,
      |           ~~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:494:17: error: no type named 'weak_ordering' in namespace 'absl'
  494 | constexpr absl::weak_ordering do_three_way_comparison(const Compare &compare,
      |           ~~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:496:32: error: no member named 'weak_ordering' in namespace 'absl'
  496 |   return compare(x, y) ? absl::weak_ordering::less
      |                          ~~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:497:48: error: no member named 'weak_ordering' in namespace 'absl'
  497 |                        : compare(y, x) ? absl::weak_ordering::greater
      |                                          ~~~~~~^
/home/akylzhan/.xmake/packages/a/abseil/b3b568d9/5469470edd9647118f0bc7cd962dde3a/include/absl/types/compare.h:498:48: error: no member named 'weak_ordering' in namespace 'absl'
  498 |                                        : absl::weak_ordering::equivalent;
      |                                          ~~~~~~^
15 errors generated.
```