### PR TITLE
Auto-update idna to 0.3.3

### DIFF
--- a/packages/i/idna/xmake.lua
+++ b/packages/i/idna/xmake.lua
@@ -6,6 +6,7 @@ package("idna")
     set_urls("https://github.com/ada-url/idna/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ada-url/idna.git")
 
+    add_versions("0.3.3", "5afa8194d7a2c5b78e4aa716d386e3a550c785efdd9478c04b7b91d57c945c80")
     add_versions("0.3.2", "3fffd81d11d5dea6ea0dd5bcd9fa6e9faa6d766ead3e1936229ec47997b90ec9")
     add_versions("0.2.0", "fa9aac3611d11ef4c0196d74bfbf5d12b87814b62d70c101e8eb74fb65c636c9")
 


### PR DESCRIPTION
New version of idna detected (package version: 0.3.2, last github version: 0.3.3)