### PR TITLE
Auto-update embree to v4.4.0

### DIFF
--- a/packages/e/embree/xmake.lua
+++ b/packages/e/embree/xmake.lua
@@ -6,6 +6,7 @@ package("embree")
 
     add_urls("https://github.com/RenderKit/embree/archive/refs/tags/$(version).tar.gz",
              "https://github.com/RenderKit/embree.git")
+    add_versions("v4.4.0", "acb517b0ea0f4b442235d5331b69f96192c28da6aca5d5dde0cbe40799638d5c")
     add_versions("v3.12.1", "0c9e760b06e178197dd29c9a54f08ff7b184b0487b5ba8b8be058e219e23336e")
     add_versions("v3.13.0", "4d86a69508a7e2eb8710d571096ad024b5174834b84454a8020d3a910af46f4f")
     add_versions("v3.13.3", "74ec785afb8f14d28ea5e0773544572c8df2e899caccdfc88509f1bfff58716f")


### PR DESCRIPTION
New version of embree detected (package version: v4.3.3, last github version: v4.4.0)