### PR TITLE
cmake: update to 4.0.0

### DIFF
--- a/packages/c/cmake/xmake.lua
+++ b/packages/c/cmake/xmake.lua
@@ -23,7 +23,7 @@ package("cmake")
         add_versions("3.29.2", "0d670b59dddd064d24cf8c386abf3590bda2642bb169e11534cf1e3d1ae3a76a")
         add_versions("3.30.1", "51e12618829b811bba6f033ee8f39f6192da1b6abb20d82a7899d5134e879a4c")
         add_versions("3.30.2", "c6fdda745f9ce69bca048e91955c7d043ba905d6388a62e0ff52b681ac17183c")
-        add_versions("4.0.0", "a7d66b55c673845e21b5541340417bae4823958393a59f4b644c26d433b19a0b")
+        add_versions("4.0.0",  "a7d66b55c673845e21b5541340417bae4823958393a59f4b644c26d433b19a0b")
     elseif is_host("linux") then
         if os.arch():find("arm64.*") then
             add_urls("https://cmake.org/files/v$(version)-aarch64.tar.gz", {version = function (version)
@@ -39,7 +39,7 @@ package("cmake")
             add_versions("3.29.2", "ca883c6dc3ce9eebd833804f0f940ecbbff603520cfd169ee58916dbbc23c2b8")
             add_versions("3.30.1", "ad234996f8750f11d7bd0d17b03f55c434816adf1f1671aab9e8bab21a43286a")
             add_versions("3.30.2", "d18f50f01b001303d21f53c6c16ff12ee3aa45df5da1899c2fe95be7426aa026")
-            add_versions("4.0.0", "3727d7a6ca900331447a55c08404cc11248b2e8d2709a6b3ed85b01189bb16af")
+            add_versions("4.0.0",  "3727d7a6ca900331447a55c08404cc11248b2e8d2709a6b3ed85b01189bb16af")
         else
             add_urls("https://cmake.org/files/v$(version)-x86_64.tar.gz", {version = function (version)
                     return table.concat(table.slice((version):split('%.'), 1, 2), '.') .. "/cmake-" .. version .. (version:ge("3.20") and "-linux" or "-Linux")
@@ -60,7 +60,7 @@ package("cmake")
             add_versions("3.29.2", "0416c70cf88e8f92efcbfe292e181bc09ead7d70e29ab37b697522c01121eab5")
             add_versions("3.30.1", "ac31f077ef3378641fa25a3cb980d21b2f083982d3149a8f2eb9154f2b53696b")
             add_versions("3.30.2", "cdd7fb352605cee3ae53b0e18b5929b642900e33d6b0173e19f6d4f2067ebf16")
-            add_versions("4.0.0", "a06e6e32da747e569162bc0442a3fd400fadd9db7d4f185c9e4464ab299a294b")
+            add_versions("4.0.0",  "a06e6e32da747e569162bc0442a3fd400fadd9db7d4f185c9e4464ab299a294b")
         end
     elseif is_host("windows") then
         if os.arch() == "x64" then
@@ -83,7 +83,7 @@ package("cmake")
             add_versions("3.29.2", "86b5de51f60a0e9d62be4d8ca76ea467d154083d356fcc9af1409606be341cd8")
             add_versions("3.30.1", "cf7788ff9d92812da194847d4ec874fc576f34079987d0f20c96cd09e2a16220")
             add_versions("3.30.2", "48bf4b3dc2d668c578e0884cac7878e146b036ca6b5ce4f8b5572f861b004c25")
-            add_versions("4.0.0", "89e87f3e297b70f1349ee7c5f90783ca96efb986b70c558c799c3c9b1b716456")
+            add_versions("4.0.0",  "89e87f3e297b70f1349ee7c5f90783ca96efb986b70c558c799c3c9b1b716456")
         elseif os.arch() == "x86" then
             add_urls("https://cmake.org/files/v$(version).zip", {excludes = {"*/doc/*"}, version = function (version)
                     return table.concat(table.slice((version):split('%.'), 1, 2), '.') .. "/cmake-" .. version .. (version:ge("3.20") and "-windows-i386" or "-win32-x86")
@@ -104,7 +104,7 @@ package("cmake")
             add_versions("3.29.2", "e51b281c9dfd1498834729b33bf49fc668ad1dadbc2eaba7b693d0f7d748450d")
             add_versions("3.30.1", "f5fb1d93b82e9a5fbd5853d4b17a130605f0b4ed13a655d1371c2d6d55f9261d")
             add_versions("3.30.2", "d01f7ea52097dd58aa225884b1ecc543827e9ef99d36dac2898609a0d5e60eb6")
-            add_versions("4.0.0", "28408c0ca3b4461550bbcad94c526846699ed79366d81b57db0375cb119875dd")
+            add_versions("4.0.0",  "28408c0ca3b4461550bbcad94c526846699ed79366d81b57db0375cb119875dd")
         elseif os.arch() == "arm64" then
             add_urls("https://cmake.org/files/v$(version).zip", {excludes = {"*/doc/*"}, version = function (version)
                     return table.concat(table.slice((version):split('%.'), 1, 2), '.') .. "/cmake-" .. version .. "-windows-arm64"
@@ -117,7 +117,7 @@ package("cmake")
             add_versions("3.29.2", "5b16a0db4966c04582c40131038de49d5b0161fcd950dc9e955753dfab858882")
             add_versions("3.30.1", "02b433f70aa549449be2d53046d0179590bf3b6290d9fda3fbbb23f96a4f2802")
             add_versions("3.30.2", "c0cef52e8f60eb1c3058f8bc0b3803c27d79f066b7d7d94f46a2c689bbd36f22")
-            add_versions("4.0.0", "6a24f1ea0965a10a2508b16db1ec8b62c83d5323ac33a1aa7d201797ba147302")
+            add_versions("4.0.0",  "6a24f1ea0965a10a2508b16db1ec8b62c83d5323ac33a1aa7d201797ba147302")
         end
     else
         add_urls("https://github.com/Kitware/CMake/releases/download/v$(version)/cmake-$(version).tar.gz")
@@ -132,7 +132,7 @@ package("cmake")
         add_versions("3.29.2", "36db4b6926aab741ba6e4b2ea2d99c9193222132308b4dc824d4123cb730352e")
         add_versions("3.30.1", "df9b3c53e3ce84c3c1b7c253e5ceff7d8d1f084ff0673d048f260e04ccb346e1")
         add_versions("3.30.2", "46074c781eccebc433e98f0bbfa265ca3fd4381f245ca3b140e7711531d60db2")
-        add_versions("4.0.0", "ddc54ad63b87e153cf50be450a6580f1b17b4881de8941da963ff56991a4083b")
+        add_versions("4.0.0",  "ddc54ad63b87e153cf50be450a6580f1b17b4881de8941da963ff56991a4083b")
     end
 
     if is_plat("mingw") and is_subhost("msys") then

--- a/packages/c/cmake/xmake.lua
+++ b/packages/c/cmake/xmake.lua
@@ -23,6 +23,7 @@ package("cmake")
         add_versions("3.29.2", "0d670b59dddd064d24cf8c386abf3590bda2642bb169e11534cf1e3d1ae3a76a")
         add_versions("3.30.1", "51e12618829b811bba6f033ee8f39f6192da1b6abb20d82a7899d5134e879a4c")
         add_versions("3.30.2", "c6fdda745f9ce69bca048e91955c7d043ba905d6388a62e0ff52b681ac17183c")
+        add_versions("4.0.0", "a7d66b55c673845e21b5541340417bae4823958393a59f4b644c26d433b19a0b")
     elseif is_host("linux") then
         if os.arch():find("arm64.*") then
             add_urls("https://cmake.org/files/v$(version)-aarch64.tar.gz", {version = function (version)
@@ -38,6 +39,7 @@ package("cmake")
             add_versions("3.29.2", "ca883c6dc3ce9eebd833804f0f940ecbbff603520cfd169ee58916dbbc23c2b8")
             add_versions("3.30.1", "ad234996f8750f11d7bd0d17b03f55c434816adf1f1671aab9e8bab21a43286a")
             add_versions("3.30.2", "d18f50f01b001303d21f53c6c16ff12ee3aa45df5da1899c2fe95be7426aa026")
+            add_versions("4.0.0", "3727d7a6ca900331447a55c08404cc11248b2e8d2709a6b3ed85b01189bb16af")
         else
             add_urls("https://cmake.org/files/v$(version)-x86_64.tar.gz", {version = function (version)
                     return table.concat(table.slice((version):split('%.'), 1, 2), '.') .. "/cmake-" .. version .. (version:ge("3.20") and "-linux" or "-Linux")
@@ -58,6 +60,7 @@ package("cmake")
             add_versions("3.29.2", "0416c70cf88e8f92efcbfe292e181bc09ead7d70e29ab37b697522c01121eab5")
             add_versions("3.30.1", "ac31f077ef3378641fa25a3cb980d21b2f083982d3149a8f2eb9154f2b53696b")
             add_versions("3.30.2", "cdd7fb352605cee3ae53b0e18b5929b642900e33d6b0173e19f6d4f2067ebf16")
+            add_versions("4.0.0", "a06e6e32da747e569162bc0442a3fd400fadd9db7d4f185c9e4464ab299a294b")
         end
     elseif is_host("windows") then
         if os.arch() == "x64" then
@@ -80,6 +83,7 @@ package("cmake")
             add_versions("3.29.2", "86b5de51f60a0e9d62be4d8ca76ea467d154083d356fcc9af1409606be341cd8")
             add_versions("3.30.1", "cf7788ff9d92812da194847d4ec874fc576f34079987d0f20c96cd09e2a16220")
             add_versions("3.30.2", "48bf4b3dc2d668c578e0884cac7878e146b036ca6b5ce4f8b5572f861b004c25")
+            add_versions("4.0.0", "89e87f3e297b70f1349ee7c5f90783ca96efb986b70c558c799c3c9b1b716456")
         elseif os.arch() == "x86" then
             add_urls("https://cmake.org/files/v$(version).zip", {excludes = {"*/doc/*"}, version = function (version)
                     return table.concat(table.slice((version):split('%.'), 1, 2), '.') .. "/cmake-" .. version .. (version:ge("3.20") and "-windows-i386" or "-win32-x86")
@@ -100,6 +104,7 @@ package("cmake")
             add_versions("3.29.2", "e51b281c9dfd1498834729b33bf49fc668ad1dadbc2eaba7b693d0f7d748450d")
             add_versions("3.30.1", "f5fb1d93b82e9a5fbd5853d4b17a130605f0b4ed13a655d1371c2d6d55f9261d")
             add_versions("3.30.2", "d01f7ea52097dd58aa225884b1ecc543827e9ef99d36dac2898609a0d5e60eb6")
+            add_versions("4.0.0", "28408c0ca3b4461550bbcad94c526846699ed79366d81b57db0375cb119875dd")
         elseif os.arch() == "arm64" then
             add_urls("https://cmake.org/files/v$(version).zip", {excludes = {"*/doc/*"}, version = function (version)
                     return table.concat(table.slice((version):split('%.'), 1, 2), '.') .. "/cmake-" .. version .. "-windows-arm64"
@@ -112,6 +117,7 @@ package("cmake")
             add_versions("3.29.2", "5b16a0db4966c04582c40131038de49d5b0161fcd950dc9e955753dfab858882")
             add_versions("3.30.1", "02b433f70aa549449be2d53046d0179590bf3b6290d9fda3fbbb23f96a4f2802")
             add_versions("3.30.2", "c0cef52e8f60eb1c3058f8bc0b3803c27d79f066b7d7d94f46a2c689bbd36f22")
+            add_versions("4.0.0", "6a24f1ea0965a10a2508b16db1ec8b62c83d5323ac33a1aa7d201797ba147302")
         end
     else
         add_urls("https://github.com/Kitware/CMake/releases/download/v$(version)/cmake-$(version).tar.gz")
@@ -126,6 +132,7 @@ package("cmake")
         add_versions("3.29.2", "36db4b6926aab741ba6e4b2ea2d99c9193222132308b4dc824d4123cb730352e")
         add_versions("3.30.1", "df9b3c53e3ce84c3c1b7c253e5ceff7d8d1f084ff0673d048f260e04ccb346e1")
         add_versions("3.30.2", "46074c781eccebc433e98f0bbfa265ca3fd4381f245ca3b140e7711531d60db2")
+        add_versions("4.0.0", "ddc54ad63b87e153cf50be450a6580f1b17b4881de8941da963ff56991a4083b")
     end
 
     if is_plat("mingw") and is_subhost("msys") then


### PR DESCRIPTION
```
Run xmake-io/github-action-setup-xmake@v1
Selected xmake branch master (commit: 9a4136c5)
Selected xmake v2.9.9 (commit: 40815a0e)
Warning: No cached files found at path "D:\a\xmake-repo\xmake-repo\.xmake-cache".
download xmake branch master
  downloading from https://github.com/xmake-io/xmake/releases/download/v2.9.9/xmake-master.win64.exe
Error: Unexpected HTTP response: 404
```
Github CI recent issue? Looks like appeared since auto-update 6 h ago.