### PR TITLE
[imgui] add sdl3 `gpu` backend

### DIFF
--- a/packages/i/imgui/port/xmake.lua
+++ b/packages/i/imgui/port/xmake.lua
@@ -138,16 +138,8 @@ target("imgui")
     end
 
     if has_config("sdl3_gpu") then
-        print("using sdl3 with gpu")
-        add_files(
-            "backends/imgui_impl_sdl3.cpp",
-            "backends/imgui_impl_sdlgpu3.cpp"
-        )
-        add_headerfiles(
-            "backends/imgui_impl_sdl3.h",
-            "backends/imgui_impl_sdlgpu3.h",
-            "backends/imgui_impl_sdlgpu3_shaders.h"
-        )
+        add_files("backends/imgui_impl_sdlgpu3.cpp")
+        add_headerfiles("backends/imgui_impl_sdlgpu3.h","backends/imgui_impl_sdlgpu3_shaders.h")
         add_packages("libsdl3")
     end
 

--- a/packages/i/imgui/port/xmake.lua
+++ b/packages/i/imgui/port/xmake.lua
@@ -14,6 +14,7 @@ option("sdl2",             {showmenu = true,  default = false})
 option("sdl2_renderer",    {showmenu = true,  default = false})
 option("sdl3",             {showmenu = true,  default = false})
 option("sdl3_renderer",    {showmenu = true,  default = false})
+option("sdl3_gpu",         {showmenu = true,  default = false})
 option("vulkan",           {showmenu = true,  default = false})
 option("win32",            {showmenu = true,  default = false})
 option("wgpu",             {showmenu = true,  default = false})
@@ -34,7 +35,7 @@ if has_config("sdl2_renderer") then
 elseif has_config("sdl2") then
     add_requires("libsdl2")
 end
-if has_config("sdl3") or has_config("sdl3_renderer") then
+if has_config("sdl3") or has_config("sdl3_renderer") or has_config("sdl3_gpu") then
     add_requires("libsdl3")
 end
 
@@ -133,6 +134,20 @@ target("imgui")
     if has_config("sdl3_renderer") then
         add_files("backends/imgui_impl_sdlrenderer3.cpp")
         add_headerfiles("(backends/imgui_impl_sdlrenderer3.h)")
+        add_packages("libsdl3")
+    end
+
+    if has_config("sdl3_gpu") then
+        print("using sdl3 with gpu")
+        add_files(
+            "backends/imgui_impl_sdl3.cpp",
+            "backends/imgui_impl_sdlgpu3.cpp"
+        )
+        add_headerfiles(
+            "backends/imgui_impl_sdl3.h",
+            "backends/imgui_impl_sdlgpu3.h",
+            "backends/imgui_impl_sdlgpu3_shaders.h"
+        )
         add_packages("libsdl3")
     end
 

--- a/packages/i/imgui/xmake.lua
+++ b/packages/i/imgui/xmake.lua
@@ -94,7 +94,7 @@ package("imgui")
     add_configs("sdl2_renderer",    {description = "Enable the sdl2 renderer backend", default = false, type = "boolean"})
     add_configs("sdl3",             {description = "Enable the sdl3 backend with sdl3_renderer", default = false, type = "boolean"})
     add_configs("sdl3_renderer",    {description = "Enable the sdl3 renderer backend", default = false, type = "boolean"})
-    add_configs("sdl3_gpu",         {description = "Enable the sdl3 backend without sdl3_gpu", default = false, type = "boolean"})
+    add_configs("sdl3_gpu",         {description = "Enable the sdl3 gpu backend", default = false, type = "boolean"})
     add_configs("vulkan",           {description = "Enable the vulkan backend", default = false, type = "boolean"})
     add_configs("win32",            {description = "Enable the win32 backend", default = false, type = "boolean"})
     add_configs("wgpu",             {description = "Enable the wgpu backend", default = false, type = "boolean"})
@@ -150,7 +150,7 @@ package("imgui")
         if package:config("sdl2_renderer") then
             package:add("deps", "libsdl2 >=2.0.17")
         end
-        if package:config("sdl3_no_renderer") or package:config("sdl3_renderer") or package:config("sdl3_gpu") then
+        if package:config("sdl3") or package:config("sdl3_renderer") or package:config("sdl3_gpu") then
             package:add("deps", "libsdl3")
         end
         if package:config("vulkan") then

--- a/packages/i/imgui/xmake.lua
+++ b/packages/i/imgui/xmake.lua
@@ -94,6 +94,7 @@ package("imgui")
     add_configs("sdl2_renderer",    {description = "Enable the sdl2 renderer backend", default = false, type = "boolean"})
     add_configs("sdl3",             {description = "Enable the sdl3 backend with sdl3_renderer", default = false, type = "boolean"})
     add_configs("sdl3_renderer",    {description = "Enable the sdl3 renderer backend", default = false, type = "boolean"})
+    add_configs("sdl3_gpu",         {description = "Enable the sdl3 backend without sdl3_gpu", default = false, type = "boolean"})
     add_configs("vulkan",           {description = "Enable the vulkan backend", default = false, type = "boolean"})
     add_configs("win32",            {description = "Enable the win32 backend", default = false, type = "boolean"})
     add_configs("wgpu",             {description = "Enable the wgpu backend", default = false, type = "boolean"})
@@ -149,7 +150,7 @@ package("imgui")
         if package:config("sdl2_renderer") then
             package:add("deps", "libsdl2 >=2.0.17")
         end
-        if package:config("sdl3_no_renderer") or package:config("sdl3_renderer") then
+        if package:config("sdl3_no_renderer") or package:config("sdl3_renderer") or package:config("sdl3_gpu") then
             package:add("deps", "libsdl3")
         end
         if package:config("vulkan") then
@@ -177,6 +178,7 @@ package("imgui")
             sdl2_renderer    = package:config("sdl2_renderer"),
             sdl3             = package:config("sdl3"),
             sdl3_renderer    = package:config("sdl3_renderer"),
+            sdl3_gpu         = package:config("sdl3_gpu"),
             vulkan           = package:config("vulkan"),
             win32            = package:config("win32"),
             wgpu             = package:config("wgpu"),


### PR DESCRIPTION
看了包里只有 sdl3 与 sdl3_render 配置，但却缺少了以`sdl3gpu`为后端相关的头文件与cpp。所以增加了 `sdl3_gpu` 配置以供引入对应的文件。