### PR TITLE
python: refactor & update.

### DIFF
--- a/packages/p/python/constants.lua
+++ b/packages/p/python/constants.lua
@@ -1,6 +1,4 @@
-constants = {}
-
---- configure
+local constants = {}
 
 -- only options listed here are yes/no configurations, underscores will be replaced with hyphens.
 function constants.get_yn_features()
@@ -43,8 +41,6 @@ function constants.get_supported_packages()
         "emscripten_target"
     }
 end
-
---- module
 
 function main()
     return constants

--- a/packages/p/python/constants.lua
+++ b/packages/p/python/constants.lua
@@ -1,0 +1,51 @@
+constants = {}
+
+--- configure
+
+-- only options listed here are yes/no configurations, underscores will be replaced with hyphens.
+function constants.get_yn_features()
+    return {
+        "wasm_dynamic_linking", -- 3.11
+        "wasm_pthreads", -- 3.11
+        "shared",
+        "profiling",
+        "gil", -- 3.13
+        "pystats", -- 3.11
+        "optimizations", -- 3.6
+        "bolt", -- 3.12
+        "loadable_sqlite_extensions", -- 3.6
+        "ipv6",
+        "test_modules" -- 3.10
+    }
+end
+
+function constants.get_all_features()
+    return table.join(
+        constants.get_yn_features(),
+        {
+            "universalsdk",
+            "framework",
+            "experimental_jit", -- 3.13
+            "big_digits"
+        }
+    )
+end
+
+function constants.get_supported_packages()
+    return {
+        "framework_name",
+        "app_store_compliance",
+        "hash_algorithm",
+        "builtin_hashlib_hashes",
+        "ssl_default_suites",
+        "lto",
+        "ensurepip",
+        "emscripten_target"
+    }
+end
+
+--- module
+
+function main()
+    return constants
+end

--- a/packages/p/python/constants.lua
+++ b/packages/p/python/constants.lua
@@ -42,6 +42,6 @@ function constants.get_supported_packages()
     }
 end
 
-function main()
+function get_python_package_constants()
     return constants
 end

--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -5,7 +5,7 @@ package("python")
 
     -- enable-FEATURE
     includes(path.join(os.scriptdir(), "constants.lua"))
-    for _, feature in ipairs(constants.get_yn_features()) do
+    for _, feature in ipairs(get_python_package_constants()) do
         -- if the user doesn't pass it (nil), we won't pass it either.
         add_configs(feature, {description = "Enable " .. feature .. ".", default = nil, type = "boolean"})
     end
@@ -169,7 +169,7 @@ package("python")
 
     --- android, iphoneos, wasm unsupported: dependencies not resolved.
     on_install("macosx", "linux", "bsd", function (package)
-        local constants = import('constants')()
+        local constants = import('constants').get_python_package_constants()
         function opt2cfg(cfg)
             if type(cfg) == "boolean" then
                 return cfg and 'yes' or 'no'

--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -97,7 +97,7 @@ package("python")
         package:add("deps", "libuuid") -- py module 'uuuid'
         package:add("deps", "zlib") -- py module 'gzip'
         package:add("deps", "ca-certificates") -- py module 'ssl'
-        if is_plat("linux", "macosx", "bsd") then
+        if package:is_plat("linux", "macosx", "bsd") then
             package:add("deps", "ncurses") -- py module 'curses'
             package:add("deps", "libedit") -- py module 'readline'
             package:add("deps", "libffi") -- py module 'ctypes'
@@ -109,16 +109,16 @@ package("python")
                 package:add("deps", "sqlite3")
             end
         end
-        if is_plat("linux", "macosx") then
+        if package:is_plat("linux", "macosx") then
             package:add("deps", "mpdecimal") -- py module 'decimal'
             package:add("deps", "lzma") -- py module 'lzma'
             package:add("deps", "readline") -- py module 'readline'
         end
-        if is_plat("linux", "bsd") then
+        if package:is_plat("linux", "bsd") then
             package:add("syslinks", "util", "pthread", "dl")
         end
         
-        if not is_plat("wasm") then
+        if not package:is_plat("wasm") then
             if package:config("openssl3") then -- openssl, py module 'ssl', 'hashlib'
                 package:add("deps", "openssl3")
             else

--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -3,27 +3,32 @@ package("python")
     set_description("The python programming language.")
     set_license("PSF")
 
-    if is_host("windows") then
-        if is_arch("x86", "i386") or os.arch() == "x86" then
-            add_urls("https://github.com/xmake-mirror/python-windows/releases/download/$(version)/python-$(version).win32.zip")
-            add_versions("2.7.18", "95e21c87c9f38fa8068e014fc3683c3bc2c827f64875e620b9ecd3c75976a79c")
-            add_versions("3.7.9", "55c8a408a11e598964f5d581589cf7f8c622e3cad048dce331ee5a61e5a6f57f")
-            add_versions("3.8.10", "f520d2880578df076e3df53bf9e147b81b5328db02d8d873670a651fa076be50")
-            add_versions("3.9.5", "ce0bfe8ced874d8d74a6cf6a98f13f5afee27cffbaf2d1ee0f09d3a027fab299")
-            add_versions("3.9.6", "2918246384dfb233bd8f8c2bcf6aa3688e6834e84ab204f7c962147c468f8d12")
-            add_versions("3.9.10", "e2c8e6b792748289ac27ef8462478022c96e24c99c4c3eb97d3afe510d9db646")
-            add_versions("3.9.13", "c60ec0da0adf3a31623073d4fa085da62747085a9f23f4348fe43dfe94ea447b")
-            add_versions("3.10.6", "c1a07f7685b5499f58cfad2bb32b394b853ba12b8062e0f7530f2352b0942096")
-            add_versions("3.10.11", "7fac6ed9a58623f31610024d2c4d6abb33fac0cf741ec1a5285d056b5933012e")
-            add_versions("3.11.3", "992648876ecca6cfbe122dc2d9c358c9029d9fdb83ee6edd6e54926bf0360da6")
-            add_versions("3.11.8", "f5e399d12b00a4f73dc3078b7b4fe900e1de6821aa3e31d1c27c6ef4e33e95d9")
-            add_versions("3.12.3", "49bbcd200cda1f56452feeaf0954045e85b27a93b929034cc03ab198c4d9662e")
-            add_versions("3.12.8", "b4ec65bf24417c4098c8d1f30a30fec12680aedd7094de3caf35e5e2d55d9c46")
-            add_versions("3.13.1", "f89b297ca94ced2fbdad7919518ebf05005f39637f8ec5b01e42f2c71d53a673")
-        else
+    -- enable-FEATURE
+    includes(path.join(os.scriptdir(), "constants.lua"))
+    for _, feature in ipairs(constants.get_yn_features()) do
+        -- if the user doesn't pass it (nil), we won't pass it either.
+        add_configs(feature, {description = "Enable " .. feature .. ".", default = nil, type = "boolean"})
+    end
+
+    add_configs("framework", {description = "(macOS) Create a Python.framework rather than a traditional Unix install.", default = nil, type = "string"})
+    add_configs("experimental_jit", {description = "Build the experimental just-in-time compiler.", default = nil, values = {true, false, "no", "yes", "yes-off", "interpreter"}})
+    add_configs("big_digits", {description = "Use big digits for Python longs.", default = nil, type = "number", values = {15, 30}})
+
+    -- with-PACKAGE
+    add_configs("framework_name", {description = "(macOS) Specify the name for the python framework.", default = nil, type = "string"})
+    add_configs("app_store_compliance", {description = "(macOS) Enable any patches required for compiliance with app stores.", default = nil, type = "boolean"}) -- 3.13
+    add_configs("hash_algorithm", {description = "Select hash algorithm for use in Python/pyhash.c", default = nil, type = "string", values = {"fnv", "siphash13", "siphash24"}}) -- 3.4, 3.11
+    add_configs("builtin_hashlib_hashes", {description = "Builtin hash modules. (md5, sha1, sha2, sha3, blake2)", default = nil, type = "string"}) -- 3.9
+    add_configs("ssl_default_suites", {description = "Override default cipher suites string. (python, openssl)", default = nil, type = "string"}) -- 3.7, 3.10
+    add_configs("lto", {description = "Enable Link-Time-Optimization in any build.", default = nil, values = {true, false, "full", "thin", "no", "yes"}})
+    add_configs("ensurepip", {description = "'install' or 'upgrade' using bundled pip", default = nil, values = {true, false, "upgrade", "install", "no"}}) -- 3.6
+    add_configs("emscripten_target", {description = "(wasm) Emscripten platform.", default = nil, type = "string", values = {"browser", "node"}})
+
+    add_configs("openssl3", {description = "Use OpenSSL v3.", default = true, type = "boolean"})
+
+    if is_plat("windows", "msys", "mingw", "cygwin") then
+        if is_arch("x64", "x86_64") then
             add_urls("https://github.com/xmake-mirror/python-windows/releases/download/$(version)/python-$(version).win64.zip")
-            add_versions("2.7.18", "6680835ed5b818e2c041c7033bea47ace17f6f3b73b0d6efb6ded8598a266754")
-            add_versions("3.7.9", "d0d879c934b463d46161f933db53a676790d72f24e92143f629ee5629ae286bc")
             add_versions("3.8.10", "acf35048274404dd415e190bf5b928fae3b03d8bb5dfbfa504f9a183361468bd")
             add_versions("3.9.5", "3265059edac21bf4c46fac13553a5d78417e7aa209eceeffd0250aa1dd8d6fdf")
             add_versions("3.9.6", "57ccd1b1b5fbc62882bd2a6f47df6e830ba39af741acf0a1d2f161eef4e87f2e")
@@ -36,11 +41,26 @@ package("python")
             add_versions("3.12.3", "00a80ccce8738de45ebe73c6084b1ea92ad131ec79cbe5c033a925c761cb5fdc")
             add_versions("3.12.8", "7f8cf0a21a076d2646b26c5248ae47f1dbc870bc059670915e042f6eb1850ecb")
             add_versions("3.13.1", "104d1de9eb6ff7c345c3415a57880dc0b2c51695515f2a87097512e6d77e977d")
+            add_versions("3.13.2", "baee66e4d1b16a220bf61d64a210676f6d6fef69c65959ffd9828264c7fe8ef5")
+        end
+        if is_arch("x86", "i386") then
+            add_urls("https://github.com/xmake-mirror/python-windows/releases/download/$(version)/python-$(version).win32.zip")
+            add_versions("3.8.10", "f520d2880578df076e3df53bf9e147b81b5328db02d8d873670a651fa076be50")
+            add_versions("3.9.5", "ce0bfe8ced874d8d74a6cf6a98f13f5afee27cffbaf2d1ee0f09d3a027fab299")
+            add_versions("3.9.6", "2918246384dfb233bd8f8c2bcf6aa3688e6834e84ab204f7c962147c468f8d12")
+            add_versions("3.9.10", "e2c8e6b792748289ac27ef8462478022c96e24c99c4c3eb97d3afe510d9db646")
+            add_versions("3.9.13", "c60ec0da0adf3a31623073d4fa085da62747085a9f23f4348fe43dfe94ea447b")
+            add_versions("3.10.6", "c1a07f7685b5499f58cfad2bb32b394b853ba12b8062e0f7530f2352b0942096")
+            add_versions("3.10.11", "7fac6ed9a58623f31610024d2c4d6abb33fac0cf741ec1a5285d056b5933012e")
+            add_versions("3.11.3", "992648876ecca6cfbe122dc2d9c358c9029d9fdb83ee6edd6e54926bf0360da6")
+            add_versions("3.11.8", "f5e399d12b00a4f73dc3078b7b4fe900e1de6821aa3e31d1c27c6ef4e33e95d9")
+            add_versions("3.12.3", "49bbcd200cda1f56452feeaf0954045e85b27a93b929034cc03ab198c4d9662e")
+            add_versions("3.12.8", "b4ec65bf24417c4098c8d1f30a30fec12680aedd7094de3caf35e5e2d55d9c46")
+            add_versions("3.13.1", "f89b297ca94ced2fbdad7919518ebf05005f39637f8ec5b01e42f2c71d53a673")
+            add_versions("3.13.2", "67ccaa5e8fb05e8e15a46f9262368fcfef190b1cfab3e2511acada7d68cf6464")
         end
     else
         add_urls("https://www.python.org/ftp/python/$(version)/Python-$(version).tgz")
-        add_versions("2.7.18", "da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814")
-        add_versions("3.7.9", "39b018bc7d8a165e59aa827d9ae45c45901739b0bbb13721e4f973f3521c166a")
         add_versions("3.8.10", "b37ac74d2cbad2590e7cd0dd2b3826c29afe89a734090a87bf8c03c45066cb65")
         add_versions("3.9.5", "e0fbd5b6e1ee242524430dee3c91baf4cbbaba4a72dd1674b90fda87b713c7ab")
         add_versions("3.9.6", "d0a35182e19e416fc8eae25a3dcd4d02d4997333e4ad1f2eee6010aadc3fe866")
@@ -50,26 +70,13 @@ package("python")
         add_versions("3.10.11", "f3db31b668efa983508bd67b5712898aa4247899a346f2eb745734699ccd3859")
         add_versions("3.11.3", "1a79f3df32265d9e6625f1a0b31c28eb1594df911403d11f3320ee1da1b3e048")
         add_versions("3.11.8", "d3019a613b9e8761d260d9ebe3bd4df63976de30464e5c0189566e1ae3f61889")
-        add_versions("3.11.9", "e7de3240a8bc2b1e1ba5c81bf943f06861ff494b69fda990ce2722a504c6153d")
         add_versions("3.12.3", "a6b9459f45a6ebbbc1af44f5762623fa355a0c87208ed417628b379d762dddb0")
         add_versions("3.12.8", "5978435c479a376648cb02854df3b892ace9ed7d32b1fead652712bee9d03a45")
-        add_versions("3.13.0", "12445c7b3db3126c41190bfdc1c8239c39c719404e844babbd015a1bc3fafcd4")
         add_versions("3.13.1", "1513925a9f255ef0793dbf2f78bb4533c9f184bdd0ad19763fd7f47a400a7c55")
+        add_versions("3.13.2", "b8d79530e3b7c96a5cb2d40d431ddb512af4a563e863728d8713039aa50203f9")
     end
 
-    add_configs("headeronly", {description = "Use header only version.", default = false, type = "boolean"})
-
-    if not is_plat(os.host()) or not is_arch(os.arch()) then
-        set_kind("binary")
-    end
-
-    if is_host("linux", "bsd") then
-        add_deps("libffi", "zlib", {host = true, private = true})
-        add_syslinks("util", "pthread", "dl")
-    end
-
-    on_load("@windows", "@msys", "@cygwin", function (package)
-
+    on_load("windows", "msys", "mingw", "cygwin", function (package)
         -- set includedirs
         package:add("includedirs", "include")
 
@@ -80,21 +87,53 @@ package("python")
         package:addenv("PATH", "Scripts")
     end)
 
-    on_load("@macosx", "@linux", "@bsd", function (package)
-        local version = package:version()
+    on_load("macosx", "linux", "bsd", function (package)
+        local pkgver = package:version()
+        local pyver = ("python%d.%d"):format(pkgver:major(), pkgver:minor())
 
-        -- set openssl dep
-        if version:ge("3.10") then
-            -- starting with Python 3.10, Python requires OpenSSL 1.1.1 or newer
-            -- see https://peps.python.org/pep-0644/
-            package:add("deps", "openssl >=1.1.1-a", "ca-certificates", {host = true})
-        else
-            package:add("deps", "openssl", "ca-certificates", {host = true})
+        -- add build dependencies
+        package:add("deps", "bzip2") -- py module 'bz2'
+        package:add("deps", "libb2") -- py module 'hashlib'
+        package:add("deps", "libuuid") -- py module 'uuuid'
+        package:add("deps", "zlib") -- py module 'gzip'
+        package:add("deps", "ca-certificates") -- py module 'ssl'
+        if is_plat("linux", "macosx", "bsd") then
+            package:add("deps", "ncurses") -- py module 'curses'
+            package:add("deps", "libedit") -- py module 'readline'
+            package:add("deps", "libffi") -- py module 'ctypes'
+            if pkgver:ge("3.10") then -- sqlite3, py module 'sqlite3'
+                package:add("deps", "sqlite3 >=3.7.15")
+            elseif pkgver:ge("3.13") then
+                package:add("deps", "sqlite3 >=3.15.2")
+            else
+                package:add("deps", "sqlite3")
+            end
+        end
+        if is_plat("linux", "macosx") then
+            package:add("deps", "mpdecimal") -- py module 'decimal'
+            package:add("deps", "lzma") -- py module 'lzma'
+            package:add("deps", "readline") -- py module 'readline'
+        end
+        if is_plat("linux", "bsd") then
+            package:add("syslinks", "util", "pthread", "dl")
+        end
+        
+        if not is_plat("wasm") then
+            if package:config("openssl3") then -- openssl, py module 'ssl', 'hashlib'
+                package:add("deps", "openssl3")
+            else
+                if pkgver:ge("3.7") then
+                    package:add("deps", "openssl >=1.0.2-a")
+                elseif pkgver:ge("3.10") then
+                    package:add("deps", "openssl >=1.1.1-a")
+                else
+                    package:add("deps", "openssl")
+                end
+            end
         end
 
         -- set includedirs
-        local pyver = ("python%d.%d"):format(version:major(), version:minor())
-        if version:ge("3.0") and version:le("3.8") then
+        if pkgver:ge("3.0") and pkgver:le("3.8") then
             package:add("includedirs", path.join("include", pyver .. "m"))
         else
             package:add("includedirs", path.join("include", pyver))
@@ -105,15 +144,11 @@ package("python")
         package:addenv("PYTHONPATH", PYTHONPATH)
         package:addenv("PATH", "bin")
         package:addenv("PATH", "Scripts")
-
-        if package:config("headeronly") then
-            package:set("links", "")
-        end
     end)
 
     on_fetch("fetch")
 
-    on_install("@windows|x86", "@windows|x64", "@msys", "@cygwin", function (package)
+    on_install("windows|x86", "windows|x64", "msys", "mingw", "cygwin", function (package)
         if package:version():ge("3.0") then
             os.cp("python.exe", path.join(package:installdir("bin"), "python3.exe"))
         else
@@ -124,25 +159,45 @@ package("python")
         os.cp("Lib", package:installdir())
         os.cp("libs/*", package:installdir("lib"))
         os.cp("*", package:installdir())
-        local python = path.join(package:installdir("bin"), "python.exe")
-        os.vrunv(python, {"-m", "pip", "install", "--upgrade", "--force-reinstall", "pip"})
-        os.vrunv(python, {"-m", "pip", "install", "--upgrade", "setuptools"})
-        os.vrunv(python, {"-m", "pip", "install", "wheel"})
+        if package:config("pip") then
+            local python = path.join(package:installdir("bin"), "python.exe")
+            os.vrunv(python, {"-m", "pip", "install", "--upgrade", "--force-reinstall", "pip"})
+            os.vrunv(python, {"-m", "pip", "install", "--upgrade", "setuptools"})
+            os.vrunv(python, {"-m", "pip", "install", "wheel"})
+        end
     end)
 
-    on_install("@macosx", "@bsd", "@linux", function (package)
-        local version = package:version()
+    --- android, iphoneos, wasm unsupported: dependencies not resolved.
+    on_install("macosx", "linux", "bsd", function (package)
+        local constants = import('constants')()
+        function opt2cfg(cfg)
+            if type(cfg) == "boolean" then
+                return cfg and 'yes' or 'no'
+            end
+            return cfg
+        end
+
+        local pkgver = package:version()
+        local pyver = ("python%d.%d"):format(pkgver:major(), pkgver:minor())
 
         -- init configs
-        local configs = {"--enable-ipv6", "--with-ensurepip", "--enable-optimizations"}
+        local configs = {}
         table.insert(configs, "--libdir=" .. package:installdir("lib"))
-        table.insert(configs, "--with-platlibdir=lib")
         table.insert(configs, "--datadir=" .. package:installdir("share"))
         table.insert(configs, "--datarootdir=" .. package:installdir("share"))
-        table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
+        for _, feature in ipairs(constants.get_all_features()) do
+            if package:config(feature) ~= nil then
+                table.insert(configs, ("--enable-%s=%s"):format(feature:gsub("_", "-"), opt2cfg(package:config(feature))))
+            end
+        end
+        for _, pkg in ipairs(constants.get_supported_packages()) do
+            if package:config(feature) ~= nil then
+                table.insert(configs, ("--with-%s=%s"):format(pkg:gsub("_", "-"), opt2cfg(package:config(feature))))
+            end
+        end
 
         -- add openssl libs path
-        local openssl = package:dep("openssl"):fetch()
+        local openssl = package:dep(package:config("openssl3") and "openssl3" or "openssl"):fetch()
         if openssl then
             local openssl_dir
             for _, linkdir in ipairs(openssl.linkdirs) do
@@ -158,7 +213,7 @@ package("python")
                     end
                 end
                 if openssl_dir then
-                    if version:ge("3.0") then
+                    if pkgver:ge("3.0") then
                         table.insert(configs, "--with-openssl=" .. openssl_dir)
                     else
                         io.gsub("setup.py", "/usr/local/ssl", openssl_dir)
@@ -177,7 +232,6 @@ package("python")
         local cppflags = {}
         local ldflags = {}
         if package:is_plat("macosx") then
-
             -- get xcode information
             import("core.tool.toolchain")
             local xcode_dir
@@ -217,21 +271,6 @@ package("python")
             table.insert(cppflags, "-fPIC")
         end
 
-        -- add external path for zlib and libffi
-        for _, libname in ipairs({"zlib", "libffi"}) do
-            local lib = package:dep(libname)
-            if lib and not lib:is_system() then
-                local fetchinfo = lib:fetch({external = false})
-                if fetchinfo then
-                    for _, includedir in ipairs(fetchinfo.includedirs or fetchinfo.sysincludedirs) do
-                        table.insert(cppflags, "-I" .. includedir)
-                    end
-                    for _, linkdir in ipairs(fetchinfo.linkdirs) do
-                        table.insert(ldflags, "-L" .. linkdir)
-                    end
-                end
-            end
-        end
         if #cppflags > 0 then
             table.insert(configs, "CPPFLAGS=" .. table.concat(cppflags, " "))
         end
@@ -239,9 +278,8 @@ package("python")
             table.insert(configs, "LDFLAGS=" .. table.concat(ldflags, " "))
         end
 
-        local pyver = ("python%d.%d"):format(version:major(), version:minor())
         -- https://github.com/python/cpython/issues/109796
-        if version:ge("3.12.0") then
+        if pkgver:ge("3.12.0") then
             os.mkdir(package:installdir("lib", pyver))
         end
 
@@ -255,29 +293,39 @@ package("python")
         import("package.tools.autoconf").configure(package, configs, {envs = {PYTHONHOME = "", PYTHONPATH = ""}})
         os.vrunv("make", {"-j4", "PYTHONAPPSDIR=" .. package:installdir()})
         os.vrunv("make", {"install", "-j4", "PYTHONAPPSDIR=" .. package:installdir()})
-        if version:ge("3.0") then
+        if pkgver:ge("3.0") then
             os.cp(path.join(package:installdir("bin"), "python3"), path.join(package:installdir("bin"), "python"))
             os.cp(path.join(package:installdir("bin"), "python3-config"), path.join(package:installdir("bin"), "python-config"))
         end
 
         -- install wheel
-        local python = path.join(package:installdir("bin"), "python")
-        local envs = {
-            PATH = package:installdir("bin"),
-            PYTHONPATH = package:installdir("lib", pyver, "site-packages"),
-            LD_LIBRARY_PATH = package:installdir("lib")
-        }
-        os.vrunv(python, {"-m", "pip", "install", "--upgrade", "--force-reinstall", "pip"}, {envs = envs})
-        os.vrunv(python, {"-m", "pip", "install", "--upgrade", "setuptools"}, {envs = envs})
-        os.vrunv(python, {"-m", "pip", "install", "wheel"}, {envs = envs})
+        if package:config("ensurepip") then
+            local python = path.join(package:installdir("bin"), "python")
+            local envs = {
+                PATH = package:installdir("bin"),
+                PYTHONPATH = package:installdir("lib", pyver, "site-packages"),
+                LD_LIBRARY_PATH = package:installdir("lib")
+            }
+            os.vrunv(python, {"-m", "pip", "install", "--upgrade", "--force-reinstall", "pip"}, {envs = envs})
+            os.vrunv(python, {"-m", "pip", "install", "--upgrade", "setuptools"}, {envs = envs})
+            os.vrunv(python, {"-m", "pip", "install", "wheel"}, {envs = envs})
+        end
     end)
 
     on_test(function (package)
-        os.vrun("python --version")
-        os.vrun("python -c \"import pip\"")
-        os.vrun("python -c \"import setuptools\"")
-        os.vrun("python -c \"import wheel\"")
-        if package:kind() ~= "binary" and not package:config("headeronly") then
-            assert(package:has_cfuncs("PyModule_New", {includes = "Python.h"}))
+        if not package:is_cross() then
+            os.vrun("python --version")
+            if package:config("ensurepip") then
+                os.vrun("python -c \"import pip\"")
+                os.vrun("python -c \"import setuptools\"")
+                os.vrun("python -c \"import wheel\"")
+            end
         end
+        assert(package:check_csnippets({test = [[
+            #include <Python.h>
+            void test() {
+                Py_Initialize();
+                Py_Finalize();
+            }
+        ]]}, {configs = {languages = 'c11'}}))
     end)


### PR DESCRIPTION
- drop py2.7.18, py3.7.9 
> They are all end-of-life. And it failed to pass the test on macosx due to some problems.
- drop py3.11.9, py3.13.0
> They were not present in the pre-builds, which resulted in different versions being available on different platforms and tests failing.
- add py3.13.2.
- add config for all *features*.
- add config for potentially useful *packages*.
> See cpython configure script for details.
- setup pip (wheel, setuptool) only when `ensurepip` is enabled.
- use openssl3 by default.
- cross-compilation issues have been resolved.
- support for more platforms (android, iphoneos, wasm).
> android, iphoneos, wasm support should be complete, but are temporarily disabled due to issues with some dependencies in xrepo.