### PR TITLE
botan: add minimal as option

### DIFF
--- a/packages/b/botan/xmake.lua
+++ b/packages/b/botan/xmake.lua
@@ -20,6 +20,7 @@ package("botan")
     add_configs("python", {description = "Enable python module", default = false, type = "boolean"})
     add_configs("endian", {description = [[The  parameter should be either “little” or “big”. If not used then if the target architecture has a default, that is used. Otherwise left unspecified, which causes less optimal codepaths to be used but will work on either little or big endian.]], default = nil, type = "string", values = {"little", "big"}})
     add_configs("modules", {description = [[Enable modules, example: {configs = {modules = {"zlib", "lzma"}}}]], type = "table"})
+    add_configs("minimal", {description = "Build a minimal version", default = true, type = "boolean"})
     if is_plat("wasm") then
         add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
     end
@@ -90,7 +91,6 @@ package("botan")
             "--prefix=" .. package:installdir(),
             "--build-tool=ninja",
             "--without-documentation",
-            "--minimized-build",
         }
 
         local cc
@@ -183,6 +183,10 @@ package("botan")
 
         if package:config("endian") then
             table.insert(configs, "--with-endian=" .. package:config("endian"))
+        end
+
+        if package:config("minimal") then
+            table.insert(configs, "--minimized-build")
         end
 
         local cxflags = {}


### PR DESCRIPTION
The original botan library used a minimal install, which resulted in a lack of many header files. This commit now passes "minimal" as an option to control whether to use a minimal or full build

minimal build:
```
allocator.h
api.h
assert.h
buf_comp.h
build.h
compiler.h
concepts.h
database.h
data_src.h
exceptn.h
hex.h
mem_ops.h
mutex.h
rng.h
secmem.h
strong_type.h
sym_algo.h
symkey.h
types.h
version.h
```

full build:
```
aead.h          build.h                der_enc.h          ed448.h        mac.h                  p11_rsa.h     pk_ops_fwd.h     sphincsplus.h       tls.h                            types.h
allocator.h     certstor_flatfile.h    dh.h               elgamal.h      mceliece.h             p11_types.h   pk_ops.h         sp_parameters.h     tls_handshake_msg.h              uuid.h
api.h           certstor.h             dilithium.h        entropy_src.h  mem_ops.h              p11_x509.h    processor_rng.h  srp6.h              tls_magic.h                      version.h
argon2fmt.h     certstor_sql.h         dl_group.h         exceptn.h      ml_dsa.h               passhash9.h   psk_db.h         stateful_rng.h      tls_messages.h                   x25519.h
argon2.h        certstor_system.h      dlies.h            fd_unix.h      ml_kem.h               pbkdf2.h      pss_params.h     stream_cipher.h     tls_policy.h                     x448.h
asn1_obj.h      chacha_rng.h           dsa.h              ffi.h          mutex.h                pbkdf.h       pubkey.h         strong_type.h       tls_psk_identity_13.h            x509_ca.h
asn1_print.h    cipher_mode.h          ec_apoint.h        filter.h       nist_keywrap.h         pem.h         pwdhash.h        sym_algo.h          tls_server.h                     x509cert.h
assert.h        cmce.h                 ecc_key.h          filters.h      numthry.h              pgp_s2k.h     reducer.h        symkey.h            tls_server_info.h                x509_crl.h
auto_rng.h      cmce_parameter_set.h   ecdh.h             fpe_fe1.h      ocsp.h                 pipe.h        rfc3394.h        system_rng.h        tls_session.h                    x509_ext.h
base32.h        compiler.h             ecdsa.h            frodokem.h     oids.h                 pk_algs.h     rfc4880.h        tls_alert.h         tls_session_manager.h            x509_key.h
base58.h        concepts.h             ecgdsa.h           frodo_mode.h   otp.h                  pkcs10.h      rng.h            tls_algos.h         tls_session_manager_hybrid.h     x509_obj.h
base64.h        credentials_manager.h  ec_group.h         gost_3410.h    p11_ecc_key.h          pkcs11f.h     roughtime.h      tls_callbacks.h     tls_session_manager_memory.h     x509path.h
bcrypt.h        cryptobox.h            ecies.h            hash.h         p11_ecdh.h             pkcs11.h      rsa.h            tls_channel.h       tls_session_manager_noop.h       x509self.h
bcrypt_pbkdf.h  curve25519.h           eckcdsa.h          hex.h          p11_ecdsa.h            pkcs11t.h     scrypt.h         tls_ciphersuite.h   tls_session_manager_sql.h        xmss.h
ber_dec.h       curve_gfp.h            ec_point_format.h  hmac_drbg.h    p11.h                  pkcs8.h       secmem.h         tls_client.h        tls_session_manager_stateless.h  xmss_parameters.h
bigint.h        database.h             ec_point.h         hss_lms.h      p11_mechanism.h        pkix_enums.h  slh_dsa.h        tls_exceptn.h       tls_signature_scheme.h           xof.h
block_cipher.h  data_snk.h             ec_scalar.h        kdf.h          p11_object.h           pkix_types.h  sm2.h            tls_extensions.h    tls_version.h                    zfec.h
buf_comp.h      data_src.h             ed25519.h          kyber.h        p11_randomgenerator.h  pk_keys.h     sodium.h         tls_external_psk.h  tss.h
```
