### PR TITLE
Auto-update gyp-next to v0.20.0

### DIFF
--- a/packages/g/gyp-next/xmake.lua
+++ b/packages/g/gyp-next/xmake.lua
@@ -7,6 +7,7 @@ package("gyp-next")
 
     add_urls("https://github.com/nodejs/gyp-next/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nodejs/gyp-next.git")
+    add_versions("v0.20.0", "b16de6130423c25f05e92329464feaf55dc51efc4557ddadfaf951770ca30252")
     add_versions("v0.19.1", "dc8fa22348d96055045eeadba938550b157ebcc275ddc7da8994eb0d54299e06")
     add_versions("v0.18.3", "9f48804a65941f53e453925ce1c628fe5a6a748f9d915ae02b5eb766c4f5a2d9")
     add_versions("v0.18.2", "d709119fa756fec7d7d2c7663553d73f6bf1ad4e139b4ec21fed5c65abc7bd3b")


### PR DESCRIPTION
New version of gyp-next detected (package version: v0.19.1, last github version: v0.20.0)