### PR TITLE
Extend LVGL package configuration

### DIFF
--- a/packages/l/lvgl/xmake.lua
+++ b/packages/l/lvgl/xmake.lua
@@ -14,6 +14,16 @@ package("lvgl")
     add_configs("shared",      {description = "Build shared library.", default = false, type = "boolean", readonly = true})
     add_configs("color_depth", {description = "Set color depth.", default = "32", type = "string", values = {"1", "8", "16", "32"}})
     add_configs("use_log",     {description = "Enable the log module.", default = false, type = "boolean"})
+    
+    -- 新增配置项
+    add_configs("tick_custom", {description = "Use custom tick.", default = false, type = "boolean"})
+    add_configs("mem_custom", {description = "Use custom memory management.", default = false, type = "boolean"})
+    add_configs("color_16_swap", {description = "Swap 16-bit color.", default = false, type = "boolean"})
+    add_configs("use_fs_stdio", {description = "Enable FS stdio support.", default = false, type = "boolean"})
+    add_configs("use_freetype", {description = "Enable FreeType font support.", default = false, type = "boolean"})
+    add_configs("use_gpu_stm32_dma2d", {description = "Use STM32's DMA2D GPU.", default = false, type = "boolean"})
+    add_configs("sprintf_custom", {description = "Use custom snprintf functions.", default = false, type = "boolean"})
+    add_configs("sprintf_use_float", {description = "Use float in snprintf.", default = false, type = "boolean"})
 
     add_deps("cmake")
     on_install(function (package)
@@ -22,10 +32,34 @@ package("lvgl")
         io.replace("src/lv_conf.h", "#define LV_BUILD_EXAMPLES -1", "#define LV_BUILD_EXAMPLES 0")
         io.replace("src/lv_conf.h", "#define LV_COLOR_DEPTH -16", "#define LV_COLOR_DEPTH " .. package:config("color_depth"))
         io.replace("src/lv_conf.h", "#define LV_USE_LOG -0", "#define LV_USE_LOG " .. (package:config("use_log") and "1" or "0"))
+
+        -- 处理新配置项
+        io.replace("src/lv_conf.h", "#define LV_TICK_CUSTOM -0", "#define LV_TICK_CUSTOM " .. (package:config("tick_custom") and "1" or "0"))
+        io.replace("src/lv_conf.h", "#define LV_MEM_CUSTOM -0", "#define LV_MEM_CUSTOM " .. (package:config("mem_custom") and "1" or "0"))
+        io.replace("src/lv_conf.h", "#define LV_COLOR_16_SWAP -0", "#define LV_COLOR_16_SWAP " .. (package:config("color_16_swap") and "1" or "0"))
+        io.replace("src/lv_conf.h", "#define LV_USE_FS_STDIO -0", "#define LV_USE_FS_STDIO " .. (package:config("use_fs_stdio") and "1" or "0"))
+        io.replace("src/lv_conf.h", "#define LV_USE_FREETYPE -0", "#define LV_USE_FREETYPE " .. (package:config("use_freetype") and "1" or "0"))
+        
+        io.replace("src/lv_conf.h", "#define LV_USE_GPU_STM32_DMA2D -0", "#define LV_USE_GPU_STM32_DMA2D " .. (package:config("use_gpu_stm32_dma2d") and "1" or "0"))
+        if package:config("use_gpu_stm32_dma2d") then
+            io.replace("src/lv_conf.h", "// #define LV_GPU_DMA2D_CMSIS_INCLUDE", "#define LV_GPU_DMA2D_CMSIS_INCLUDE")
+        end
+
+        io.replace("src/lv_conf.h", "#define LV_SPRINTF_CUSTOM -0", "#define LV_SPRINTF_CUSTOM " .. (package:config("sprintf_custom") and "1" or "0"))
+        if package:config("sprintf_custom") then
+            io.replace("src/lv_conf.h", "#define LV_SPRINTF_USE_FLOAT -0", "#define LV_SPRINTF_USE_FLOAT " .. (package:config("sprintf_use_float") and "1" or "0"))
+            io.replace("src/lv_conf.h", "#define LV_SPRINTF_INCLUDE <stdio.h>", "#define LV_SPRINTF_INCLUDE <stdio.h>")
+            io.replace("src/lv_conf.h", "#define lv_snprintf  snprintf", "#define lv_snprintf  snprintf")
+            io.replace("src/lv_conf.h", "#define lv_vsnprintf vsnprintf", "#define lv_vsnprintf vsnprintf")
+        else
+            io.replace("src/lv_conf.h", "#define LV_SPRINTF_USE_FLOAT -0", "#define LV_SPRINTF_USE_FLOAT 0")
+        end
+
         if package:version():le("8.1.0") then
             io.replace("CMakeLists.txt", "add_library(lvgl STATIC ${SOURCES})", "add_library(lvgl STATIC ${SOURCES})\ninstall(TARGETS lvgl)\ninstall(FILES lvgl.h DESTINATION include/lvgl)\ninstall(DIRECTORY src DESTINATION include/lvgl FILES_MATCHING PATTERN \"*.h\")", {plain = true})
             io.replace("CMakeLists.txt", "if(ESP_PLATFORM)", "cmake_minimum_required(VERSION 3.15)\nif(ESP_PLATFORM)", {plain = true})
         end
+
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         import("package.tools.cmake").install(package, configs)


### PR DESCRIPTION
为lvgl package 添加了一些宏配置，便于启用一些功能，涉及的宏如下：

```
#define LV_TICK_CUSTOM 0
#define LV_MEM_CUSTOM 0
#define LV_COLOR_16_SWAP 0
#define LV_USE_FS_STDIO 0
#define LV_USE_FREETYPE 0

/*Use STM32's DMA2D (aka Chrom Art) GPU*/
#define LV_USE_GPU_STM32_DMA2D 0
#if LV_USE_GPU_STM32_DMA2D
    /*Must be defined to include path of CMSIS header of target processor
    e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
    #define LV_GPU_DMA2D_CMSIS_INCLUDE
#endif

/*Change the built in (v)snprintf functions*/
#define LV_SPRINTF_CUSTOM 0
#if LV_SPRINTF_CUSTOM
    #define LV_SPRINTF_INCLUDE <stdio.h>
    #define lv_snprintf  snprintf
    #define lv_vsnprintf vsnprintf
#else   /*LV_SPRINTF_CUSTOM*/
```
    #define LV_SPRINTF_USE_FLOAT 0
#endif  /*LV_SPRINTF_CUSTOM*/

