### PR TITLE
websocketpp: adapt to new versions of boost

### DIFF
--- a/packages/w/websocketpp/xmake.lua
+++ b/packages/w/websocketpp/xmake.lua
@@ -11,7 +11,7 @@ package("websocketpp")
     --add_patches("0.8.2", [[https://github.com/zaphoyd/websocketpp/compare/0.8.2%2E%2E%2Eamini-allight%3Awebsocketpp%3Adevelop.diff]], "1d50646a00452155443f401a4b88b8b16047f3218cbe0a33a6947e92d094a13c")
 
     add_deps("cmake")
-    add_deps("boost") --, {configs = {system = true, asio = true, regex = true}}
+    add_deps("boost", {configs = {system = true, asio = true, regex = true}}
 
     on_install(function (package)
         local configs = {}

--- a/packages/w/websocketpp/xmake.lua
+++ b/packages/w/websocketpp/xmake.lua
@@ -8,7 +8,7 @@ package("websocketpp")
     add_versions("0.8.2", "6ce889d85ecdc2d8fa07408d6787e7352510750daa66b5ad44aacb47bea76755")
 
     -- Compatibility fixes for Boost 1.87 Reference to PR https://github.com/zaphoyd/websocketpp/pull/1164
-    add_patches("0.8.2", [[https://github.com/zaphoyd/websocketpp/compare/0.8.2%2E%2E%2Eamini-allight%3Awebsocketpp%3Adevelop.diff]], "1d50646a00452155443f401a4b88b8b16047f3218cbe0a33a6947e92d094a13c")
+    add_patches("0.8.2", [[https://github.com/zaphoyd/websocketpp/compare/0.8.2%2E%2E%2Eamini-allight%3Awebsocketpp%3Adevelop.diff]], "5396d10ebe593f031580b3c3683f205a8d4c57f2d0942d48c5a4b74e64365f97")
 
     add_deps("cmake")
     add_deps("boost", {configs = {system = true, asio = true, regex = true, thread = true}})

--- a/packages/w/websocketpp/xmake.lua
+++ b/packages/w/websocketpp/xmake.lua
@@ -8,7 +8,7 @@ package("websocketpp")
     add_versions("0.8.2", "6ce889d85ecdc2d8fa07408d6787e7352510750daa66b5ad44aacb47bea76755")
 
     -- Compatibility fixes for Boost 1.87 Reference to PR https://github.com/zaphoyd/websocketpp/pull/1164
-    --add_patches("0.8.2", [[https://github.com/zaphoyd/websocketpp/compare/0.8.2%2E%2E%2Eamini-allight%3Awebsocketpp%3Adevelop.diff]], "1d50646a00452155443f401a4b88b8b16047f3218cbe0a33a6947e92d094a13c")
+    add_patches("0.8.2", [[https://github.com/zaphoyd/websocketpp/compare/0.8.2%2E%2E%2Eamini-allight%3Awebsocketpp%3Adevelop.diff]], "1d50646a00452155443f401a4b88b8b16047f3218cbe0a33a6947e92d094a13c")
 
     add_deps("cmake")
     add_deps("boost", {configs = {system = true, asio = true, regex = true, thread = true}})

--- a/packages/w/websocketpp/xmake.lua
+++ b/packages/w/websocketpp/xmake.lua
@@ -11,7 +11,7 @@ package("websocketpp")
     --add_patches("0.8.2", [[https://github.com/zaphoyd/websocketpp/compare/0.8.2%2E%2E%2Eamini-allight%3Awebsocketpp%3Adevelop.diff]], "1d50646a00452155443f401a4b88b8b16047f3218cbe0a33a6947e92d094a13c")
 
     add_deps("cmake")
-    add_deps("boost", {configs = {system = true, asio = true, regex = true}}
+    add_deps("boost", {configs = {system = true, asio = true, regex = true}})
 
     on_install(function (package)
         local configs = {}

--- a/packages/w/websocketpp/xmake.lua
+++ b/packages/w/websocketpp/xmake.lua
@@ -11,7 +11,7 @@ package("websocketpp")
     --add_patches("0.8.2", [[https://github.com/zaphoyd/websocketpp/compare/0.8.2%2E%2E%2Eamini-allight%3Awebsocketpp%3Adevelop.diff]], "1d50646a00452155443f401a4b88b8b16047f3218cbe0a33a6947e92d094a13c")
 
     add_deps("cmake")
-    add_deps("boost", {configs = {system = true, asio = true, regex = true}})
+    add_deps("boost", {configs = {system = true, asio = true, regex = true, thread = true}})
 
     on_install(function (package)
         local configs = {}

--- a/packages/w/websocketpp/xmake.lua
+++ b/packages/w/websocketpp/xmake.lua
@@ -13,8 +13,8 @@ package("websocketpp")
     add_deps("cmake")
     add_deps("boost", {configs = {system = true, asio = true, regex = true, thread = true}})
 
-    on_install(function (package)
-        local configs = {}
+    on_install("!wasm", function (package)
+        local configs = {"-DCMAKE_POLICY_DEFAULT_CMP0057=NEW"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)

--- a/packages/w/websocketpp/xmake.lua
+++ b/packages/w/websocketpp/xmake.lua
@@ -7,10 +7,13 @@ package("websocketpp")
              "https://github.com/zaphoyd/websocketpp.git")
     add_versions("0.8.2", "6ce889d85ecdc2d8fa07408d6787e7352510750daa66b5ad44aacb47bea76755")
 
-    add_deps("cmake")
-    add_deps("boost")
+    -- Compatibility fixes for Boost 1.87 Reference to PR https://github.com/zaphoyd/websocketpp/pull/1164
+    --add_patches("0.8.2", [[https://github.com/zaphoyd/websocketpp/compare/0.8.2%2E%2E%2Eamini-allight%3Awebsocketpp%3Adevelop.diff]], "1d50646a00452155443f401a4b88b8b16047f3218cbe0a33a6947e92d094a13c")
 
-    on_install("linux", "macosx", "windows", function (package)
+    add_deps("cmake")
+    add_deps("boost") --, {configs = {system = true, asio = true, regex = true}}
+
+    on_install(function (package)
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))


### PR DESCRIPTION
Hash of patch changed on next day for some reason.
```
checkinfo: ...amdir/core/sandbox/modules/import/core/tool/compiler.lua:84: @programdir/modules/core/tools/gcc.lua:980: /home/runner/.xmake/packages/w/websocketpp/0.8.2/2e65daa25197460ab878866d27c4d816/include/websocketpp/transport/asio/connection.hpp:89:24: error: no type named 'io_service' in namespace 'websocketpp::lib::asio'
   89 |     typedef lib::asio::io_service * io_service_ptr;
      |             ~~~~~~~~~~~^
/home/runner/.xmake/packages/w/websocketpp/0.8.2/2e65daa25197460ab878866d27c4d816/include/websocketpp/transport/asio/connection.hpp:91:40: error: no member named 'io_service' in namespace 'websocketpp::lib::asio'
   91 |     typedef lib::shared_ptr<lib::asio::io_service::strand> strand_ptr;
      |                             ~~~~~~~~~~~^
/home/runner/.xmake/packages/w/websocketpp/0.8.2/2e65daa25197460ab878866d27c4d816/include/websocketpp/transport/asio/connection.hpp:315:17: error: no matching constructor for initialization of 'lib::asio::steady_timer' (aka 'basic_waitable_timer<chrono::steady_clock>')
  315 |             new lib::asio::steady_timer(
      |                 ^
  316 |                 *m_io_service,
      |                 ~~~~~~~~~~~~~~
  317 |                 lib::asio::milliseconds(duration))
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/.xmake/packages/b/boost/1.87.0/555799b995ac421cb2bbfc1dd7e81c95/include/boost/asio/basic_waitable_timer.hpp:232:12: note: candidate constructor template not viable: no known conversion from 'std::chrono::milliseconds' (aka 'duration<long, ratio<1, 1000>>') to 'const time_point' (aka 'const time_point<std::chrono::steady_clock, duration<long, ratio<1, 1000000000>>>') for 2nd argument
  232 |   explicit basic_waitable_timer(ExecutionContext& context,
      |            ^
  233 |       const time_point& expiry_time,
```
https://github.com/PointCloudLibrary/pcl/commit/0932486c52a2cf4f0821e25d5ea2d5767fff8381
io_service -> io_context