### PR TITLE
Auto-update libremidi to v5.2.0

### DIFF
--- a/packages/l/libremidi/xmake.lua
+++ b/packages/l/libremidi/xmake.lua
@@ -6,6 +6,7 @@ package("libremidi")
     add_urls("https://github.com/jcelerier/libremidi/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jcelerier/libremidi.git")
 
+    add_versions("v5.2.0", "d34a2e8aaede56f234f0f1b653fef0d84aeae1084e66d71c7237c85280d4be1a")
     add_versions("v5.1.0", "bd5f2f81fbed58c9d926741f5df5ec5b714854004492d1cf30609f650e199338")
     add_versions("v4.5.0", "2e884a4c826dd87157ee4fab8cd8c7b9dbbc1ddb804cb10ef0852094200724db")
     add_versions("v3.0", "133b40396ca72e35d94cb0950199c9d123352951e4705971a9cd7606f905328a")


### PR DESCRIPTION
New version of libremidi detected (package version: v5.1.0, last github version: v5.2.0)