### PR TITLE
Auto-update avir to 3.1

### DIFF
--- a/packages/a/avir/xmake.lua
+++ b/packages/a/avir/xmake.lua
@@ -8,6 +8,7 @@ package("avir")
     add_urls("https://github.com/avaneev/avir/archive/refs/tags/$(version).tar.gz",
              "https://github.com/avaneev/avir.git")
 
+    add_versions("3.1", "8235740e578f86d08d03d3f7ae2a6893554c1ae17a061117475219fe3538a7d2")
     add_versions("3.0", "011909d31cf782152a69f570563eb70700504f168174a6049b6acbb9b9f511ea")
 
     on_install(function (package)


### PR DESCRIPTION
New version of avir detected (package version: 3.0, last github version: 3.1)