### PR TITLE
Slang rewrite

### DIFF
--- a/packages/s/shader-slang/patches/v2025.6.3.patch
+++ b/packages/s/shader-slang/patches/v2025.6.3.patch
@@ -1,0 +1,13 @@
+diff --git a/source/slang-glslang/slang-glslang.cpp b/source/slang-glslang/slang-glslang.cpp
+index 8d9f64fd5..011dbf256 100644
+--- a/source/slang-glslang/slang-glslang.cpp
++++ b/source/slang-glslang/slang-glslang.cpp
+@@ -1,7 +1,7 @@
+ // slang-glslang.cpp
+ #include "slang-glslang.h"
+ 
+-#include "SPIRV/GlslangToSpv.h"
++#include "glslang/SPIRV/GlslangToSpv.h"
+ #include "glslang/MachineIndependent/localintermediate.h"
+ #include "glslang/Public/ShaderLang.h"
+ #include "slang.h"

--- a/packages/s/shader-slang/port/prelude/xmake.lua
+++ b/packages/s/shader-slang/port/prelude/xmake.lua
@@ -1,0 +1,28 @@
+target("prelude")
+    set_kind("object")
+    add_packages("unordered_dense")
+    add_deps("slang-embed")
+    set_languages("cxx17")
+    set_warnings("none")
+
+    add_files(
+        "slang-cpp-host-prelude.h.cpp",
+        "slang-cpp-prelude.h.cpp",
+        "slang-cuda-prelude.h.cpp",
+        "slang-hlsl-prelude.h.cpp",
+        "slang-torch-prelude.h.cpp",
+        { always_added = true }
+    )
+    add_includedirs("./", "$(projectdir)/include", { public = true })
+
+    before_build(function ()
+        for _, file_path in ipairs(os.files("$(scriptdir)/*-prelude.h")) do
+            local file_name = path.filename(file_path)
+            print("Generating prelude for " .. file_path)
+            os.vrunv("$(buildir)/generators/slang-embed", {
+                file_path, path.join(os.scriptdir(), file_name .. ".cpp")
+            })
+        end
+    end)
+target_end()
+

--- a/packages/s/shader-slang/port/slang_target.lua
+++ b/packages/s/shader-slang/port/slang_target.lua
@@ -1,0 +1,114 @@
+function add_slang_target(name, options)
+    local from_table = function (tbl, func)
+        tbl = tbl or {}
+        for _, i in ipairs(tbl) do
+            local args = {}
+            for _, v in ipairs(i) do
+                if type(v) == "string" then
+                    table.insert(args, v)
+                elseif type(v) == "table" then
+                    table.insert(args, v)
+                end
+            end
+            func(table.unpack(args))
+        end
+    end
+
+    options = options or {}
+    local kind = options.kind or "static"
+    target(name)
+        set_kind(kind)
+        set_default(options.default or false)
+        set_languages("cxx17")
+        set_warnings("extra")
+        add_rpathdirs("$ORIGIN")
+
+        on_config(function (target)
+            if is_mode("debug") then
+                target:add("defines", "_DEBUG")
+            end
+
+            if is_plat("windows") then
+                target:add("syslinks", "advapi32", "Shell32")
+            elseif is_plat("linux") then
+                target:add("syslinks", "dl", "pthread")
+            end
+
+            target:add("defines", "SLANG_COMPILER")
+            if target:has_tool("cc", "cl") or target:has_tool("cc", "clang_cl") then
+                target:add("defines", "_UNICODE", { force = true, public = true  })
+                target:add("defines", "UNICODE", { force = true, public = true  })
+                target:add("defines", "WIN32_LEAN_AND_MEAN", { force = true, public = true  })
+                target:add("defines", "VC_EXTRALEAN", { force = true, public = true  })
+                target:add("defines", "NOMINMAX", { force = true, public = true  })
+                target:add("defines", "_WIN32", { force = true, public = true  })
+
+                target:add("defines", "SLANG_VC=14", { force = true, public = true })
+            elseif target:has_tool("cc", "clang") then
+                target:add("defines", "SLANG_CLANG=1", { force = true, public = true })
+            elseif target:has_tool("cc", "gcc") then
+                target:add("defines", "SLANG_GCC=1", { force = true, public = true })
+            end
+
+            if options.on_config then
+                options.on_config(target)
+            end
+        end)
+
+        from_table(options.includes, add_includedirs)
+        from_table(options.files, add_files)
+        from_table(options.remove_files, remove_files)
+        from_table(options.deps, add_deps)
+        from_table(options.packages, add_packages)
+        from_table(options.defines, add_defines)
+        from_table(options.config_files, add_configfiles)
+        from_table(options.ldflags, add_ldflags)
+        from_table(options.linkdirs, add_linkdirs)
+        from_table(options.links, add_links)
+
+        if options.export_macro_prefix then
+            local export_type_as = options.export_type_as or ""
+            if kind == "shared" or export_type_as == "shared" then
+                add_defines(options.export_macro_prefix .. "_DYNAMIC", { public = true })
+                add_defines(options.export_macro_prefix .. "_DYNAMIC_EXPORT", { public = false })
+            elseif kind == "static" or export_type_as == "static" then
+                add_defines(options.export_macro_prefix .. "_STATIC", { public = true })
+            end
+        end
+
+        if is_os("windows") and options.windows_files then
+            add_files(options.windows_files)
+        elseif is_os("linux") and options.linux_files then
+            add_files(options.linux_files)
+        end
+
+        if options.rules then
+            for _, rule in ipairs(options.rules) do
+                add_rules(rule)
+            end
+        end
+
+        if options.output_dir then
+            set_targetdir(options.output_dir)
+        end
+
+        if options.install_dir then
+            set_installdir(options.install_dir)
+        end
+
+        if options.before_build then
+            before_build(options.before_build)
+        end
+
+        if options.kind == "binary" then
+            add_cxxflags("-fPIE", { tools = { "clang", "gcc" } })
+        else
+            add_cxxflags("-fPIC", { tools = { "clang", "gcc" } })
+        end
+
+        set_enabled(not options.enabled or false)
+        set_policy("build.fence", options.fence or false)
+    target_end()
+end
+
+

--- a/packages/s/shader-slang/port/source/compiler-core/xmake.lua
+++ b/packages/s/shader-slang/port/source/compiler-core/xmake.lua
@@ -1,0 +1,20 @@
+add_slang_target("compiler-core", {
+    includes = {
+        { ".", { public = true } }
+    },
+    files = {
+        { "./*.cpp" }
+    },
+    deps = {
+        { "core", { public = false } }
+    },
+    defines = {
+        { "SLANG_ENABLE_DXIL_SUPPORT=0", { public = true } }
+    },
+    windows_files = "./windows/*.cpp",
+    packages = {
+        { "spirv-headers", { public = true } }
+    }
+})
+
+

--- a/packages/s/shader-slang/port/source/core/xmake.lua
+++ b/packages/s/shader-slang/port/source/core/xmake.lua
@@ -1,0 +1,16 @@
+add_slang_target("core", {
+    includes = {
+        { "$(projectdir)/include", "$(projectdir)/source", { public = true } }
+    },
+    files = {
+        { "./*.cpp" }
+    },
+    windows_files = "./windows/*.cpp",
+    linux_files = "./unix/*.cpp",
+    packages = {
+        { "miniz", "lz4", { public = false } },
+        { "unordered_dense", { public = true } },
+    },
+})
+
+

--- a/packages/s/shader-slang/port/source/slang-core-module/xmake.lua
+++ b/packages/s/shader-slang/port/source/slang-core-module/xmake.lua
@@ -22,7 +22,7 @@ add_slang_target("slang-embedded-core-module", {
         { "./slang-embedded-core-module.cpp" }
     },
     deps = {
-        { "core", "slang-bootstrap", { public = false } }
+        { "core", "slang-without-embedded-core-module", "slang-bootstrap", { public = false } }
     },
 --  ── common args end ─────────────────────────────────────────────────
     defines = {

--- a/packages/s/shader-slang/port/source/slang-core-module/xmake.lua
+++ b/packages/s/shader-slang/port/source/slang-core-module/xmake.lua
@@ -22,7 +22,7 @@ add_slang_target("slang-embedded-core-module", {
         { "./slang-embedded-core-module.cpp" }
     },
     deps = {
-        { "core", "slang-without-embedded-core-module", "slang-bootstrap", { public = false } }
+        { "core", "slang-bootstrap", { public = false } }
     },
 --  ── common args end ─────────────────────────────────────────────────
     defines = {

--- a/packages/s/shader-slang/port/source/slang-core-module/xmake.lua
+++ b/packages/s/shader-slang/port/source/slang-core-module/xmake.lua
@@ -1,0 +1,77 @@
+add_slang_target("slang-no-embedded-core-module", {
+--  ── common args ─────────────────────────────────────────────────────
+    kind = "object",
+    export_type_as = "shared",
+    export_macro_prefix = "SLANG",
+    files = {
+        { "./slang-embedded-core-module.cpp" }
+    },
+    deps = {
+        { "core", { public = false } }
+    },
+--  ── common args end ─────────────────────────────────────────────────
+})
+
+add_slang_target("slang-embedded-core-module", {
+--  ── common args ─────────────────────────────────────────────────────
+    kind = "object",
+    export_type_as = "shared",
+    export_macro_prefix = "SLANG",
+    includes = { { "$(buildir)", { public = false } } },
+    files = {
+        { "./slang-embedded-core-module.cpp" }
+    },
+    deps = {
+        { "core", "slang-bootstrap", { public = false } }
+    },
+--  ── common args end ─────────────────────────────────────────────────
+    defines = {
+        { "SLANG_EMBED_CORE_MODULE", { public = false } }
+    },
+    before_build = function ()
+        import("core.project.config")
+        local output_dir = config.buildir()
+        local generated_header = path.join(output_dir, "slang-core-module-generated.h")
+
+        os.vrunv("$(buildir)/generators/slang-bootstrap", {
+            "-archive-type", "riff-lz4", "-save-core-module-bin-source", generated_header
+        })
+    end
+})
+
+add_slang_target("slang-embedded-core-module-source", {
+    kind = "object",
+    export_macro_prefix = "SLANG",
+    export_type_as = "shared",
+    includes = {
+        { "$(projectdir)/source/slang", "$(buildir)/core-module-meta", { public = false } }
+    },
+    files = {
+        { "./slang-embedded-core-module-source.cpp" }
+    },
+    deps = {
+        { "core", "slang-generate", "slang-capability-defs", "slang-reflect-headers", { public = false } }
+    },
+    packages = {
+        { "spirv-headers" }
+    },
+    defines = {
+        { "SLANG_EMBED_CORE_MODULE_SOURCE", { public = false } }
+    },
+    before_build = function ()
+        import("core.project.config")
+        local output_dir = path.join(config.buildir(), "core-module-meta")
+        local args = {}
+        for _, v in ipairs(os.files("$(projectdir)/source/slang/*.meta.slang")) do
+            table.insert(args, v)
+        end
+
+        table.insert(args, "--target-directory")
+        table.insert(args, output_dir)
+
+        os.mkdir(output_dir)
+        os.vrunv("$(buildir)/generators/slang-generate", args)
+    end
+})
+-- add_slang_target("slang-no-embedded-core-module-source", core_module_source_common_args)
+

--- a/packages/s/shader-slang/port/source/slang-glslang/xmake.lua
+++ b/packages/s/shader-slang/port/source/slang-glslang/xmake.lua
@@ -1,0 +1,17 @@
+add_slang_target("slang-glslang", {
+    kind = "shared",
+    includes = {
+        { "$(projectdir)/source/slang-glslang", "$(projectdir)/include" }
+    },
+    files = {
+        { "slang-glslang.cpp" }
+    },
+    packages = {
+        { "glslang", "spirv-headers", "spirv-tools" }
+    },
+    ldflags = {
+        { "-Wl,--exclude-libs,ALL" }
+    }
+})
+
+

--- a/packages/s/shader-slang/port/source/slang/xmake.lua
+++ b/packages/s/shader-slang/port/source/slang/xmake.lua
@@ -1,0 +1,183 @@
+add_slang_target("slang-capability-defs", {
+    kind = "object",
+    fence = true,
+    deps = {
+        { "slang-capability-generator" }
+    },
+    includes = {
+        { "$(buildir)/capabilities", "$(projectdir)/source/slang", { public = true } }
+    },
+    before_build = function()
+        import("core.project.config")
+        local output_dir = path.join(config.buildir(), "capabilities")
+        os.mkdir(output_dir)
+
+        for _, file_path in ipairs(os.files("$(scriptdir)/*.capdef")) do
+            print("Generating capability defs for " .. file_path)
+            os.vrunv("$(buildir)/generators/slang-capability-generator", {
+                file_path, "--target-directory", output_dir, "--doc",
+                path.join(os.projectdir(), "docs/dummy.md")
+            })
+        end
+    end,
+})
+
+add_slang_target("slang-capability-lookup", {
+    kind = "object",
+    deps = {
+        { "core", "slang-capability-defs" }
+    },
+    files = {
+        { "$(buildir)/capabilities/slang-lookup-capability-defs.cpp", { always_added = true } }
+    },
+})
+
+add_slang_target("slang-lookup-tables", {
+    kind = "object",
+    deps = {
+        { "slang-lookup-generator", "slang-spirv-embed-generator" }
+    },
+    files = {
+        {
+            "$(buildir)/slang-lookup-tables/slang-lookup-GLSLstd450.cpp",
+            "$(buildir)/slang-lookup-tables/slang-spirv-core-grammar-embed.cpp",
+            { always_added = true }
+        }
+    },
+    packages = {
+        { "spirv-headers" }
+    },
+    before_build = function(target)
+        import("core.project.config")
+        local output_dir = path.join(config.buildir(), "slang-lookup-tables")
+        local spirv_path = target:pkg("spirv-headers"):installdir():gsub("\\", "/")
+        local grammar_dir = path.join(spirv_path, "include", "spirv", "unified1")
+
+        local glsl_grammar_file = path.join(grammar_dir, "extinst.glsl.std.450.grammar.json")
+        local glsl_generated_source = path.join(output_dir, "slang-lookup-GLSLstd450.cpp")
+        local spirv_grammar_file = path.join(grammar_dir, "spirv.core.grammar.json")
+        local spirv_generated_source = path.join(output_dir, "slang-spirv-core-grammar-embed.cpp")
+        os.mkdir(output_dir)
+
+        os.vrunv("$(buildir)/generators/slang-lookup-generator", {
+            glsl_grammar_file, glsl_generated_source, "GLSLstd450", "GLSLstd450",
+            "spirv/unified1/GLSL.std.450.h",
+        })
+
+        os.vrunv("$(buildir)/generators/slang-spirv-embed-generator", {
+            spirv_grammar_file, spirv_generated_source
+        })
+    end
+})
+
+add_slang_target("slang-reflect-headers", {
+    kind = "phony",
+    fence = true,
+    includes = {
+        { "$(buildir)/ast-reflect", { public = true } }
+    },
+    deps = {
+        { "slang-cpp-extractor", { public = false } }
+    },
+    before_build = function()
+        import("core.project.config")
+        local working_dir = path.join(os.scriptdir())
+        local output_dir = path.absolute(path.join(config.buildir(), "ast-reflect"))
+
+        os.mkdir(output_dir)
+
+        local SLANG_REFLECT_INPUT = {
+            "slang-ast-support-types.h",
+            "slang-ast-base.h",
+            "slang-ast-decl.h",
+            "slang-ast-expr.h",
+            "slang-ast-modifier.h",
+            "slang-ast-stmt.h",
+            "slang-ast-type.h",
+            "slang-ast-val.h",
+        }
+
+        local args = {}
+        for _, v in ipairs(SLANG_REFLECT_INPUT) do
+            table.insert(args, path.join(working_dir, v))
+        end
+        table.insert(args, "-strip-prefix")
+        table.insert(args, "slang-")
+        table.insert(args, "-o")
+        table.insert(args, path.join(output_dir, "slang-generated"))
+        table.insert(args, "-output-fields")
+        table.insert(args, "-mark-suffix")
+        table.insert(args, "_CLASS")
+        os.vrunv("$(buildir)/generators/slang-cpp-extractor", args)
+    end
+})
+
+---------------------------------------------------------------------------------
+
+local slang_link_args = {
+    "core",
+    "prelude",
+    "compiler-core",
+    "slang-capability-defs",
+    "slang-capability-lookup",
+    "slang-reflect-headers",
+    "slang-lookup-tables",
+    { public = false }
+}
+
+local slang_packages_args = {
+    "spirv-headers",
+    { public = false }
+}
+
+local slang_public_includes = {
+    "$(projectdir)/include", { public = true },
+}
+
+add_slang_target("slang-common-objects", {
+    kind = "object",
+    export_macro_prefix = "SLANG",
+    export_type_as = "shared",
+    includes = {
+        { "$(projectdir)", "$(buildir)", { public = false } }
+    },
+    files = {
+        { "./*.cpp", "../slang-record-replay/record/*.cpp", "../slang-record-replay/util/*.cpp" }
+    },
+    config_files = {
+        { "$(projectdir)/slang-tag-version.h.in", { filename = "slang-tag-version.h", pattern = "@(.-)@", public = true } },
+    },
+    defines = {
+        { "SLANG_USE_SYSTEM_SPIRV_HEADER" }
+    },
+    deps = { slang_link_args },
+    packages = { slang_packages_args },
+})
+
+add_slang_target("slang-without-embedded-core-module", {
+    fence = true,
+    kind = "shared",
+    export_macro_prefix = "SLANG",
+    includes = {
+        slang_public_includes,
+    },
+    deps = {
+        slang_link_args,
+        { "slang-common-objects", "slang-no-embedded-core-module", "slang-embedded-core-module-source", { public = false } }
+    },
+    packages = { slang_packages_args },
+    output_dir = "$(buildir)/generators",
+    install_dir = "$(buildir)/generators",
+})
+
+add_slang_target("slang", {
+    kind = "shared",
+    includes = {
+        slang_public_includes,
+    },
+    deps = {
+        slang_link_args,
+        { "slang-embedded-core-module", "slang-embedded-core-module-source", "slang-common-objects", { public = false } }
+    },
+    packages = { slang_packages_args },
+})

--- a/packages/s/shader-slang/port/source/xmake.lua
+++ b/packages/s/shader-slang/port/source/xmake.lua
@@ -1,0 +1,21 @@
+add_requires("unordered_dense v4.5.0")
+add_requires("miniz 2.2.0")
+add_requires("lz4 v1.10.0")
+add_requires("spirv-headers 1.4.309+0")
+add_requires("spirv-tools 1.4.309+0")
+add_requires("glslang 1.4.309+0")
+
+includes("core")
+includes("compiler-core")
+includes("slang-core-module")
+includes("slang")
+includes("slang-glslang")
+
+add_slang_target("slang-build-all", {
+    kind = "phony",
+    default = true,
+    fence = true,
+    deps = {
+        { "slang", "slang-glslang" }
+    },
+})

--- a/packages/s/shader-slang/port/tools/xmake.lua
+++ b/packages/s/shader-slang/port/tools/xmake.lua
@@ -1,0 +1,70 @@
+local add_generator = function(dir, options)
+    options = options or {}
+    if options.deps then
+        table.insert(options.deps, { public = false })
+    end
+
+    if options.public_deps then
+        table.insert(options.public_deps, { public = true })
+    end
+
+    add_slang_target(options.name or dir, {
+        kind = "binary",
+        files = {
+            { dir .. "/*.cpp" }
+        },
+        deps = {
+            options.deps or {},
+            options.public_deps or {},
+            { "core", { public = false } }
+        },
+        output_dir = "$(buildir)/generators",
+        install_dir = "$(buildir)/generators",
+        defines = {
+            options.defines or {}
+        },
+        linkdirs = {
+            { "$(buildir)/generators" }
+        },
+        links = {
+            options.links or {}
+        },
+        fence = true,
+    })
+end
+
+add_generator("slang-embed")
+add_generator("slang-generate")
+add_generator("slang-lookup-generator", { deps = { "compiler-core" } })
+add_generator("slang-capability-generator", { deps = { "compiler-core" } })
+add_generator("slang-spirv-embed-generator", { deps = { "compiler-core" } })
+
+add_slang_target("slang-cpp-parser", {
+    fence = true,
+    kind = "static",
+    files = { { "slang-cpp-parser/*.cpp" } },
+    includes = { { ".", { public = true } } },
+    deps = { { "core", "compiler-core", { public = false } } },
+    output_dir = "$(buildir)/generators",
+    export_macro_prefix = "SLANG",
+    export_type_as = "shared",
+})
+
+add_generator("slang-cpp-extractor", { deps = { "compiler-core", "slang-cpp-parser" } })
+
+add_generator("$(projectdir)/source/slangc", {
+    name = "slang-bootstrap",
+    deps = {
+        "prelude",
+        "slang-capability-lookup",
+        "slang-lookup-tables",
+    },
+    public_deps = {
+        "slang-without-embedded-core-module"
+    },
+    defines = {
+        "SLANG_BOOTSTRAP=1",
+    },
+})
+
+

--- a/packages/s/shader-slang/port/tools/xmake.lua
+++ b/packages/s/shader-slang/port/tools/xmake.lua
@@ -58,6 +58,7 @@ add_generator("$(projectdir)/source/slangc", {
         "prelude",
         "slang-capability-lookup",
         "slang-lookup-tables",
+        "slang-without-embedded-core-module",
     },
     links = {
         "slang-without-embedded-core-module"

--- a/packages/s/shader-slang/port/tools/xmake.lua
+++ b/packages/s/shader-slang/port/tools/xmake.lua
@@ -59,7 +59,7 @@ add_generator("$(projectdir)/source/slangc", {
         "slang-capability-lookup",
         "slang-lookup-tables",
     },
-    public_deps = {
+    links = {
         "slang-without-embedded-core-module"
     },
     defines = {

--- a/packages/s/shader-slang/port/xmake.lua
+++ b/packages/s/shader-slang/port/xmake.lua
@@ -1,0 +1,28 @@
+add_rules("mode.debug", "mode.release", "mode.releasedbg")
+
+option("slang_version", {description = "Slang version", type = "string"})
+
+-- Global Compiler Options --
+add_cxxflags(
+    "-Wno-assume",
+    "-Wno-switch",
+    "-Wno-constant-logical-operand",
+    "-Wno-invalid-offsetof",
+    "-Wno-dangling-else",
+    "-fms-extensions",
+    { force = true, tools = { "clang", "gcc", "clang_cl" } }
+)
+
+set_encodings("utf-8")
+
+set_project("slang")
+if has_config("slang_version") then
+    local version = get_config("slang_version")
+    set_version(version)
+    set_configvar("SLANG_VERSION_FULL", version)
+end
+
+includes("slang_target.lua")
+includes("tools")
+includes("source")
+includes("prelude")

--- a/packages/s/shader-slang/xmake.lua
+++ b/packages/s/shader-slang/xmake.lua
@@ -1,0 +1,32 @@
+package("shader-slang")
+    set_homepage("https://github.com/shader-slang/slang")
+    set_description("Making it easier to work with shaders")
+    set_license("MIT")
+
+    add_urls("https://github.com/shader-slang/slang.git", { submodules = false })
+
+    add_versions("v2025.6.3", "b9300bae08a77df6ef2efe2b62de14a13b10b9a4")
+    add_patches("v2025.6.3", path.join(os.scriptdir(), "patches", "v2025.6.3.patch"))
+
+    add_configs("shared", { description = "Build shared library", default = true, type = "boolean", readonly = true })
+
+    on_load(function (package)
+        local version = package:version();
+        package:add("defines", "SLANG_VERSION=\"" .. version:gsub("v", "") .. "\"")
+    end)
+
+    on_install("windows", "linux", function (package)
+        local root = path.join(os.scriptdir(), "port")
+        for _, file in ipairs(os.files(path.join(root, "**.lua"))) do
+            os.cp(file, path.relative(file, root))
+        end
+
+        import("package.tools.xmake").install(package, {
+            slang_version = package:version_str(),
+        })
+        os.cp("include/*.h", package:installdir("include"))
+        os.trycp(path.join(package:buildir(), "**.so"), package:installdir("lib"))
+        os.trycp(path.join(package:buildir(), "**.dll"), package:installdir("lib"))
+    end)
+package_end()
+


### PR DESCRIPTION
My alternative approach to properly adding slang-shader.
I've partially rewritten the build script and removed CMake dependencies.
Current version directly pulls dependencies from xmake-repo instead.
Previously implemented on https://github.com/xmake-io/xmake-repo/pull/4138 https://github.com/xmake-io/xmake-repo/pull/4416.

This currently only supports slang -> spir-v output (with slang-glslang optimizer).

I've renamed it to `shader-slang` because of a name collusion with another library named `slang` (see: https://github.com/shader-slang/slang/issues/4016).

Any help on improving this package is appreciated.