### PR TITLE
Auto-update highs to v1.10.0

### DIFF
--- a/packages/h/highs/xmake.lua
+++ b/packages/h/highs/xmake.lua
@@ -6,6 +6,7 @@ package("highs")
     add_urls("https://github.com/ERGO-Code/HiGHS/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ERGO-Code/HiGHS.git")
 
+    add_versions("v1.10.0", "cf29873b894133bac111fc45bbf10989b6c5c041992fcd10e31222253e371a4c")
     add_versions("v1.9.0", "dff575df08d88583c109702c7c5c75ff6e51611e6eacca8b5b3fdfba8ecc2cb4")
     add_versions("v1.8.1", "a0d09371fadb56489497996b28433be1ef91a705e3811fcb1f50a107c7d427d1")
     add_versions("v1.8.0", "e184e63101cf19688a02102f58447acc7c021d77eef0d3475ceaceb61f035539")


### PR DESCRIPTION
New version of highs detected (package version: v1.9.0, last github version: v1.10.0)