### PR TITLE
Test melon

### DIFF
--- a/packages/m/melon/xmake.lua
+++ b/packages/m/melon/xmake.lua
@@ -6,20 +6,23 @@ package("melon")
     add_urls("https://github.com/Water-Melon/Melon.git")
     add_versions("2025.01.18", "9df92922ab384295380d4414493e69983671dbf5")
 
-    if is_plat("mingw") then
-        add_deps("mman_win32")    
-    end
+    on_check(function (package)
+        if is_plat("mingw") and is_subhost("msys") then
+            raise("package(melon) is unsupported on MinGW64/UCRT64. Use CLANG64 Shell.")
+        end
+        if is_plat("android") then
+            import("core.tool.toolchain")
+            local ndk = toolchain.load("ndk", {plat = package:plat(), arch = package:arch()})
+            local ndk_sdkver = ndk:config("ndk_sdkver")
+            assert(ndk_sdkver and tonumber(ndk_sdkver) >= 26, "package(melon): need ndk api level >= 26 for android")
+        end
+    end)
 
     on_install(function (package)
         io.replace("include/mln_utils.h", 
         "#if defined(__APPLE__) || defined(MSVC) || defined(__wasm__) || defined(__FreeBSD__)", 
-        "#if defined(__APPLE__) || defined(MSVC) || defined(__wasm__) || defined(__FreeBSD__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__ANDROID_API__)", {plain = true})
-        if is_plat("mingw") then
-            io.replace("src/mln_bignum.c", "#include <stdlib.h>", "#include <pthread.h>\n#include <stdlib.h>", {plain = true})
+        "#if defined(__APPLE__) || defined(MSVC) || defined(__wasm__) || defined(__FreeBSD__) || defined(__ANDROID_API__)", {plain = true})
 
-            io.replace("include/mln_event.h", "#if defined(MSVC)", "#if 1", {plain = true})
-            io.replace("include/mln_connection.h", "#if defined(MSVC)", "#if 1", {plain = true})
-        end
         if is_plat("windows") then
             for _, file in ipairs(os.files("src/*.c")) do
                 io.replace(file, "!defined(MSVC)", "0", {plain = true})
@@ -36,18 +39,10 @@ package("melon")
         io.replace("src/mln_path.c", "MLN_NULL", [["]] .. path.join(home, "bin"):gsub([[\]], [[\\]]) .. [["]], {plain = true})
         io.replace("src/mln_path.c", "MLN_LANG_LIB", [["]] .. path.join(home, "lib"):gsub([[\]], [[\\]]) .. [["]], {plain = true})
         io.replace("src/mln_path.c", "MLN_LANG_DYLIB", [["]] .. path.join(home, "lib"):gsub([[\]], [[\\]]) .. [["]], {plain = true})
-        io.cat("src/mln_path.c")
 
         io.writefile("xmake.lua", [[
             add_rules("mode.debug", "mode.release")
-            if is_plat("mingw") then
-                add_requires("mman_win32")    
-            end
             target("melon")
-                if is_plat("mingw") then
-                    add_packages("mman_win32")
-                    add_defines("_DEFAULT_SOURCE", "_POSIX_C_SOURCE=200809L")
-                end
                 if is_plat("windows") then
                     set_languages("c11")
                 else

--- a/packages/m/melon/xmake.lua
+++ b/packages/m/melon/xmake.lua
@@ -1,6 +1,6 @@
 package("melon")
     set_homepage("http://doc.melonc.io")
-    set_description(" A generic cross-platform C library that includes many commonly used components and frameworks, and a new scripting language interpreter. It currently supports C99 and Aspect-Oriented Programming (AOP).")
+    set_description("A generic cross-platform C library that includes many commonly used components and frameworks, and a new scripting language interpreter. It currently supports C99 and Aspect-Oriented Programming (AOP).")
     set_license("BSD-3-Clause")
 
     add_urls("https://github.com/Water-Melon/Melon.git")
@@ -17,7 +17,7 @@ package("melon")
     end)
 
     on_install("!android", function (package)
-        if is_plat("windows") then
+        if package:is_plat("windows") then
             for _, file in ipairs(os.files("src/*.c")) do
                 io.replace(file, "!defined(MSVC)", "0", {plain = true})
                 io.replace(file, "defined(MSVC)", "1", {plain = true})

--- a/packages/m/melon/xmake.lua
+++ b/packages/m/melon/xmake.lua
@@ -11,7 +11,7 @@ package("melon")
     end
 
     on_check("mingw", function (package)
-        if is_subhost("macos") or is_subhost("msys") then
+        if is_subhost("macosx") or is_subhost("msys") then
             raise("package(melon) is unsupported on MinGW64/UCRT64. Use CLANG64 Shell.")
         end
     end)

--- a/packages/m/melon/xmake.lua
+++ b/packages/m/melon/xmake.lua
@@ -11,6 +11,9 @@ package("melon")
     end
 
     on_check("mingw", function (package)
+        if is_subhost("macosx") then
+            raise("package(melon) is unsupported on Mac OS X subhost.")
+        end
         local msystem = os.getenv("MSYSTEM")
         if msystem then
             if msystem ~= "CLANG64" or msystem ~= "CLANGARM64" then 

--- a/packages/m/melon/xmake.lua
+++ b/packages/m/melon/xmake.lua
@@ -11,8 +11,11 @@ package("melon")
     end
 
     on_check("mingw", function (package)
-        if is_subhost("macosx") or is_subhost("msys") then
-            raise("package(melon) is unsupported on MinGW64/UCRT64. Use CLANG64 Shell.")
+        local msystem = os.getenv("MSYSTEM")
+        if msystem then
+            if msystem != "CLANG64" or msystem != "CLANGARM64" then 
+                raise("package(melon) is unsupported on MinGW64/UCRT64. Use CLANG64 Shell.")
+            end
         end
     end)
 

--- a/packages/m/melon/xmake.lua
+++ b/packages/m/melon/xmake.lua
@@ -13,8 +13,8 @@ package("melon")
     on_check("mingw", function (package)
         local msystem = os.getenv("MSYSTEM")
         if msystem then
-            if msystem != "CLANG64" or msystem != "CLANGARM64" then 
-                raise("package(melon) is unsupported on MinGW64/UCRT64. Use CLANG64 Shell.")
+            if msystem ~= "CLANG64" or msystem ~= "CLANGARM64" then 
+                raise("package(melon) is unsupported on MinGW64/UCRT64. Use CLANG64/CLANGARM64 Shell.")
             end
         end
     end)

--- a/packages/m/melon/xmake.lua
+++ b/packages/m/melon/xmake.lua
@@ -1,0 +1,55 @@
+package("melon")
+    set_homepage("http://doc.melonc.io")
+    set_description(" A generic cross-platform C library that includes many commonly used components and frameworks, and a new scripting language interpreter. It currently supports C99 and Aspect-Oriented Programming (AOP).")
+    set_license("BSD-3-Clause")
+
+    add_urls("https://github.com/Water-Melon/Melon.git")
+    add_versions("2025.01.18", "9df92922ab384295380d4414493e69983671dbf5")
+
+    on_install(function (package)
+        if is_plat("windows") then
+            for _, file in ipairs(os.files("src/*.c")) do
+                io.replace(file, "!defined(MSVC)", "0", {plain = true})
+                io.replace(file, "defined(MSVC)", "1", {plain = true})
+            end
+            for _, file in ipairs(os.files("include/*.h")) do
+                io.replace(file, "!defined(MSVC)", "0", {plain = true})
+                io.replace(file, "defined(MSVC)", "1", {plain = true})
+            end
+        end
+
+        local home = package:installdir()
+        io.replace("src/mln_path.c", "MLN_ROOT", [["]] .. path.join(home, "bin"):gsub([[\]], [[\\]]) .. [["]], {plain = true})
+        io.replace("src/mln_path.c", "MLN_NULL", [["]] .. path.join(home, "bin"):gsub([[\]], [[\\]]) .. [["]], {plain = true})
+        io.replace("src/mln_path.c", "MLN_LANG_LIB", [["]] .. path.join(home, "lib"):gsub([[\]], [[\\]]) .. [["]], {plain = true})
+        io.replace("src/mln_path.c", "MLN_LANG_DYLIB", [["]] .. path.join(home, "lib"):gsub([[\]], [[\\]]) .. [["]], {plain = true})
+        io.cat("src/mln_path.c")
+
+        io.writefile("xmake.lua", [[
+            add_rules("mode.debug", "mode.release")
+            target("melon")
+                if is_plat("windows") then
+                    set_languages("c11")
+                else
+                    set_languages("gnu99")
+                end
+                set_kind("$(kind)")
+                add_files("src/*.c")
+                add_headerfiles("include/*.h")
+                add_includedirs("include")
+                if is_plat("windows") and is_kind("shared") then
+                    add_rules("utils.symbols.export_all")
+                end
+                if is_plat("linux", "bsd") then
+                    add_syslinks("dl", "pthread")
+                end
+                if is_plat("windows", "mingw") then
+                    add_syslinks("ws2_32")
+                end
+        ]])
+        import("package.tools.xmake").install(package)
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("mln_aes_init", {includes = "mln_aes.h"}))
+    end)

--- a/packages/m/melon/xmake.lua
+++ b/packages/m/melon/xmake.lua
@@ -10,23 +10,13 @@ package("melon")
         add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
     end
 
-    on_check(function (package)
-        if is_plat("mingw") and is_subhost("msys") then
+    on_check("mingw", function (package)
+        if is_subhost("macos") or is_subhost("msys") then
             raise("package(melon) is unsupported on MinGW64/UCRT64. Use CLANG64 Shell.")
-        end
-        if is_plat("android") then
-            import("core.tool.toolchain")
-            local ndk = toolchain.load("ndk", {plat = package:plat(), arch = package:arch()})
-            local ndk_sdkver = ndk:config("ndk_sdkver")
-            assert(ndk_sdkver and tonumber(ndk_sdkver) >= 26, "package(melon): need ndk api level >= 26 for android")
         end
     end)
 
-    on_install(function (package)
-        io.replace("include/mln_utils.h", 
-        "#if defined(__APPLE__) || defined(MSVC) || defined(__wasm__) || defined(__FreeBSD__)", 
-        "#if defined(__APPLE__) || defined(MSVC) || defined(__wasm__) || defined(__FreeBSD__) || defined(__ANDROID_API__)", {plain = true})
-
+    on_install("!android", function (package)
         if is_plat("windows") then
             for _, file in ipairs(os.files("src/*.c")) do
                 io.replace(file, "!defined(MSVC)", "0", {plain = true})

--- a/packages/m/melon/xmake.lua
+++ b/packages/m/melon/xmake.lua
@@ -6,6 +6,10 @@ package("melon")
     add_urls("https://github.com/Water-Melon/Melon.git")
     add_versions("2025.01.18", "9df92922ab384295380d4414493e69983671dbf5")
 
+    if is_plat("windows") then
+        add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+    end
+
     on_check(function (package)
         if is_plat("mingw") and is_subhost("msys") then
             raise("package(melon) is unsupported on MinGW64/UCRT64. Use CLANG64 Shell.")
@@ -52,9 +56,6 @@ package("melon")
                 add_files("src/*.c")
                 add_headerfiles("include/*.h")
                 add_includedirs("include")
-                if is_plat("windows") and is_kind("shared") then
-                    add_rules("utils.symbols.export_all")
-                end
                 if is_plat("linux", "bsd") then
                     add_syslinks("dl", "pthread")
                 end


### PR DESCRIPTION
Windows has not DLL build support.

MinGW32/64 or UCRT would not work, but Clang64 is working. I do not know upon Mac OS X MinGW-W64 so Ill place up placeholder there.
```lua
        if is_subhost("macosx") then
            raise("package(melon) is unsupported on Mac OS X subhost.")
        end
```