### PR TITLE
Auto-update boost_sml to v1.1.12

### DIFF
--- a/packages/b/boost_sml/xmake.lua
+++ b/packages/b/boost_sml/xmake.lua
@@ -7,6 +7,7 @@ package("boost_sml")
     add_urls("https://github.com/boost-ext/sml/archive/refs/tags/$(version).tar.gz",
              "https://github.com/boost-ext/sml.git")
 
+    add_versions("v1.1.12", "65b53b3b839881512a5bf5bd443afd7dd64a406c706aab469f2e7cfd1d0a6012")
     add_versions("v1.1.11", "8773efd639ce9649dc449135c8c53232e1cb5f4037d44be02c1b9ccc343f246d")
     add_versions("v1.1.8", "d2626b2fd249fa0788ca364a2f8dcb4762dd72195f86d43370e4cad4c02262c5")
 


### PR DESCRIPTION
New version of boost_sml detected (package version: v1.1.11, last github version: v1.1.12)