### PR TITLE
Auto-update entt to v3.15.0

### DIFF
--- a/packages/e/entt/xmake.lua
+++ b/packages/e/entt/xmake.lua
@@ -45,7 +45,7 @@ package("entt")
     end
 
     on_install(function (package)
-        local configs = {"-DENTT_BUILD_TESTING=OFF", "-DENTT_INSTALL=Y"}
+        local configs = {"-DENTT_BUILD_TESTING=OFF", "-DENTT_INSTALL=ON"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         import("package.tools.cmake").install(package, configs)
         os.cp("natvis/entt/*.natvis", package:installdir("include", "entt", "natvis"))

--- a/packages/e/entt/xmake.lua
+++ b/packages/e/entt/xmake.lua
@@ -45,7 +45,7 @@ package("entt")
     end
 
     on_install(function (package)
-        local configs = {"-DENTT_BUILD_TESTING=OFF"}
+        local configs = {"-DENTT_BUILD_TESTING=OFF", "-DENTT_INSTALL=Y"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         import("package.tools.cmake").install(package, configs)
         os.cp("natvis/entt/*.natvis", package:installdir("include", "entt", "natvis"))

--- a/packages/e/entt/xmake.lua
+++ b/packages/e/entt/xmake.lua
@@ -7,6 +7,7 @@ package("entt")
     set_urls("https://github.com/skypjack/entt/archive/refs/tags/$(version).tar.gz",
              "https://github.com/skypjack/entt.git")
 
+    add_versions("v3.15.0", "01466fcbf77618a79b62891510c0bbf25ac2804af5751c84982b413852234d66")
     add_versions("v3.14.0", "e31f6e95a30e2977a50449ef9a607a9ff40febe6f9da2a8144a183f8606f7719")
     add_versions("v3.13.2", "cb556aa543d01177b62de41321759e02d96078948dda72705b3d7fe68af88489")
     add_versions("v3.13.1", "a4f290b601a70333126abd2cec7b0c232c74a4f85dcf1e04d969e8122dae8652")


### PR DESCRIPTION
New version of entt detected (package version: v3.14.0, last github version: v3.15.0)