### PR TITLE
Auto-update steam-audio to v4.6.1

### DIFF
--- a/packages/s/steam-audio/patch.lua
+++ b/packages/s/steam-audio/patch.lua
@@ -14,6 +14,11 @@ function main(package)
         _unsafe_patch(package)
     end
 
+    if package:is_plat("windows") and package:is_arch("arm64") then
+        -- https://github.com/microsoft/vcpkg/blob/218f0d9ad10eb7b56624d3a6de5ad7a44bdf2927/ports/steam-audio/fix-arm64-windows.patch
+        io.replace("CMakeLists.txt", "set(IPL_CPU_X64 TRUE)", "set(IPL_CPU_ARMV8 TRUE)", {plain = true})
+    end
+
     if package:is_cross() then
         io.replace("CMakeLists.txt", "add_compile_options(-m32 -mfpmath=sse -march=native)", "", {plain = true})
     end

--- a/packages/s/steam-audio/xmake.lua
+++ b/packages/s/steam-audio/xmake.lua
@@ -6,6 +6,7 @@ package("steam-audio")
     add_urls("https://github.com/ValveSoftware/steam-audio/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ValveSoftware/steam-audio.git")
 
+    add_versions("v4.6.1", "9965993d9df46d0585bd1dcb0acd3c5ae031656c75c87bbd49429db37757b65d")
     add_versions("v4.6.0", "b81479bf8fc55c3bbd49c1f9eb1356d7ff7a3a5efc553ba6653ed41715aaf368")
 
     add_configs("fft", {description = "Choice fft library", default = "pffft", type = "string", values = {"ipp", "ffts", "pffft"}})


### PR DESCRIPTION
New version of steam-audio detected (package version: v4.6.0, last github version: v4.6.1)