### PR TITLE
Test libjq

### DIFF
--- a/packages/l/libjq/xmake.lua
+++ b/packages/l/libjq/xmake.lua
@@ -31,18 +31,16 @@ package("libjq")
         add_syslinks("shlwapi")
     end
 
+    on_check(function (package)
+        assert(not (package:is_plat("android") and is_subhost("windows")), "package(libjq): does not support windows@android.")
+        assert(not (package:is_plat("mingw") and is_subhost("msys")), "package(libjq): does not support mingw@msys.")
+    end)
+
     on_load(function (package)
         if package:config("oniguruma") then
             package:add("deps", "oniguruma")
         end
     end)
-
-    if on_check then
-        on_check(function (package)
-            assert(not (package:is_plat("android") and package:is_subhost("windows")), "package(libjq): does not support windows@android.")
-            assert(not (package:is_plat("mingw") and package:is_subhost("msys")), "package(libjq): does not support windows@msys.")
-        end)
-    end
 
     on_install("!windows and !wasm", function (package)
         if not package:is_cross() then

--- a/packages/l/libjq/xmake.lua
+++ b/packages/l/libjq/xmake.lua
@@ -7,11 +7,7 @@ package("libjq")
 
     add_versions("1.7.1" , "fc75b1824aba7a954ef0886371d951c3bf4b6e0a921d1aefc553f309702d6ed1")
 
-    if is_subhost("msys") then
-        add_deps("autotools")
-    else
-        add_deps("autoconf", "automake", "libtool")
-    end
+    add_deps("autoconf", "automake", "libtool")
 
     add_configs("oniguruma",    {description = "Build with oniguruma", default = true, type = "boolean"})
     add_configs("all_static",   {description = "link jq with static libraries only", default = false, type = "boolean"})
@@ -40,9 +36,12 @@ package("libjq")
         end
     end)
 
-    on_check(function (package)
-        assert(not (package:is_plat("android") and package:is_subhost("windows")), "package(libjq): does not support windows@android.")
-    end)
+    if on_check then
+        on_check(function (package)
+            assert(not (package:is_plat("android") and package:is_subhost("windows")), "package(libjq): does not support windows@android.")
+            assert(not (package:is_plat("mingw") and package:is_subhost("msys")), "package(libjq): does not support windows@mingw.")
+        end)
+    end
 
     on_install("!windows and !wasm", function (package)
         local configs = {"--enable-docs=no"}

--- a/packages/l/libjq/xmake.lua
+++ b/packages/l/libjq/xmake.lua
@@ -10,7 +10,7 @@ package("libjq")
     add_deps("autoconf", "automake", "libtool")
 
     add_configs("oniguruma",    {description = "Build with oniguruma", default = true, type = "boolean"})
-    add_configs("all_static",   {description = "link jq with static libraries only", default = false, type = "boolean"})
+    add_configs("all_static",   {description = "Link jq with static libraries only", default = false, type = "boolean"})
 
     if not is_host("windows") then
         add_extsources("pkgconfig::libjq")
@@ -39,7 +39,7 @@ package("libjq")
     if on_check then
         on_check(function (package)
             assert(not (package:is_plat("android") and package:is_subhost("windows")), "package(libjq): does not support windows@android.")
-            assert(not (package:is_plat("mingw") and package:is_subhost("msys")), "package(libjq): does not support windows@mingw.")
+            assert(not (package:is_plat("mingw") and package:is_subhost("msys")), "package(libjq): does not support windows@msys.")
         end)
     end
 

--- a/packages/l/libjq/xmake.lua
+++ b/packages/l/libjq/xmake.lua
@@ -45,6 +45,9 @@ package("libjq")
     end
 
     on_install("!windows and !wasm", function (package)
+        if not package:is_cross() then
+            package:addenv("PATH", "bin")
+        end
         local configs = {"--enable-docs=no"}
         if package:config("shared") then
             table.insert(configs, "--enable-shared")

--- a/packages/l/libjq/xmake.lua
+++ b/packages/l/libjq/xmake.lua
@@ -35,15 +35,19 @@ package("libjq")
         end
     end)
 
-    on_install(function (package)
+    on_install("!windows and !msys and !wasm", function (package)
         local configs = {"--enable-docs=no"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
         if package:is_debug() then
             table.insert(configs, "--enable-debug")
         end
+        local opt = {}
+        if package:config("oniguruma") then
+            opt.packagedeps = "oniguruma"
+        end
         table.insert(configs, "--with-oniguruma=" .. (package:config("oniguruma") and "yes" or "no"))
-        import("package.tools.autoconf").install(package, configs, {packagedeps = "oniguruma"})
+        import("package.tools.autoconf").install(package, configs, opt)
     end)
 
     on_test(function (package)

--- a/packages/l/libjq/xmake.lua
+++ b/packages/l/libjq/xmake.lua
@@ -1,0 +1,51 @@
+package("libjq")
+    set_homepage("https://jqlang.org")
+    set_description("Command-line JSON processor")
+
+    add_urls("https://github.com/jqlang/jq/archive/refs/tags/jq-$(version).tar.gz",
+             "https://github.com/jqlang/jq.git")
+
+    add_versions("1.7.1" , "fc75b1824aba7a954ef0886371d951c3bf4b6e0a921d1aefc553f309702d6ed1")
+
+    add_deps("autoconf", "automake", "libtool")
+
+    add_configs("oniguruma", {description = "Build with oniguruma", default = true, type = "boolean"})
+
+    if not is_host("windows") then
+        add_extsources("pkgconfig::libjq")
+    end
+
+    if is_plat("mingw") and is_subhost("msys") then
+        add_extsources("pacman::jq")
+    elseif is_plat("linux") then
+        add_extsources("apt::libjq-dev")
+    elseif is_plat("macosx") then
+        add_extsources("brew::jq")
+    end
+
+    if is_plat("linux", "bsd") then
+        add_syslinks("m", "pthread")
+    elseif is_plat("windows", "mingw") then
+        add_syslinks("shlwapi")
+    end
+
+    on_load(function (package)
+        if package:config("oniguruma") then
+            package:add("deps", "oniguruma")
+        end
+    end)
+
+    on_install(function (package)
+        local configs = {"--enable-docs=no"}
+        table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
+        table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
+        if package:is_debug() then
+            table.insert(configs, "--enable-debug")
+        end
+        table.insert(configs, "--with-oniguruma=" .. (package:config("oniguruma") and "yes" or "no"))
+        import("package.tools.autoconf").install(package, configs, {packagedeps = "oniguruma"})
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("jq_init" , {includes = "jq.h"}))
+    end)

--- a/packages/l/libjq/xmake.lua
+++ b/packages/l/libjq/xmake.lua
@@ -7,6 +7,12 @@ package("libjq")
 
     add_versions("1.7.1" , "fc75b1824aba7a954ef0886371d951c3bf4b6e0a921d1aefc553f309702d6ed1")
 
+    if is_subhost("msys") then
+        add_deps("autotools")
+    else
+        add_deps("autoconf", "automake", "libtool")
+    end
+
     add_configs("oniguruma",    {description = "Build with oniguruma", default = true, type = "boolean"})
     add_configs("all_static",   {description = "link jq with static libraries only", default = false, type = "boolean"})
 
@@ -32,6 +38,10 @@ package("libjq")
         if package:config("oniguruma") then
             package:add("deps", "oniguruma")
         end
+    end)
+
+    on_check(function (package)
+        assert(not (package:is_plat("android") and package:is_subhost("windows")), "package(libjq): does not support windows@android.")
     end)
 
     on_install("!windows and !wasm", function (package)

--- a/packages/l/libjq/xmake.lua
+++ b/packages/l/libjq/xmake.lua
@@ -70,5 +70,8 @@ package("libjq")
     end)
 
     on_test(function (package)
+        if not package:is_cross() then
+            os.vrun("jq --version")
+        end
         assert(package:has_cfuncs("jq_init" , {includes = "jq.h"}))
     end)

--- a/packages/l/libjq/xmake.lua
+++ b/packages/l/libjq/xmake.lua
@@ -1,6 +1,7 @@
 package("libjq")
     set_homepage("https://jqlang.org")
     set_description("Command-line JSON processor")
+    set_license("MIT")
 
     add_urls("https://github.com/jqlang/jq/archive/refs/tags/jq-$(version).tar.gz",
              "https://github.com/jqlang/jq.git")

--- a/packages/l/libjq/xmake.lua
+++ b/packages/l/libjq/xmake.lua
@@ -35,7 +35,12 @@ package("libjq")
         end
     end)
 
-    on_install("!windows and !msys and !wasm", function (package)
+    on_check(function (package)
+        assert(not (package:is_plat("android") and package:is_subhost("windows")), "package(libjq): does not support windows@android.")
+        assert(not (package:is_plat("mingw") and package:is_subhost("msys")), "package(libjq): does not support windows@mingw.")
+    end)
+
+    on_install("!windows and !wasm", function (package)
         local configs = {"--enable-docs=no"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))


### PR DESCRIPTION
If msys, does it need to be? Or keep as is.
```
    if is_subhost("msys") then
        add_deps("autotools")
    else
        add_deps("autoconf", "automake", "libtool")
    end
    
    -- assert(not (package:is_plat("mingw") and package:is_subhost("msys")), "package(libjq): does not support windows@mingw.")
    
```
Seems it some sort of bug for msys. :/ IDK what can be done upon that. 
https://github.com/jqlang/jq/wiki/Cross-compilation it seems mingw-w64 can *cross-build* for windows.
```
checkinfo: cannot runv(autoreconf --version), No such file or directory
checking for autoreconf ... no
error: @programdir\modules\package\tools\autoconf.lua:515: autoreconf not found!
```
Shy version.
![image](https://github.com/user-attachments/assets/f128e470-ff2b-46da-a93c-2b0b94a53fc6)

