### PR TITLE
Auto-update lzav to 4.9

### DIFF
--- a/packages/l/lzav/xmake.lua
+++ b/packages/l/lzav/xmake.lua
@@ -7,6 +7,7 @@ package("lzav")
     add_urls("https://github.com/avaneev/lzav/archive/refs/tags/$(version).tar.gz",
              "https://github.com/avaneev/lzav.git")
 
+    add_versions("4.9", "460aaed16cce0ce1d6af03cf20db1dd9566adef7e1cbc8529ce1b8653ede0412")
     add_versions("4.7", "bb888588ec0edce238ce900806ff9cd1722b6109374cb7766587ad8375cd1517")
     add_versions("4.5", "2323c33c0b44e4ed70f93c04ebd36402c1b399cbe967b4c178d56b1599c71ffe")
     add_versions("4.4", "6b1ea3da59162d5b42a9b1e1b23b21c5caca584a7f55c844c3941e4dd1518cd5")


### PR DESCRIPTION
New version of lzav detected (package version: 4.7, last github version: 4.9)