### PR TITLE
v8: fix and update to 13.5.212.10

### DIFF
--- a/packages/v/v8/patches/13.5.212.10.patch
+++ b/packages/v/v8/patches/13.5.212.10.patch
@@ -1,0 +1,20 @@
+diff --git a/third_party/partition_alloc/src/partition_alloc/BUILD.gn b/third_party/partition_alloc/src/partition_alloc/BUILD.gn
+index ba9ed4ea..759d0b8d 100644
+--- a/third_party/partition_alloc/src/partition_alloc/BUILD.gn
++++ b/third_party/partition_alloc/src/partition_alloc/BUILD.gn
+@@ -41,8 +41,13 @@ partition_alloc_dchecks_are_on =
+ # Building PartitionAlloc for Windows component build.
+ # Currently use build_with_chromium not to affect any third_party code,
+ # but if any third_party code wants to use, remove build_with_chromium.
+-use_partition_alloc_as_malloc_on_win_component_build =
+-    build_with_chromium && is_win && is_component_build
++if (build_with_chromium && is_win && is_component_build) {
++    use_partition_alloc_as_malloc_on_win_component_build = true
++} else {
++    use_partition_alloc_as_malloc_on_win_component_build = false
++}
++#use_partition_alloc_as_malloc_on_win_component_build =
++#    build_with_chromium && is_win && is_component_build
+ 
+ # TODO(crbug.com/40276913): Split PartitionAlloc into a public and
+ # private parts. The public config would include add the "./include" dir and

--- a/packages/v/v8/xmake.lua
+++ b/packages/v/v8/xmake.lua
@@ -53,17 +53,20 @@ package("v8")
         os.vrunv(gclient, {"sync", "--reset", "--delete_unversioned_trees", "-v"}, {envs = envs})
 
         -- Fix GN issue
-        local patchPath = path.join(package:scriptdir(), "patches", "fix_chromium.patch")
-        local sourcePath = path.join(package:cachedir(), "source", "v8")
-        local cwd = os.cd(sourcePath)
+        local patchPath = path.join(package:scriptdir(), "patches", package:version() .. ".patch")
 
-        os.execv("git", {"apply", patchPath})
+        if os.exists(patchPath) then
+            local sourcePath = path.join(package:cachedir(), "source", "v8")
+            local cwd = os.cd(sourcePath)
 
-        os.cd(path.join("third_party", "partition_alloc"))
-        os.execv("git", {"add", path.join("src", "partition_alloc", "BUILD.gn")})
-        os.execv("git", {"commit", "-m", "xmake-patch-01"})
+            os.execv("git", {"apply", patchPath})
 
-        os.cd(cwd)
+            os.cd(path.join("third_party", "partition_alloc"))
+            os.execv("git", {"add", path.join("src", "partition_alloc", "BUILD.gn")})
+            os.execv("git", {"commit", "-m", "xmake-patch-01"})
+
+            os.cd(cwd)
+        end
 
         -- Setup args.gn
         local configs = {

--- a/packages/v/v8/xmake.lua
+++ b/packages/v/v8/xmake.lua
@@ -1,9 +1,11 @@
 package("v8")
-    set_homepage("https://chromium.googlesource.com/v8/v8.git")
+    set_homepage("https://v8.dev")
     set_description("V8 JavaScript Engine")
 
     add_urls("https://github.com/v8/v8.git")
-    add_versions("10.0.58", "d75903764c8547b6fc35c7a3fe4991320be03135")
+    add_versions("13.3.415.19", "fe051262efbbd92479a08436f733eba9f756e008")
+    add_versions("13.4.114.19", "a57459aad9ec3ed5f78d9ded700d52e31029efd2")
+    add_versions("13.5.212.10", "e2591684c45463aa1e46ebefc3fd35deee63f37c")
 
     add_deps("depot_tools")
 
@@ -11,24 +13,11 @@ package("v8")
         add_syslinks("pthread", "dl")
     elseif is_plat("windows") then
         add_syslinks("user32", "winmm", "advapi32", "dbghelp", "shlwapi")
-        add_configs("vs_runtime", {description = "Set vs runtime.", default = "MT", readonly = true})
+        add_configs("runtimes", {description = "Set runtime.", default = "MT", readonly = true})
     end
 
-    add_links("v8_monolith",
-              "v8_initializers",
-              "v8_init",
-              "v8_compiler",
-              "v8_compiler_opt",
-              "v8_cppgc_shared",
-              "v8_bigint",
-              "v8_snapshot",
-              "v8_base_without_compiler",
-              "v8_libplatform",
-              "v8_libbase",
-              "torque_base",
-              "torque_generated_definitions",
-              "cppgc_base",
-              "torque_ls_base")
+    add_includedirs("include", {public = true})
+    add_links("v8_monolith")
 
     on_install("linux", "macosx", "windows", function (package)
         import("core.base.global")
@@ -49,30 +38,56 @@ package("v8")
     "managed": False,
     "custom_deps": {},
   }]]=])
+
         if package:is_plat("windows") then
-            envs.DEPOT_TOOLS_WIN_TOOLCAHIN = "0"
+            envs.DEPOT_TOOLS_WIN_TOOLCHAIN = "0"
+            envs.GYP_MSVS_VERSION = "2022"
         end
         local gclient = is_host("windows") and "gclient.bat" or "gclient"
-        os.vrunv(gclient, {"sync", "-v"}, {envs = envs})
+
+        -- Prevent long path issue on Windows
+        os.vrun("git config --global core.longpaths true")
+
+        -- Update repository and dependencies
+        -- Clean any local changes to apply patches
+        os.vrunv(gclient, {"sync", "--reset", "--delete_unversioned_trees", "-v"}, {envs = envs})
+
+        -- Fix GN issue
+        local patchPath = path.join(package:scriptdir(), "patches", "fix_chromium.patch")
+        local sourcePath = path.join(package:cachedir(), "source", "v8")
+        local cwd = os.cd(sourcePath)
+
+        os.execv("git", {"apply", patchPath})
+
+        os.cd(path.join("third_party", "partition_alloc"))
+        os.execv("git", {"add", path.join("src", "partition_alloc", "BUILD.gn")})
+        os.execv("git", {"commit", "-m", "xmake-patch-01"})
+
+        os.cd(cwd)
+
+        -- Setup args.gn
         local configs = {
             is_official_build = false,
             is_component_build = false,
             is_debug = package:debug(),
-            is_shared_library = package:config("shared"),
-            symbol_level = 0,
+            symbol_level = package:debug() and 2 or 0,
+            strip_debug_info = not package:debug(),
             treat_warnings_as_errors = false,
             use_custom_libcxx = false,
-            v8_static_library = not package:config("shared"),
             v8_monolithic = true,
-            v8_use_external_startup_data = false,
+            v8_enable_sandbox = false,
+            v8_enable_pointer_compression = false,
+            v8_enable_webassembly = false,
+            v8_enable_gdbjit = package:debug(),
+            v8_enable_i18n_support = false,
             v8_enable_test_features = false,
-            v8_enable_i18n_support = false}
+            v8_use_external_startup_data = false
+        }
 
-        if package:is_plat("windows") then
-            configs.extra_cflags = {(package:config("vs_runtime"):startswith("MT") and "/MT" or "/MD")}
-            configs.is_clang = false 
-        end
-        import("package.tools.gn").build(package, configs, {buildir = "out.gn"})
+        -- Build V8 library
+        import("package.tools.gn").build(package, configs, {buildir = "out.gn", target = {"v8_monolith"}})
+
+        -- Install headers and library files
         os.cp("include", package:installdir())
         os.trycp("out.gn/obj/*.a", package:installdir("lib"))
         os.trycp("out.gn/obj/*.lib", package:installdir("lib"))
@@ -80,5 +95,11 @@ package("v8")
     end)
 
     on_test(function (package)
-        assert(package:has_cxxfuncs("v8::V8::InitializePlatform(0)", {configs = {languages = "c++17"}, includes = "v8.h"}))
+        assert(package:has_cxxfuncs("v8::V8::InitializePlatform(0)", {
+            configs = {
+                languages = "c++20",
+                cxxflags = "/Zc:__cplusplus"
+            },
+            includes = "v8.h"
+        }))
     end)


### PR DESCRIPTION
**Requires:**
xmake v2.9.9 to use `target` option when building with GN tool.

**Features:**
- support latest stable version 13.5.212.10
- tested on Windows only
- fix syntax to configure "runtimes", only MT for now
- only build static monolith flavor
- patch to fix build configuration of a dependency (third_party/partition_alloc/)
- erase previous version 10.0.58

**Notes:**
- `add_patches` is not used, because afaik, it is not meant to run in this context. `gclient` is ran during `on_install` callback. `add_patches` would try to apply the patch before execution of `gclient`, that is before files to be patched are even cloned/pulled.

**Questions:**
(1) Is testing on Linux + macOS required to merge?
(2) Is backward compatibility with version 10.0.58 required to merge?