### PR TITLE
Auto-update leancrypto to v1.3.0

### DIFF
--- a/packages/l/leancrypto/xmake.lua
+++ b/packages/l/leancrypto/xmake.lua
@@ -5,6 +5,7 @@ package("leancrypto")
     add_urls("https://github.com/smuellerDD/leancrypto/archive/refs/tags/$(version).tar.gz",
              "https://github.com/smuellerDD/leancrypto.git")
 
+    add_versions("v1.3.0", "53b51936d77304e82cc6aa34a0a65eec3327ca1165342180694c5aa6a7d745c8")
     add_versions("v1.2.0", "247481cac4cedbf4b9e1c689b7726592015352a11cd22625013185d01cda2c15")
 
     if is_plat("linux") then


### PR DESCRIPTION
New version of leancrypto detected (package version: v1.2.0, last github version: v1.3.0)