### PR TITLE
Auto-update ngtcp2 to 1.12.0

### DIFF
--- a/packages/n/ngtcp2/xmake.lua
+++ b/packages/n/ngtcp2/xmake.lua
@@ -4,6 +4,7 @@ package("ngtcp2")
     set_license("MIT")
 
     add_urls("https://github.com/ngtcp2/ngtcp2/releases/download/v$(version)/ngtcp2-$(version).tar.gz")
+    add_versions("1.12.0", "c08af5c9bfc019f36681775ff07f5623587ca352694943f49133e670dea4ef10")
     add_versions("1.11.0", "41fc390d07b89e2285e1107279518e755cdd5cd046630da3301a9cadcfc9e4b6")
     add_versions("1.10.0", "24c79798650222f932ca443ac5af93b7487b5abd7b852a3bc5129f87008b95bc")
     add_versions("1.9.1", "0d8ebc929d5aa444d848ac7ae971cb3cadaba7ccec7db21f3117fc7167e582c3")


### PR DESCRIPTION
New version of ngtcp2 detected (package version: 1.11.0, last github version: 1.12.0)