### PR TITLE
Auto-update s2n-tls to v1.5.15

### DIFF
--- a/packages/s/s2n-tls/xmake.lua
+++ b/packages/s/s2n-tls/xmake.lua
@@ -6,6 +6,7 @@ package("s2n-tls")
     add_urls("https://github.com/aws/s2n-tls/archive/refs/tags/$(version).tar.gz",
              "https://github.com/aws/s2n-tls.git")
 
+    add_versions("v1.5.15", "103f9361c736fea7278038891b0566ff975c40ac59cef5ac5b9225a476c8abc6")
     add_versions("v1.5.14", "3f65f1eca85a8ac279de204455a3e4940bc6ad4a1df53387d86136bcecde0c08")
     add_versions("v1.5.12", "718866ea8276f4d5c78a4b6506561599a4ff5c05b3fccee7ef7ad6198b23e660")
     add_versions("v1.5.10", "6f13d37658954cc24f4eb8c7f30736e026ce06f8c9609f7820ab82504618a98d")


### PR DESCRIPTION
New version of s2n-tls detected (package version: v1.5.14, last github version: v1.5.15)