### PR TITLE
Allow node-addon-api to be used on non-Linux platforms

### DIFF
--- a/packages/n/node-addon-api/xmake.lua
+++ b/packages/n/node-addon-api/xmake.lua
@@ -9,7 +9,8 @@ package("node-addon-api")
     add_configs("napi_version", {description = "Target a specific Node-API version.", default = nil, type = "number"})
 
     set_urls("https://github.com/nodejs/node-addon-api/archive/refs/tags/$(version).tar.gz",
-        "https://github.com/nodejs/node-addon-api.git")
+             "https://github.com/nodejs/node-addon-api.git")
+
     add_versions("v8.3.1", "16aa87cdf2f86f185ef4927cf525c01bc19138465f0dcf6ef7f66c5a985d671d")
     add_versions("v8.3.0", "a5ddbbe7c4a04aa4d438205e2f90bfc476042951e8ebddac6883f123a7e88cae")
     add_versions("v8.2.2", "b9fe0f1535deb17825ff57fb97b4690f49517a42c923e475e960870831f2fa79")
@@ -22,7 +23,7 @@ package("node-addon-api")
         if not package:config("deprecated") then
             package:add("defines", "NODE_ADDON_API_DISABLE_DEPRECATED")
         end
-        
+
         local errors = package:config("errors")
         if errors == "noexcept" or errors == "maybe" then
             package:add("cxxflags", "-fno-exceptions")
@@ -41,5 +42,5 @@ package("node-addon-api")
     end)
 
     on_test(function (package)
-        assert(package:has_cxxfuncs("Napi::Just(0)", {includes = "napi.h"}))
+        assert(package:has_cxxfuncs("Napi::Just(0)", {configs = {languages = "c++11"}, includes = "napi.h"}))
     end)

--- a/packages/n/node-addon-api/xmake.lua
+++ b/packages/n/node-addon-api/xmake.lua
@@ -36,7 +36,7 @@ package("node-addon-api")
         end
     end)
 
-    on_install("linux" ,function(package)
+    on_install(function(package)
         os.cp("*.h", package:installdir("include"))
     end)
 


### PR DESCRIPTION
`node-addon-api` 目前的配置只允许在 linux 平台上使用，但根据其官方 [README.md](https://github.com/nodejs/node-addon-api)，并没有相关限制