### PR TITLE
Auto-update ftxui to v6.0.2

### DIFF
--- a/packages/f/ftxui/xmake.lua
+++ b/packages/f/ftxui/xmake.lua
@@ -5,6 +5,7 @@ package("ftxui")
 
     add_urls("https://github.com/ArthurSonzogni/FTXUI/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ArthurSonzogni/FTXUI.git")
+    add_versions("v6.0.2", "ace3477a8dd7cdb911dbc75e7b43cdcc9cf1d4a3cc3fb41168ecc31c06626cb9")
     add_versions("v5.0.0", "a2991cb222c944aee14397965d9f6b050245da849d8c5da7c72d112de2786b5b")
     add_versions("v4.1.1", "9009d093e48b3189487d67fc3e375a57c7b354c0e43fc554ad31bec74a4bc2dd")
     add_versions("v3.0.0", "a8f2539ab95caafb21b0c534e8dfb0aeea4e658688797bb9e5539729d9258cc1")


### PR DESCRIPTION
New version of ftxui detected (package version: v5.0.0, last github version: v6.0.2)