### PR TITLE
Auto-update cutlass to v3.8.0

### DIFF
--- a/packages/c/cutlass/xmake.lua
+++ b/packages/c/cutlass/xmake.lua
@@ -7,6 +7,7 @@ package("cutlass")
     add_urls("https://github.com/NVIDIA/cutlass/archive/refs/tags/$(version).tar.gz",
              "https://github.com/NVIDIA/cutlass.git")
 
+    add_versions("v3.8.0", "14a5e6314f23e41295d8377b6fa6028b35392757a0ee4538a4eacaaa5d7eee37")
     add_versions("v3.7.0", "dfcafb7435a1b114ce32faee4f3257e276caf08f55fea04fa8bf3efa3a83c814")
     add_versions("v3.6.0", "7576f3437b90d0de5923560ccecebaa1357e5d72f36c0a59ad77c959c9790010")
     add_versions("v3.5.1", "20b7247cda2d257cbf8ba59ba3ca40a9211c4da61a9c9913e32b33a2c5883a36")


### PR DESCRIPTION
New version of cutlass detected (package version: v3.7.0, last github version: v3.8.0)