### PR TITLE
Auto-update boost_ut to v2.3.1

### DIFF
--- a/packages/b/boost_ut/xmake.lua
+++ b/packages/b/boost_ut/xmake.lua
@@ -6,6 +6,7 @@ package("boost_ut")
 
     add_urls("https://github.com/boost-ext/ut/archive/refs/tags/$(version).tar.gz")
     add_urls("https://github.com/boost-ext/ut.git")
+    add_versions("v2.3.1", "e51bf1873705819730c3f9d2d397268d1c26128565478e2e65b7d0abb45ea9b1")
     add_versions("v2.3.0", "9c07a2b7947cc169fc1713ad462ccc43a704076447893a1fd25bdda5eec4aab6")
     add_versions("v2.1.1", "016ac5ece1808cd1100be72f90da4fa59ea41de487587a3283c6c981381cc216")
     add_versions("v2.1.0", "1c9c35c039ad3a9795a278447db6da0a4ec1a1d223bf7d64687ad28f673b7ae8")


### PR DESCRIPTION
New version of boost_ut detected (package version: v2.3.0, last github version: v2.3.1)