### PR TITLE
Auto-update nlopt to v2.10.0

### DIFF
--- a/packages/n/nlopt/xmake.lua
+++ b/packages/n/nlopt/xmake.lua
@@ -6,6 +6,7 @@ package("nlopt")
     add_urls("https://github.com/stevengj/nlopt/archive/refs/tags/$(version).tar.gz",
              "https://github.com/stevengj/nlopt.git")
 
+    add_versions("v2.10.0", "506f83a9e778ad4f204446e99509cb2bdf5539de8beccc260a014bd560237be1")
     add_versions("v2.9.1", "1e6c33f8cbdc4138d525f3326c231f14ed50d99345561e85285638c49b64ee93")
     add_versions("v2.8.0", "e02a4956a69d323775d79fdaec7ba7a23ed912c7d45e439bc933d991ea3193fd")
     add_versions("v2.7.0", "b881cc2a5face5139f1c5a30caf26b7d3cb43d69d5e423c9d78392f99844499f")


### PR DESCRIPTION
New version of nlopt detected (package version: v2.9.1, last github version: v2.10.0)