### PR TITLE
Auto-update aws-c-common to v0.12.2

### DIFF
--- a/packages/a/aws-c-common/xmake.lua
+++ b/packages/a/aws-c-common/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-common")
     add_urls("https://github.com/awslabs/aws-c-common/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-common.git")
 
+    add_versions("v0.12.2", "ecea168ea974f2da73b5a0adc19d9c5ebca73ca4b9f733de7c37fc453ee7d1c2")
     add_versions("v0.12.0", "765ca1be2be9b62a63646cb1f967f2aa781071f7780fdb5bbc7e9acfea0a1f35")
     add_versions("v0.11.3", "efcd2fb20f3149752fed87fa7901e933f3b1a64dfa4ac989f869ded87891bb3c")
     add_versions("v0.11.1", "b442cc59f507fbe232c0ae433c836deff83330270a58fa13bf360562efda368a")


### PR DESCRIPTION
New version of aws-c-common detected (package version: v0.12.0, last github version: v0.12.2)