### PR TITLE
Auto-update libassert to v2.1.5

### DIFF
--- a/packages/l/libassert/xmake.lua
+++ b/packages/l/libassert/xmake.lua
@@ -6,6 +6,7 @@ package("libassert")
     add_urls("https://github.com/jeremy-rifkin/libassert/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jeremy-rifkin/libassert.git")
 
+    add_versions("v2.1.5", "0812721d4bbc0193ef2509909b05bb0226d5718284ad9419d478e091ed2101de")
     add_versions("v2.1.4", "9fa5f5b69e24d020a72b706f05802bf0028587b93a43b59bc99b5bef305b0c72")
     add_versions("v2.1.2", "a7220ca354270deca08a7a162b93523c738ba3c8037a4df1a46ababfdc664196")
     add_versions("v2.1.1", "2bdf27523f964f41668d266cfdbd7f5f58988af963d976577195969ed44359d1")


### PR DESCRIPTION
New version of libassert detected (package version: v2.1.4, last github version: v2.1.5)