### PR TITLE
Auto-update cnats to v3.10.1

### DIFF
--- a/packages/c/cnats/xmake.lua
+++ b/packages/c/cnats/xmake.lua
@@ -6,6 +6,7 @@ package("cnats")
     add_urls("https://github.com/nats-io/nats.c/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nats-io/nats.c.git")
 
+    add_versions("v3.10.1", "1765533bbc1270ab7c89e3481b4778db7d1e7b4db2fa906b6602cd5c02846222")
     add_versions("v3.9.2", "28c4f39b88f095d78d653e8d4fe4581163fe96ecde5f9683933f0d82fd889a57")
     add_versions("v3.8.2", "083ee03cf5a413629d56272e88ad3229720c5006c286e8180c9e5b745c10f37d")
 


### PR DESCRIPTION
New version of cnats detected (package version: v3.9.2, last github version: v3.10.1)