### PR TITLE
Auto-update libavif to v1.2.1

### DIFF
--- a/packages/l/libavif/xmake.lua
+++ b/packages/l/libavif/xmake.lua
@@ -22,6 +22,11 @@ package("libavif")
             local ndk = package:toolchain("ndk"):config("ndkver")
             assert(ndk and tonumber(ndk) > 22, "package(libavif): library deps libyuv need ndk version > 22")
         end)
+        on_check("linux", function (package)
+            if package:is_arch("arm64") then
+                raise("package(libavif): library deps libyuv unsupport compile flags -march=armv9-a+sme")
+            end
+        end)
     end
 
     on_load(function (package)

--- a/packages/l/libavif/xmake.lua
+++ b/packages/l/libavif/xmake.lua
@@ -6,6 +6,7 @@ package("libavif")
     add_urls("https://github.com/AOMediaCodec/libavif/archive/refs/tags/$(version).tar.gz",
              "https://github.com/AOMediaCodec/libavif.git")
 
+    add_versions("v1.2.1", "9c859c7c12ccb0f407511bfe303e6a7247f5f6738f54852662c6df8048daddf4")
     add_versions("v1.1.1", "914662e16245e062ed73f90112fbb4548241300843a7772d8d441bb6859de45b")
     add_versions("v1.1.0", "edb31951005d7a143be1724f24825809599a4832073add50eaf987733defb5c8")
     add_versions("v1.0.4", "dc56708c83a4b934a8af2b78f67f866ba2fb568605c7cf94312acf51ee57d146")

--- a/packages/l/libyuv/xmake.lua
+++ b/packages/l/libyuv/xmake.lua
@@ -34,6 +34,11 @@ package("libyuv")
             local ndk = package:toolchain("ndk"):config("ndkver")
             assert(ndk and tonumber(ndk) > 22, "package(libyuv): need ndk version > 22")
         end)
+        on_check("linux", function (package)
+            if package:is_arch("arm64") then
+                raise("package(libuv) unsupport compile flags -march=armv9-a+sme")
+            end
+        end)
     end
 
     on_load(function (package)


### PR DESCRIPTION
New version of libavif detected (package version: v1.1.1, last github version: v1.2.1)