### PR TITLE
Auto-update vcpkg to 2025.03.19

### DIFF
--- a/packages/v/vcpkg/xmake.lua
+++ b/packages/v/vcpkg/xmake.lua
@@ -5,6 +5,7 @@ package("vcpkg")
     set_license("MIT")
 
     add_urls("https://github.com/microsoft/vcpkg/archive/refs/tags/$(version).tar.gz")
+    add_versions("2025.03.19", "b943a85c6a50cedf4d0d97ff67f96afa4efb28213fd3bad16ff234337eb22f7a")
     add_versions("2024.11.16", "ec932ad758fb2b3aefc0d712d4bde8d913cd97ad2a0067d52f23d05c31b42aa0")
     add_versions("2024.10.21", "879ff57284d0bdcab127315a994cf571de4c1c72a0f7a80b770c3e3714d1649b")
     add_versions("2024.09.30", "02a8f2e70e61d02401ec9f04906996549c270f6bdc788a82f830e0a87768543e")


### PR DESCRIPTION
New version of vcpkg detected (package version: 2024.11.16, last github version: 2025.03.19)