### PR TITLE
zlibcomplete: Fixed cmake compiler test failure on riscv cross compil…

### DIFF
--- a/packages/z/zlibcomplete/xmake.lua
+++ b/packages/z/zlibcomplete/xmake.lua
@@ -21,6 +21,9 @@ package("zlibcomplete")
         else
             table.insert(configs, "-DZLIBCOMPLETE_STATIC=on")
         end
+        if package:is_cross() then
+            table.insert(configs, "-DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY")
+        end
         import("package.tools.cmake").install(package, configs)
         os.cp("lib/zlc/*.hpp", package:installdir("include", "zlc"))
     end)

--- a/packages/z/zlibcomplete/xmake.lua
+++ b/packages/z/zlibcomplete/xmake.lua
@@ -16,6 +16,7 @@ package("zlibcomplete")
         table.insert(configs, "-DZLIBCOMPLETE_EXAMPLES=off")
         table.insert(configs, "-DZLIBCOMPLETE_DOCS=off")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DCMAKE_POLICY_DEFAULT_CMP0057=NEW")
         if package:config("shared") then
             table.insert(configs, "-DZLIBCOMPLETE_SHARED=on")
         else


### PR DESCRIPTION
## 主题
修复zlibcomplete库在交叉编译工具链上安装失败的bug

## Bug表现
- 修改前，使用riscv64-unknown-elf-*工具链并添加zlibcomplete至项目时，cmake在test compiler阶段报错，显示riscv64-unknown-elf-gcc无法通过测试
- 查看日志，发现是因为其向riscv64-unknown-elf-gcc传递了不受支持的`-rdynamic`选项
- `xmake f -vD ...`的日志：
```
xmake f -c -m release -a rv32im_zicond_zicsr_zifencei -p baremetal -vD
checking for git ... /usr/bin/git
checking for gzip ... /usr/bin/gzip
checking for tar ... /usr/bin/tar
/usr/bin/git rev-parse HEAD
checking for gcc ... /usr/local/bin/gcc
checkinfo: cannot runv(nim --version), No such file or directory
checking for nim ... no
checkinfo: cannot runv(nim --version), No such file or directory
checking for nim ... no
checking for cmake ... no
checking for cmake ... /usr/bin/cmake
finding zlib from xmake ..
checking for xmake::zlib ... zlib v1.3.1
finding zlibcomplete from xmake ..
checking for xmake::zlibcomplete ... no
finding zlibcomplete from vcpkg ..
checking for brew ... no
finding zlibcomplete from conan ..
checking for zlibcomplete ... no
note: install or modify (m) these packages (pass -y to skip confirm)?
in xmake-repo:
  -> zlibcomplete 1.0.5 [toolchains:"riscv-gcc-baremetal", license:MIT]
please input: y (y/n/m)
y
checking for ping ... /usr/bin/ping
pinging the host(github.com) ... 0 ms
/usr/bin/tar -xf /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/1.0.5.tar.gz -C source.tmp
checking for riscv64-unknown-elf-gcc ... /opt/riscv/bin/riscv64-unknown-elf-gcc
checking for the c compiler (cc) ... riscv64-unknown-elf-gcc
checking for riscv64-unknown-elf-g++ ... /opt/riscv/bin/riscv64-unknown-elf-g++
checking for the c++ compiler (cxx) ... riscv64-unknown-elf-g++
checking for riscv64-unknown-elf-g++ ... /opt/riscv/bin/riscv64-unknown-elf-g++
checking for the assember (as) ... riscv64-unknown-elf-g++
checking for riscv64-unknown-elf-gcc-ar ... /opt/riscv/bin/riscv64-unknown-elf-gcc-ar
checking for the static library archiver (ar) ... riscv64-unknown-elf-gcc-ar
checking for riscv64-unknown-elf-ld ... /opt/riscv/bin/riscv64-unknown-elf-ld
checking for the linker (ld) ... riscv64-unknown-elf-ld
checking for /opt/riscv/bin/riscv64-unknown-elf-gcc ... ok
checking for flags (-fPIC) ... ok
> riscv64-unknown-elf-gcc "-fPIC" "-funroll-loops" "-finline-functions" "-march=rv32im_zicond_zicsr_zifencei" "-mabi=ilp32"
checking for /opt/riscv/bin/riscv64-unknown-elf-g++ ... ok
checking for flags (-fPIC) ... ok
> riscv64-unknown-elf-g++ "-fPIC" "-ffunction-sections" "-funroll-loops" "-finline-functions" "-march=rv32im_zicond_zicsr_zifencei" "-mabi=ilp32"
checking for flags (-fPIC) ... ok
> riscv64-unknown-elf-g++ "-fPIC" "-nostartfiles" "-march=rv32im_zicond_zicsr_zifencei" "-Xassembler" "--defsym" "-Xassembler" "ARCH_RV32IM_ZICOND_ZICSR_ZIFENCEI=1" "-mabi=ilp32"
checking for riscv64-unknown-elf-ld ... /opt/riscv/bin/riscv64-unknown-elf-ld
checking for the shared library linker (sh) ... riscv64-unknown-elf-ld
checking for cmake ... /usr/bin/cmake
/usr/bin/cmake -DZLIBCOMPLETE_EXAMPLES=off -DZLIBCOMPLETE_DOCS=off -DCMAKE_BUILD_TYPE=Release -DZLIBCOMPLETE_STATIC=on -DCMAKE_INSTALL_PREFIX=/home/stehsaer/.xmake/packages/z/zlibcomplete/1.0.5/d2eddf2797484a3a897b3164ee74865b -DCMAKE_INSTALL_LIBDIR:PATH=lib -G "Unix Makefiles" -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_FIND_USE_INSTALL_PREFIX=0 -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH "-DCMAKE_CXX_FLAGS=-ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI" "-DCMAKE_MODULE_LINKER_FLAGS=-lm -lc -lgcc -lstdc++" -DHAVE_FLAG_SEARCH_PATHS_FIRST=0 "-DCMAKE_ASM_FLAGS=-nostartfiles -march=rv32im_zicond_zicsr_zifencei \"-Xassembler --defsym -Xassembler\" ARCH_RV32IM_ZICOND_ZICSR_ZIFENCEI=1 -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI" -DCMAKE_AR=/opt/riscv/bin/riscv64-unknown-elf-gcc-ar "-DCMAKE_C_FLAGS=-funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI" -DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=0 -DCMAKE_OSX_SYSROOT= -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_STATIC_LINKER_FLAGS= "-DCMAKE_SHARED_LINKER_FLAGS=-lm -lc -lgcc -lstdc++" -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH -DCMAKE_CXX_COMPILER=/opt/riscv/bin/riscv64-unknown-elf-g++ -DCMAKE_C_COMPILER=/opt/riscv/bin/riscv64-unknown-elf-gcc -DCMAKE_ASM_COMPILER=/opt/riscv/bin/riscv64-unknown-elf-g++ /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - failed
-- Check for working C compiler: /opt/riscv/bin/riscv64-unknown-elf-gcc
-- Check for working C compiler: /opt/riscv/bin/riscv64-unknown-elf-gcc - broken
CMake Error at /usr/share/cmake-3.25/Modules/CMakeTestCCompiler.cmake:70 (message):
  The C compiler

    "/opt/riscv/bin/riscv64-unknown-elf-gcc"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27/CMakeFiles/CMakeScratch/TryCompile-olEYL3
    
    Run Build Command(s):/usr/bin/gmake -f Makefile cmTC_555c5/fast && /usr/bin/gmake  -f CMakeFiles/cmTC_555c5.dir/build.make CMakeFiles/cmTC_555c5.dir/build
    gmake[1]: 进入目录“/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27/CMakeFiles/CMakeScratch/TryCompile-olEYL3”
    Building C object CMakeFiles/cmTC_555c5.dir/testCCompiler.c.o
    /opt/riscv/bin/riscv64-unknown-elf-gcc   -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI  -fPIE -o CMakeFiles/cmTC_555c5.dir/testCCompiler.c.o -c /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27/CMakeFiles/CMakeScratch/TryCompile-olEYL3/testCCompiler.c
    Linking C executable cmTC_555c5
    /usr/bin/cmake -E cmake_link_script CMakeFiles/cmTC_555c5.dir/link.txt --verbose=1
    /opt/riscv/bin/riscv64-unknown-elf-gcc -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI  -rdynamic CMakeFiles/cmTC_555c5.dir/testCCompiler.c.o -o cmTC_555c5 
    riscv64-unknown-elf-gcc: error: unrecognized command-line option '-rdynamic'
    gmake[1]: *** [CMakeFiles/cmTC_555c5.dir/build.make:99：cmTC_555c5] 错误 1
    gmake[1]: 离开目录“/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27/CMakeFiles/CMakeScratch/TryCompile-olEYL3”
    gmake: *** [Makefile:127：cmTC_555c5/fast] 错误 2
    
    

  

  CMake will not be able to correctly generate this project.
Call Stack (most recent call first):
  CMakeLists.txt:3 (project)


-- Configuring incomplete, errors occurred!
See also "/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27/CMakeFiles/CMakeOutput.log".
See also "/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27/CMakeFiles/CMakeError.log".
error: @programdir/core/sandbox/modules/os.lua:378: execv(/usr/bin/cmake -DZLIBCOMPLETE_EXAMPLES=off -DZLIBCOMPLETE_DOCS=off -DCMAKE_BUILD_TYPE=Release -DZLIBCOMPLETE_STATIC=on -DCMAKE_INSTALL_PREFIX=/home/stehsaer/.xmake/packages/z/zlibcomplete/1.0.5/d2eddf2797484a3a897b3164ee74865b -DCMAKE_INSTALL_LIBDIR:PATH=lib -G "Unix Makefiles" -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_FIND_USE_INSTALL_PREFIX=0 -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH "-DCMAKE_CXX_FLAGS=-ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI" "-DCMAKE_MODULE_LINKER_FLAGS=-lm -lc -lgcc -lstdc++" -DHAVE_FLAG_SEARCH_PATHS_FIRST=0 "-DCMAKE_ASM_FLAGS=-nostartfiles -march=rv32im_zicond_zicsr_zifencei \"-Xassembler --defsym -Xassembler\" ARCH_RV32IM_ZICOND_ZICSR_ZIFENCEI=1 -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI" -DCMAKE_AR=/opt/riscv/bin/riscv64-unknown-elf-gcc-ar "-DCMAKE_C_FLAGS=-funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI" -DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=0 -DCMAKE_OSX_SYSROOT= -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_STATIC_LINKER_FLAGS= "-DCMAKE_SHARED_LINKER_FLAGS=-lm -lc -lgcc -lstdc++" -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH -DCMAKE_CXX_COMPILER=/opt/riscv/bin/riscv64-unknown-elf-g++ -DCMAKE_C_COMPILER=/opt/riscv/bin/riscv64-unknown-elf-gcc -DCMAKE_ASM_COMPILER=/opt/riscv/bin/riscv64-unknown-elf-g++ /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source) failed(1)
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:1004]:
    [@programdir/core/sandbox/modules/os.lua:378]:
    [@programdir/core/sandbox/modules/os.lua:291]: in function 'vrunv'
    [@programdir/modules/package/tools/cmake.lua:1317]: in function 'configure'
    [@programdir/modules/package/tools/cmake.lua:1359]: in function 'install'
    [...epositories/xmake-repo/packages/z/zlibcomplete/xmake.lua:27]: in function 'script'
    [...dir/modules/private/action/require/impl/utils/filter.lua:114]: in function 'call'
    [.../modules/private/action/require/impl/actions/install.lua:452]:

  => install zlibcomplete 1.0.5 .. failed
error: @programdir/core/main.lua:329: @programdir/modules/async/runjobs.lua:325: .../modules/private/action/require/impl/actions/install.lua:561: install failed!
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:1004]:
    [.../modules/private/action/require/impl/actions/install.lua:561]: in function 'catch'
    [@programdir/core/sandbox/modules/try.lua:123]: in function 'try'
    [.../modules/private/action/require/impl/actions/install.lua:419]:
    [...modules/private/action/require/impl/install_packages.lua:510]: in function 'jobfunc'
    [@programdir/modules/async/runjobs.lua:241]:

stack traceback:
        [C]: in function 'error'
        @programdir/core/base/os.lua:1004: in function 'base/os.raiselevel'
        (...tail calls...)
        @programdir/core/main.lua:329: in upvalue 'cotask'
        @programdir/core/base/scheduler.lua:406: in function <@programdir/core/base/scheduler.lua:399>
```

## 修改方案
- 参照[Cmake文档](https://cmake.org/cmake/help/latest/variable/CMAKE_TRY_COMPILE_TARGET_TYPE.html)，当检测到`package:is_cross()`时，就将该Cmake flag设置为STATIC_LIBRARY，从而避免Cmake在测试时向编译器传递`-rdynamic`选项
- 修改后的安装日志：
```
xmake f -c -m release -a rv32im_zicond_zicsr_zifencei -p baremetal -vD
checking for git ... /usr/bin/git
checking for gzip ... /usr/bin/gzip
checking for tar ... /usr/bin/tar
/usr/bin/git rev-parse HEAD
checking for gcc ... /usr/local/bin/gcc
checkinfo: cannot runv(nim --version), No such file or directory
checking for nim ... no
checkinfo: cannot runv(nim --version), No such file or directory
checking for nim ... no
checking for cmake ... no
checking for cmake ... /usr/bin/cmake
finding zlib from xmake ..
checking for xmake::zlib ... zlib v1.3.1
finding zlibcomplete from xmake ..
checking for xmake::zlibcomplete ... no
finding zlibcomplete from vcpkg ..
checking for brew ... no
finding zlibcomplete from conan ..
checking for zlibcomplete ... no
note: install or modify (m) these packages (pass -y to skip confirm)?
in xmake-repo:
  -> zlibcomplete 1.0.5 [toolchains:"riscv-gcc-baremetal", license:MIT]
please input: y (y/n/m)
y
checking for ping ... /usr/bin/ping
pinging the host(github.com) ... 0 ms
/usr/bin/tar -xf /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/1.0.5.tar.gz -C source.tmp
checking for riscv64-unknown-elf-gcc ... /opt/riscv/bin/riscv64-unknown-elf-gcc
checking for the c compiler (cc) ... riscv64-unknown-elf-gcc
checking for riscv64-unknown-elf-g++ ... /opt/riscv/bin/riscv64-unknown-elf-g++
checking for the c++ compiler (cxx) ... riscv64-unknown-elf-g++
checking for riscv64-unknown-elf-g++ ... /opt/riscv/bin/riscv64-unknown-elf-g++
checking for the assember (as) ... riscv64-unknown-elf-g++
checking for riscv64-unknown-elf-gcc-ar ... /opt/riscv/bin/riscv64-unknown-elf-gcc-ar
checking for the static library archiver (ar) ... riscv64-unknown-elf-gcc-ar
checking for riscv64-unknown-elf-ld ... /opt/riscv/bin/riscv64-unknown-elf-ld
checking for the linker (ld) ... riscv64-unknown-elf-ld
checking for /opt/riscv/bin/riscv64-unknown-elf-gcc ... ok
checking for flags (-fPIC) ... ok
> riscv64-unknown-elf-gcc "-fPIC" "-funroll-loops" "-finline-functions" "-march=rv32im_zicond_zicsr_zifencei" "-mabi=ilp32"
checking for /opt/riscv/bin/riscv64-unknown-elf-g++ ... ok
checking for flags (-fPIC) ... ok
> riscv64-unknown-elf-g++ "-fPIC" "-ffunction-sections" "-funroll-loops" "-finline-functions" "-march=rv32im_zicond_zicsr_zifencei" "-mabi=ilp32"
checking for flags (-fPIC) ... ok
> riscv64-unknown-elf-g++ "-fPIC" "-nostartfiles" "-march=rv32im_zicond_zicsr_zifencei" "-Xassembler" "--defsym" "-Xassembler" "ARCH_RV32IM_ZICOND_ZICSR_ZIFENCEI=1" "-mabi=ilp32"
checking for riscv64-unknown-elf-ld ... /opt/riscv/bin/riscv64-unknown-elf-ld
checking for the shared library linker (sh) ... riscv64-unknown-elf-ld
checking for cmake ... /usr/bin/cmake
/usr/bin/cmake -DZLIBCOMPLETE_EXAMPLES=off -DZLIBCOMPLETE_DOCS=off -DCMAKE_BUILD_TYPE=Release -DZLIBCOMPLETE_STATIC=on -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DCMAKE_INSTALL_PREFIX=/home/stehsaer/.xmake/packages/z/zlibcomplete/1.0.5/d2eddf2797484a3a897b3164ee74865b -DCMAKE_INSTALL_LIBDIR:PATH=lib -G "Unix Makefiles" -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH -DCMAKE_C_COMPILER=/opt/riscv/bin/riscv64-unknown-elf-gcc -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH -DCMAKE_CXX_COMPILER=/opt/riscv/bin/riscv64-unknown-elf-g++ "-DCMAKE_SHARED_LINKER_FLAGS=-lm -lc -lgcc -lstdc++" -DCMAKE_SYSTEM_NAME=Linux "-DCMAKE_MODULE_LINKER_FLAGS=-lm -lc -lgcc -lstdc++" -DCMAKE_STATIC_LINKER_FLAGS= -DHAVE_FLAG_SEARCH_PATHS_FIRST=0 -DCMAKE_AR=/opt/riscv/bin/riscv64-unknown-elf-gcc-ar -DCMAKE_FIND_USE_INSTALL_PREFIX=0 -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=0 -DCMAKE_OSX_SYSROOT= -DCMAKE_ASM_COMPILER=/opt/riscv/bin/riscv64-unknown-elf-g++ "-DCMAKE_C_FLAGS=-funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI" -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH "-DCMAKE_ASM_FLAGS=-nostartfiles -march=rv32im_zicond_zicsr_zifencei \"-Xassembler --defsym -Xassembler\" ARCH_RV32IM_ZICOND_ZICSR_ZIFENCEI=1 -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI" "-DCMAKE_CXX_FLAGS=-ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI" "-DCMAKE_CXX_FLAGS_RELEASE=-ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -O3 -DNDEBUG" -DCMAKE_STATIC_LINKER_FLAGS_RELEASE= "-DCMAKE_C_FLAGS_RELEASE=-funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -O3 -DNDEBUG" "-DCMAKE_SHARED_LINKER_FLAGS_RELEASE=-lm -lc -lgcc -lstdc++" /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/riscv/bin/riscv64-unknown-elf-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/riscv/bin/riscv64-unknown-elf-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found ZLIB: /home/stehsaer/.xmake/packages/z/zlib/v1.3.1/f32b7f7a53c54ac2957912bb141558aa/lib/libz.a (found version "1.3.1") 
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_ASM_COMPILER
    CMAKE_ASM_FLAGS
    CMAKE_INSTALL_LIBDIR
    HAVE_FLAG_SEARCH_PATHS_FIRST


-- Build files have been written to: /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27
make -j18 VERBOSE=1
/usr/bin/cmake -S/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source -B/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27 --check-build-system CMakeFiles/Makefile.cmake 0
/usr/bin/cmake -E cmake_progress_start /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27/CMakeFiles /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27//CMakeFiles/progress.marks
make  -f CMakeFiles/Makefile2 all
make[1]: 进入目录“/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27”
make  -f CMakeFiles/zlibcomplete.dir/build.make CMakeFiles/zlibcomplete.dir/depend
make[2]: 进入目录“/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27”
cd /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27 && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27 /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27 /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27/CMakeFiles/zlibcomplete.dir/DependInfo.cmake --color=
make[2]: 离开目录“/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27”
make  -f CMakeFiles/zlibcomplete.dir/build.make CMakeFiles/zlibcomplete.dir/build
make[2]: 进入目录“/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27”
[ 33%] Building CXX object CMakeFiles/zlibcomplete.dir/lib/zlibmisc.cpp.o
[ 33%] Building CXX object CMakeFiles/zlibcomplete.dir/lib/zlibtop.cpp.o
[ 50%] Building CXX object CMakeFiles/zlibcomplete.dir/lib/mainpage.cpp.o
[ 66%] Building CXX object CMakeFiles/zlibcomplete.dir/lib/gzipcomplete.cpp.o
[ 83%] Building CXX object CMakeFiles/zlibcomplete.dir/lib/raw.cpp.o
/opt/riscv/bin/riscv64-unknown-elf-g++  -I/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/lib -I/home/stehsaer/.xmake/packages/z/zlib/v1.3.1/f32b7f7a53c54ac2957912bb141558aa/include -ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -O3 -DNDEBUG -fPIC -MD -MT CMakeFiles/zlibcomplete.dir/lib/zlibmisc.cpp.o -MF CMakeFiles/zlibcomplete.dir/lib/zlibmisc.cpp.o.d -o CMakeFiles/zlibcomplete.dir/lib/zlibmisc.cpp.o -c /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/lib/zlibmisc.cpp
/opt/riscv/bin/riscv64-unknown-elf-g++  -I/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/lib -I/home/stehsaer/.xmake/packages/z/zlib/v1.3.1/f32b7f7a53c54ac2957912bb141558aa/include -ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -O3 -DNDEBUG -fPIC -MD -MT CMakeFiles/zlibcomplete.dir/lib/zlibtop.cpp.o -MF CMakeFiles/zlibcomplete.dir/lib/zlibtop.cpp.o.d -o CMakeFiles/zlibcomplete.dir/lib/zlibtop.cpp.o -c /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/lib/zlibtop.cpp
/opt/riscv/bin/riscv64-unknown-elf-g++  -I/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/lib -I/home/stehsaer/.xmake/packages/z/zlib/v1.3.1/f32b7f7a53c54ac2957912bb141558aa/include -ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -O3 -DNDEBUG -fPIC -MD -MT CMakeFiles/zlibcomplete.dir/lib/gzipcomplete.cpp.o -MF CMakeFiles/zlibcomplete.dir/lib/gzipcomplete.cpp.o.d -o CMakeFiles/zlibcomplete.dir/lib/gzipcomplete.cpp.o -c /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/lib/gzipcomplete.cpp
/opt/riscv/bin/riscv64-unknown-elf-g++  -I/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/lib -I/home/stehsaer/.xmake/packages/z/zlib/v1.3.1/f32b7f7a53c54ac2957912bb141558aa/include -ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -O3 -DNDEBUG -fPIC -MD -MT CMakeFiles/zlibcomplete.dir/lib/mainpage.cpp.o -MF CMakeFiles/zlibcomplete.dir/lib/mainpage.cpp.o.d -o CMakeFiles/zlibcomplete.dir/lib/mainpage.cpp.o -c /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/lib/mainpage.cpp
/opt/riscv/bin/riscv64-unknown-elf-g++  -I/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/lib -I/home/stehsaer/.xmake/packages/z/zlib/v1.3.1/f32b7f7a53c54ac2957912bb141558aa/include -ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -O3 -DNDEBUG -fPIC -MD -MT CMakeFiles/zlibcomplete.dir/lib/raw.cpp.o -MF CMakeFiles/zlibcomplete.dir/lib/raw.cpp.o.d -o CMakeFiles/zlibcomplete.dir/lib/raw.cpp.o -c /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/lib/raw.cpp
[100%] Linking CXX static library libzlibcomplete.a
/usr/bin/cmake -P CMakeFiles/zlibcomplete.dir/cmake_clean_target.cmake
/usr/bin/cmake -E cmake_link_script CMakeFiles/zlibcomplete.dir/link.txt --verbose=1
/opt/riscv/bin/riscv64-unknown-elf-gcc-ar qc libzlibcomplete.a CMakeFiles/zlibcomplete.dir/lib/gzipcomplete.cpp.o CMakeFiles/zlibcomplete.dir/lib/mainpage.cpp.o CMakeFiles/zlibcomplete.dir/lib/raw.cpp.o CMakeFiles/zlibcomplete.dir/lib/zlibmisc.cpp.o CMakeFiles/zlibcomplete.dir/lib/zlibtop.cpp.o
/opt/riscv/bin/riscv64-unknown-elf-ranlib libzlibcomplete.a
make[2]: 离开目录“/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27”
[100%] Built target zlibcomplete
make[1]: 离开目录“/home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27”
/usr/bin/cmake -E cmake_progress_start /home/stehsaer/.xmake/cache/packages/2504/z/zlibcomplete/1.0.5/source/build_d2eddf27/CMakeFiles 0
make install
[100%] Built target zlibcomplete
Install the project...
-- Install configuration: "Release"
-- Installing: /home/stehsaer/.xmake/packages/z/zlibcomplete/1.0.5/d2eddf2797484a3a897b3164ee74865b/lib/libzlibcomplete.a
finding zlibcomplete from xmake ..
checking for xmake::zlibcomplete ... zlibcomplete 1.0.5
{ 
  static = true,
  sysincludedirs = { 
    "/home/stehsaer/.xmake/packages/z/zlibcomplete/1.0.5/d2eddf2797484a3a897b3164ee74865b/include" 
  },
  license = "MIT",
  version = "1.0.5",
  libfiles = { 
    "/home/stehsaer/.xmake/packages/z/zlibcomplete/1.0.5/d2eddf2797484a3a897b3164ee74865b/lib/libzlibcomplete.a" 
  },
  links = { 
    "zlibcomplete" 
  },
  linkdirs = { 
    "/home/stehsaer/.xmake/packages/z/zlibcomplete/1.0.5/d2eddf2797484a3a897b3164ee74865b/lib" 
  } 
}

patching /home/stehsaer/.xmake/packages/z/zlibcomplete/1.0.5/d2eddf2797484a3a897b3164ee74865b/lib/pkgconfig/zlibcomplete.pc ..
> /opt/riscv/bin/riscv64-unknown-elf-g++ -c -ffunction-sections -funroll-loops -finline-functions -march=rv32im_zicond_zicsr_zifencei -mabi=ilp32 -DRVISA_I -DRVISA_M -DRVISA_ZICOND -DRVISA_ZICSR -DRVISA_ZIFENCEI -isystem /home/stehsaer/.xmake/packages/z/zlibcomplete/1.0.5/d2eddf2797484a3a897b3164ee74865b/include -isystem /home/stehsaer/.xmake/packages/z/zlib/v1.3.1/f32b7f7a53c54ac2957912bb141558aa/include -o /tmp/.xmake1000/250417/_3A5EDD0FB5EE45308219C9249A6A3B60.o /tmp/.xmake1000/250417/_073AC96BDA8744DC950E0D474D7969B8.cpp
checking for flags (-fdiagnostics-color=always) ... ok
> riscv64-unknown-elf-g++ "-fdiagnostics-color=always" "-ffunction-sections" "-funroll-loops" "-finline-functions" "-march=rv32im_zicond_zicsr_zifencei" "-mabi=ilp32"
checking for flags (-Wno-gnu-line-marker -Werror) ... ok
> riscv64-unknown-elf-g++ "-Wno-gnu-line-marker" "-Werror" "-ffunction-sections" "-funroll-loops" "-finline-functions" "-march=rv32im_zicond_zicsr_zifencei" "-mabi=ilp32"
> /opt/riscv/bin/riscv64-unknown-elf-ld -o /tmp/.xmake1000/250417/_3A5EDD0FB5EE45308219C9249A6A3B60.b /tmp/.xmake1000/250417/_3A5EDD0FB5EE45308219C9249A6A3B60.o -L/opt/riscv/bin/../riscv64-unknown-elf/lib/rv32im_zicond_zicsr_zifencei/ilp32 -L/opt/riscv/bin/../lib/gcc/riscv64-unknown-elf/14.2.0/rv32im_zicond_zicsr_zifencei/ilp32 --oformat elf32-littleriscv --gc-sections -( -L /home/stehsaer/.xmake/packages/z/zlibcomplete/1.0.5/d2eddf2797484a3a897b3164ee74865b/lib -L /home/stehsaer/.xmake/packages/z/zlib/v1.3.1/f32b7f7a53c54ac2957912bb141558aa/lib -lzlibcomplete -lz -lm -lc -lgcc -lstdc++
> checking for c++ includes(zlc/zlibcomplete.hpp)
> checking for c++ links(zlibcomplete, z)
> checking for c++ snippet(has_cxxincludes)
  => install zlibcomplete 1.0.5 .. ok
configure
{
    buildir = build
    ndk_stdcxx = true
    network = public
    kind = static
    plat = baremetal
    pkg_searchdirs = ~/Dev/xmake-search-dir
    theme = default
    ccache = true
    host = linux
    clean = true
    ccprefix = riscv64-unknown-elf
    mode = release
    arch = rv32im_zicond_zicsr_zifencei
    proxy_pac = ~/.xmake/pac.lua
    nano_libc = false
}
```
### 修改的合理性说明
- 在许多场景下，cross被用于嵌入式等不支持共享库的执行环境的开发与构建
- 留意到shared选项（`add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})`），即表明该库原本就支持且默认编译为静态库
- 本次bug发生的位置在Cmake的工具链测试流程，并不影响库本身的编译
- 因此添加该检测，应该能够让该库在不支持共享库的这类工具链上正常安装，且不影响其他的平台

## 项目配置
```lua
add_requires("zlibcomplete", {configs={shared=false}})

target("myproject")

	set_kind("binary")
	add_files("main.cpp")
	add_packages("zlibcomplete")
        -- 其他配置
```

## 系统配置
**系统**：`Debian 12 Bookworm`
**Xmake版本**：`xmake v2.9.7+HEAD.2bb99e0`