### PR TITLE
Test sfgui

### DIFF
--- a/packages/s/sfgui/port/xmake.lua
+++ b/packages/s/sfgui/port/xmake.lua
@@ -1,0 +1,47 @@
+add_rules("mode.debug", "mode.release")
+set_languages("c++17")
+
+add_requires("sfml", {configs = {graphics = true}})
+add_requires("opengl")
+
+if is_plat("linux", "bsd", "cross") then
+    add_requires("libx11")
+end
+
+option("font", {default = true})
+
+target("sfgui")
+    set_kind("$(kind)")
+
+    if is_plat("windows") then
+        add_defines("WIN32_LEAN_AND_MEAN", "NOMINMAX")
+    end
+
+    if is_plat("windows") and is_kind("shared") then
+        add_defines("SFGUI_EXPORTS")
+    end
+
+    if is_kind("static") then
+        add_defines("SFGUI_STATIC")
+    end
+
+    add_packages("sfml", "opengl")
+
+    if is_plat("linux", "bsd", "cross") then
+        add_packages("libx11")
+    end
+
+    if is_plat("macosx", "iphoneos") then
+        add_frameworks("CoreFoundation", "Foundation")
+    end
+
+    add_files("src/**.cpp")
+
+    if not has_config("font") then
+        remove_files("src/SFGUI/DejaVuSansFont.cpp")
+    else
+        add_defines("SFGUI_INCLUDE_FONT")
+    end
+
+    add_includedirs("src", "include", "extlibs/libELL/include")
+    add_headerfiles("include/(SFGUI/**.hpp)", "include/(SFGUI/**.inl)")

--- a/packages/s/sfgui/port/xmake.lua
+++ b/packages/s/sfgui/port/xmake.lua
@@ -1,7 +1,12 @@
 add_rules("mode.debug", "mode.release")
 set_languages("c++17")
 
-add_requires("sfml", {configs = {graphics = true}})
+if is_plat("mingw") then
+    add_requires("sfml", {configs = {graphics = true, shared = true}})
+else
+    add_requires("sfml", {configs = {graphics = true}})
+end
+
 add_requires("opengl")
 
 if is_plat("linux", "bsd", "cross") then

--- a/packages/s/sfgui/port/xmake.lua
+++ b/packages/s/sfgui/port/xmake.lua
@@ -17,7 +17,7 @@ target("sfgui")
         add_defines("WIN32_LEAN_AND_MEAN", "NOMINMAX")
     end
 
-    if is_plat("windows") and is_kind("shared") then
+    if is_plat("windows", "mingw") and is_kind("shared") then
         add_defines("SFGUI_EXPORTS")
     end
 

--- a/packages/s/sfgui/xmake.lua
+++ b/packages/s/sfgui/xmake.lua
@@ -27,6 +27,7 @@ package("sfgui")
     end
 
     on_install("windows", "linux", "macosx", "mingw", function (package)
+        io.replace("include/SFGUI/Config.hpp", "defined( SFGUI_STATIC )", not package:config("shared") and "1" or "0", {plain = true})
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         import("package.tools.xmake").install(package)
     end)
@@ -37,5 +38,5 @@ package("sfgui")
                 sfg::Window::Ptr window = sfg::Window::Create();
 	            window->SetTitle( "Title" );
             }
-        ]]}, {configs = {languages = "c++17", defines = not package:config("shared") and "SFGUI_STATIC" or nil}, includes = { "SFGUI/SFGUI.hpp", "SFGUI/Widgets.hpp" } }))
+        ]]}, {configs = {languages = "c++17"}, includes = { "SFGUI/SFGUI.hpp", "SFGUI/Widgets.hpp" } }))
     end)

--- a/packages/s/sfgui/xmake.lua
+++ b/packages/s/sfgui/xmake.lua
@@ -10,7 +10,12 @@ package("sfgui")
 
     add_configs("font", {description = "Include default font in library (DejaVuSans)", default = true, type = "boolean"})
 
-    add_deps("sfml", {configs = {graphics = true}})
+    if is_plat("mingw") then
+        add_deps("sfml", {configs = {graphics = true, shared = true}})
+    else
+        add_deps("sfml", {configs = {graphics = true}})
+    end
+
     add_deps("opengl")
 
     if is_plat("linux", "bsd", "cross") then
@@ -20,14 +25,10 @@ package("sfgui")
     if is_plat("macosx", "iphoneos") then
         add_frameworks("CoreFoundation", "Foundation")
     end
- 
+
     on_install("windows", "linux", "macosx", "mingw", function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
-        local configs = {}
-        if package:config("shared") then
-            configs.kind = "shared"
-        end
-        import("package.tools.xmake").install(package, configs)
+        import("package.tools.xmake").install(package)
     end)
 
     on_test(function (package)

--- a/packages/s/sfgui/xmake.lua
+++ b/packages/s/sfgui/xmake.lua
@@ -27,7 +27,7 @@ package("sfgui")
     end
 
     on_install("windows", "linux", "macosx", "mingw", function (package)
-        io.replace("include/SFGUI/Config.hpp", "defined( SFGUI_STATIC )", not package:config("shared") and "1" or "0", {plain = true})
+        io.replace("include/SFGUI/Config.hpp", "!defined( SFGUI_STATIC )", not package:config("shared") and "0" or "1", {plain = true})
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         import("package.tools.xmake").install(package)
     end)

--- a/packages/s/sfgui/xmake.lua
+++ b/packages/s/sfgui/xmake.lua
@@ -21,7 +21,7 @@ package("sfgui")
         add_frameworks("CoreFoundation", "Foundation")
     end
 
-    on_install(function (package)
+    on_install("windows", "linux", "macosx", "mingw", function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         local configs = {}
         if package:config("shared") then

--- a/packages/s/sfgui/xmake.lua
+++ b/packages/s/sfgui/xmake.lua
@@ -20,7 +20,7 @@ package("sfgui")
     if is_plat("macosx", "iphoneos") then
         add_frameworks("CoreFoundation", "Foundation")
     end
-
+ 
     on_install("windows", "linux", "macosx", "mingw", function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         local configs = {}
@@ -34,7 +34,7 @@ package("sfgui")
         assert(package:check_cxxsnippets({test = [[
             void test() {
                 sfg::Window::Ptr window = sfg::Window::Create();
-	            window->SetTitle( "Title" );      
+	            window->SetTitle( "Title" );
             }
         ]]}, {configs = {languages = "c++17", defines = not package:config("shared") and "SFGUI_STATIC" or nil}, includes = { "SFGUI/SFGUI.hpp", "SFGUI/Widgets.hpp" } }))
     end)

--- a/packages/s/sfgui/xmake.lua
+++ b/packages/s/sfgui/xmake.lua
@@ -1,0 +1,40 @@
+package("sfgui")
+    set_homepage("https://github.com/TankOs/SFGUI")
+    set_description("Simple and Fast Graphical User Interface")
+    set_license("zlib")
+
+    add_urls("https://github.com/TankOs/SFGUI/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/TankOs/SFGUI.git")
+
+    add_versions("1.0.0", "280993756cfa8ca82574a5c505f4ce65f192037d523d38572552e96ca18aa3a0")
+
+    add_configs("font", {description = "Include default font in library (DejaVuSans)", default = true, type = "boolean"})
+
+    add_deps("sfml", {configs = {graphics = true}})
+    add_deps("opengl")
+
+    if is_plat("linux", "bsd", "cross") then
+        add_deps("libx11")
+    end
+
+    if is_plat("macosx", "iphoneos") then
+        add_frameworks("CoreFoundation", "Foundation")
+    end
+
+    on_install(function (package)
+        os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
+        local configs = {}
+        if package:config("shared") then
+            configs.kind = "shared"
+        end
+        import("package.tools.xmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            void test() {
+                sfg::Window::Ptr window = sfg::Window::Create();
+	            window->SetTitle( "Title" );      
+            }
+        ]]}, {configs = {languages = "c++17", defines = not package:config("shared") and "SFGUI_STATIC" or nil}, includes = { "SFGUI/SFGUI.hpp", "SFGUI/Widgets.hpp" } }))
+    end)


### PR DESCRIPTION
Feel free to change this PR.
SFML 3 supports "windows", "linux", "macosx", "mingw".
Dunno upon error here for MinGW... Would be nice to avoid ```defines = not package:config("shared") and "SFGUI_STATIC" or nil```
https://stackoverflow.com/questions/48661676/sfml-undefined-reference-to-imp
_imp___ZN2sf6StringC1EPKcRKSt6locale <=> sf::String::String(const char*, const std::locale&) ?
Resolves https://github.com/xmake-io/xmake-repo/pull/2122