### PR TITLE
Fix SFML mingw cross compiling

### DIFF
--- a/packages/s/sfml/xmake.lua
+++ b/packages/s/sfml/xmake.lua
@@ -248,7 +248,9 @@ package("sfml")
         table.insert(configs, "-DSFML_BUILD_WINDOW=" .. (package:config("window") and "ON" or "OFF"))
         table.insert(configs, "-DSFML_BUILD_NETWORK=" .. (package:config("network") and "ON" or "OFF"))
         table.insert(configs, "-DWARNINGS_AS_ERRORS=OFF")
-        table.insert(configs, "-DSFML_USE_SYSTEM_DEPS=TRUE")
+        if not is_plat("mingw") then
+            table.insert(configs, "-DSFML_USE_SYSTEM_DEPS=TRUE")
+        end
         if package:gitref() or package:version():ge("3.0.0") then 
             table.insert(configs, "-DCMAKE_CXX_STANDARD=17") 
         end


### PR DESCRIPTION
Setting the `SFML_USE_SYSTEM_DEPS` to `TRUE` when compiling with mingw on linux gives me this error :
```
In file included from /home/simon/.xmake/cache/packages/2503/s/sfml/3.0.0/source/extlibs/headers/miniaudio/miniaudio.h:3754,
                 from /home/simon/.xmake/cache/packages/2503/s/sfml/3.0.0/source/src/SFML/Audio/AudioDevice.hpp:34,
                 from /home/simon/.xmake/cache/packages/2503/s/sfml/3.0.0/source/src/SFML/Audio/Listener.cpp:28:
/usr/include/stdint.h:90:33: error: conflicting declaration ‘typedef long unsigned int uintptr_t’
   90 | typedef unsigned long int       uintptr_t;
      |                                 ^~~~~~~~~
In file included from /usr/share/mingw-w64/include/crtdefs.h:10,
                 from /usr/share/mingw-w64/include/stddef.h:7,
                 from /usr/lib/gcc/x86_64-w64-mingw32/12-posix/include/stddef.h:1,
                 from /home/simon/.xmake/cache/packages/2503/s/sfml/3.0.0/source/extlibs/headers/miniaudio/miniaudio.h:3750:
/usr/share/mingw-w64/include/corecrt.h:75:44: note: previous declaration as ‘typedef long long unsigned int uintptr_t’
   75 | __MINGW_EXTENSION typedef unsigned __int64 uintptr_t;
      |                                            ^~~~~~~~~
In file included from /home/simon/.xmake/cache/packages/2503/s/sfml/3.0.0/source/extlibs/headers/miniaudio/miniaudio.h:3754,
                 from /home/simon/.xmake/cache/packages/2503/s/sfml/3.0.0/source/src/SFML/Audio/AudioDevice.hpp:34,
                 from /home/simon/.xmake/cache/packages/2503/s/sfml/3.0.0/source/src/SFML/Audio/AudioResource.cpp:28:
/usr/include/stdint.h:90:33: error: conflicting declaration ‘typedef long unsigned int uintptr_t’
   90 | typedef unsigned long int       uintptr_t;
```

My fix seems a little dirty but I don't really know how to do it differently