### PR TITLE
libllvm: add package.

### DIFF
--- a/packages/l/libllvm/constants.lua
+++ b/packages/l/libllvm/constants.lua
@@ -1,0 +1,375 @@
+--- from llvm/CMakeLists.txt
+
+function get_llvm_all_projects()
+    -- @see https://llvm.org/docs/CMake.html
+    -- Some projects listed here can also go in LLVM_ENABLE_RUNTIMES. They should
+    -- only appear in one of the two lists. If a project is a valid possiblity for
+    -- both, prefer putting it in LLVM_ENABLE_RUNTIMES.
+    return {
+        "bolt",
+        "clang",
+        "clang-tools-extra",    -- But we do not build clang tools.
+        "libclc",
+        "lld",
+        "lldb",
+        "mlir",                 -- TODO: incompleted.
+        "polly"
+    }
+end
+
+function get_llvm_extra_projects()
+    return {
+        "flang"
+    }
+end
+
+function get_llvm_known_projects()
+    return table.join(get_llvm_all_projects(), get_llvm_extra_projects())
+end
+
+function get_llvm_all_runtimes()
+    return {
+        "libc",
+        "libunwind",
+        "libcxxabi",
+        "pstl",
+        "libcxx",
+        "compiler-rt",
+        "openmp",
+        "llvm-libgcc",
+        "offload",
+        "flang-rt"
+    }
+end
+
+--- from cmake/llvm/LLVMExports.cmake
+
+function get_llvm_shared_libraries()
+    return {
+        "LLVM",
+        "Remarks",
+        "LTO"
+    }
+end
+
+function get_llvm_static_libraries()
+    return {
+        "LLVMExegesisMips",
+        "LLVMExegesisPowerPC",
+        "LLVMExegesisAArch64",
+        "LLVMExegesisX86",
+        "LLVMOptDriver",
+        "LLVMExegesis",
+        "LLVMOrcDebugging",
+        "LLVMBPFCodeGen",
+        "LLVMAMDGPUCodeGen",
+        "LLVMOrcJIT",
+        "LLVMLTO",
+        "LLVMPasses",
+        "LLVMX86CodeGen",
+        "LLVMRISCVCodeGen",
+        "LLVMPowerPCCodeGen",
+        "LLVMMipsCodeGen",
+        "LLVMARMCodeGen",
+        "LLVMAArch64CodeGen",
+        "LLVMNVPTXCodeGen",
+        "LLVMHexagonCodeGen",
+        "LLVMCoroutines",
+        "LLVMWebAssemblyCodeGen",
+        "LLVMDWARFLinkerParallel",
+        "LLVMDWARFLinkerClassic",
+        "LLVMXCoreCodeGen",
+        "LLVMVECodeGen",
+        "LLVMSystemZCodeGen",
+        "LLVMSparcCodeGen",
+        "LLVMMSP430CodeGen",
+        "LLVMLoongArchCodeGen",
+        "LLVMLanaiCodeGen",
+        "LLVMAVRCodeGen",
+        "LLVMGlobalISel",
+        "LLVMipo",
+        "LLVMWebAssemblyUtils",
+        "LLVMInterpreter",
+        "LLVMDWARFLinker",
+        "LLVMMIRParser",
+        "LLVMAsmPrinter",
+        "LLVMSelectionDAG",
+        "LLVMFrontendOpenMP",
+        "LLVMCodeGen",
+        "LLVMFuzzMutate",
+        "LLVMAMDGPUTargetMCA",
+        "LLVMAMDGPUDisassembler",
+        "LLVMAMDGPUAsmParser",
+        "LLVMMCJIT",
+        "LLVMScalarOpts",
+        "LLVMAMDGPUDesc",
+        "LLVMExecutionEngine",
+        "LLVMLinker",
+        "LLVMHipStdPar",
+        "LLVMObjCARCOpts",
+        "LLVMVectorize",
+        "LLVMInstCombine",
+        "LLVMAggressiveInstCombine",
+        "LLVMInstrumentation",
+        "LLVMFrontendOffloading",
+        "LLVMAMDGPUUtils",
+        "LLVMTarget",
+        "LLVMTransformUtils",
+        "LLVMFrontendDriver",
+        "LLVMBitWriter",
+        "LLVMIRPrinter",
+        "LLVMCoverage",
+        "LLVMAnalysis",
+        "LLVMCFIVerify",
+        "LLVMProfileData",
+        "LLVMDebuginfod",
+        "LLVMARMDisassembler",
+        "LLVMARMAsmParser",
+        "LLVMSymbolize",
+        "LLVMDebugInfoLogicalView",
+        "LLVMTextAPIBinaryReader",
+        "LLVMDWP",
+        "LLVMDebugInfoGSYM",
+        "LLVMXRay",
+        "LLVMLibDriver",
+        "LLVMDlltoolDriver",
+        "LLVMARMDesc",
+        "LLVMRuntimeDyld",
+        "LLVMJITLink",
+        "LLVMDebugInfoPDB",
+        "LLVMDebugInfoDWARF",
+        "LLVMObjectYAML",
+        "LLVMObjCopy",
+        "LLVMCodeGenData",
+        "LLVMInterfaceStub",
+        "LLVMX86TargetMCA",
+        "LLVMX86AsmParser",
+        "LLVMWebAssemblyDisassembler",
+        "LLVMWebAssemblyAsmParser",
+        "LLVMVEAsmParser",
+        "LLVMSystemZDisassembler",
+        "LLVMSystemZAsmParser",
+        "LLVMSparcAsmParser",
+        "LLVMRISCVTargetMCA",
+        "LLVMRISCVDisassembler",
+        "LLVMRISCVAsmParser",
+        "LLVMPowerPCAsmParser",
+        "LLVMMSP430AsmParser",
+        "LLVMMipsAsmParser",
+        "LLVMLoongArchDisassembler",
+        "LLVMLoongArchAsmParser",
+        "LLVMLanaiDisassembler",
+        "LLVMLanaiAsmParser",
+        "LLVMHexagonDisassembler",
+        "LLVMHexagonAsmParser",
+        "LLVMBPFAsmParser",
+        "LLVMAVRAsmParser",
+        "LLVMAArch64Disassembler",
+        "LLVMAArch64AsmParser",
+        "LLVMObject",
+        "LLVMXCoreDesc",
+        "LLVMXCoreDisassembler",
+        "LLVMX86Desc",
+        "LLVMX86Disassembler",
+        "LLVMWebAssemblyDesc",
+        "LLVMVEDesc",
+        "LLVMVEDisassembler",
+        "LLVMSystemZDesc",
+        "LLVMSparcDesc",
+        "LLVMSparcDisassembler",
+        "LLVMRISCVDesc",
+        "LLVMPowerPCDesc",
+        "LLVMPowerPCDisassembler",
+        "LLVMNVPTXDesc",
+        "LLVMMSP430Disassembler",
+        "LLVMMSP430Desc",
+        "LLVMMipsDesc",
+        "LLVMMipsDisassembler",
+        "LLVMLoongArchDesc",
+        "LLVMLanaiDesc",
+        "LLVMHexagonDesc",
+        "LLVMBPFDesc",
+        "LLVMBPFDisassembler",
+        "LLVMAVRDesc",
+        "LLVMAVRDisassembler",
+        "LLVMAArch64Desc",
+        "LLVMIRReader",
+        "LLVMXCoreInfo",
+        "LLVMX86Info",
+        "LLVMWebAssemblyInfo",
+        "LLVMVEInfo",
+        "LLVMSystemZInfo",
+        "LLVMSparcInfo",
+        "LLVMRISCVInfo",
+        "LLVMPowerPCInfo",
+        "LLVMNVPTXInfo",
+        "LLVMMSP430Info",
+        "LLVMMipsInfo",
+        "LLVMLoongArchInfo",
+        "LLVMLanaiInfo",
+        "LLVMHexagonInfo",
+        "LLVMBPFInfo",
+        "LLVMAVRInfo",
+        "LLVMARMInfo",
+        "LLVMAMDGPUInfo",
+        "LLVMAArch64Info",
+        "LLVMMCA",
+        "LLVMMCDisassembler",
+        "LLVMMCParser",
+        "LLVMDiff",
+        "LLVMAsmParser",
+        "LLVMSandboxIR",
+        "LLVMAArch64Utils",
+        "LLVMCFGuard",
+        "LLVMFrontendHLSL",
+        "LLVMBitReader",
+        "LLVMTextAPI",
+        "LLVMMC",
+        "LLVMCore",
+        "LLVMTableGenCommon",
+        "LLVMWindowsDriver",
+        "LLVMOrcTargetProcess",
+        "LLVMBinaryFormat",
+        "LLVMFuzzerCLI",
+        "LLVMRemarks",
+        "LLVMTableGenBasic",
+        "LLVMWindowsManifest",
+        "LLVMTargetParser",
+        "LLVMLineEditor",
+        "LLVMARMUtils",
+        "LLVMOrcShared",
+        "LLVMDebugInfoBTF",
+        "LLVMDebugInfoCodeView",
+        "LLVMDebugInfoMSF",
+        "LLVMOption",
+        "LLVMFrontendOpenACC",
+        "LLVMExtensions",
+        "LLVMBitstreamReader",
+        "LLVMCodeGenTypes",
+        "LLVMFileCheck",
+        "LLVMTableGen",
+        "LLVMSupport",
+        "LLVMDemangle",
+        "Remarks", -- shared
+        "LTO"      -- shared
+    }
+end
+
+function get_bolt_shared_libraries()
+    return {} -- TODO
+end
+
+function get_bolt_static_libraries()
+    return {
+        "LLVMBOLTRewrite",
+        "LLVMBOLTRuntimeLibs",
+        "LLVMBOLTTargetRISCV",
+        "LLVMBOLTTargetX86",
+        "LLVMBOLTTargetAArch64",
+        "LLVMBOLTProfile",
+        "LLVMBOLTPasses",
+        "LLVMBOLTCore",
+        "LLVMBOLTUtils"
+    }
+end
+
+function get_polly_shared_libraries()
+    return {} -- TODO
+end
+
+function get_polly_static_libraries()
+    return {
+        "Polly",
+        "LLVMPolly", -- shared
+        "PollyISL",
+    }
+end
+
+--- from cmake/clang/ClangTargets.cmake
+
+function get_clang_shared_libraries()
+    return {
+        "clang-cpp",
+        "clang" -- Clang's stable CAPI (shared)
+    }
+end
+
+function get_clang_static_libraries()
+    return {
+        "clangInterpreter",
+        "clangFrontendTool",
+        "clangStaticAnalyzerFrontend",
+        "clangStaticAnalyzerCheckers",
+        "clangTransformer",
+        "clangStaticAnalyzerCore",
+        "clangToolingRefactoring",
+        "clangExtractAPI",
+        "clangCrossTU",
+        "clangHandleCXX",
+        "clangDependencyScanning",
+        "clangIndex",
+        "clangTooling",
+        "clangToolingSyntax",
+        "clangRewriteFrontend",
+        "clangARCMigrate",
+        "clangCodeGen",
+        "clangFrontend",
+        "clangAnalysisFlowSensitiveModels",
+        "clangSerialization",
+        "clangParse",
+        "clangFormat",
+        "clangAnalysisFlowSensitive",
+        "clangSema",
+        "clangToolingInclusions",
+        "clangAnalysis",
+        "clangDynamicASTMatchers",
+        "clangToolingCore",
+        "clangInstallAPI",
+        "clangToolingASTDiff",
+        "clangToolingInclusionsStdlib",
+        "clangEdit",
+        "clangASTMatchers",
+        "clangRewrite",
+        "clangAST",
+        "clangIndexSerialization",
+        "clangDriver",
+        "clangLex",
+        "clangAPINotes",
+        "clangHandleLLVM",
+        "clangSupport",
+        "clangDirectoryWatcher",
+        "clangBasic",
+        "clang", -- Clang's stable CAPI (shared)
+    }
+end
+
+--- from cmake/lld/LLDTargets.cmake
+
+function get_lld_shared_libraries()
+    return {} -- TODO
+end
+
+function get_lld_static_libraries()
+    return {
+        "lldMinGW",
+        "lldWasm",
+        "lldMachO",
+        "lldELF",
+        "lldCOFF",
+        "lldCommon",
+    }
+end
+
+--- lldb
+
+function get_lldb_shared_libraries()
+    return {
+        "lldb"
+    }
+end
+
+function get_lldb_static_libraries()
+    return {
+        "lldb" -- shared
+    }
+end

--- a/packages/l/libllvm/xmake.lua
+++ b/packages/l/libllvm/xmake.lua
@@ -1,0 +1,222 @@
+package("libllvm")
+    set_kind("library")
+    set_homepage("https://llvm.org/")
+    set_description("The LLVM Compiler Infrastructure.")
+
+    -- The LLVM shared library cannot be built under windows.
+    add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = is_plat("windows")})
+
+    add_configs("exception", {description = "Enable C++ exception support for LLVM.", default = true, type = "boolean"})
+    add_configs("rtti",      {description = "Enable C++ RTTI support for LLVM.", default = true, type = "boolean"})
+
+    add_configs("ms_dia",  {description = "Enable DIA SDK to support non-native PDB parsing. (msvc only)", default = true, type = "boolean"})
+    add_configs("libffi",  {description = "Enable libffi to support the LLVM interpreter to call external functions.", default = false, type = "boolean"})
+    add_configs("httplib", {description = "Enable cpp-httplib to support llvm-debuginfod serve debug information over HTTP.", default = false, type = "boolean"})
+    add_configs("libcxx",  {description = "Use libc++ as C++ standard library instead of libstdc++, ", default = false, type = "boolean"})
+
+    includes(path.join(os.scriptdir(), "constants.lua"))
+    for _, project in ipairs(get_llvm_known_projects()) do
+        add_configs(project:gsub("-", "_"), {description = "Build " .. project .. " project.", default = (project == "clang"), type = "boolean"})
+    end
+    for _, runtime in ipairs(get_llvm_all_runtimes()) do
+        add_configs(runtime:gsub("-", "_"), {description = "Build " .. runtime .. " runtime.", default = false, type = "boolean"})
+    end
+
+    if is_plat("windows") then
+        -- pre-built
+        if is_arch("x64") then
+            add_urls("https://github.com/xmake-mirror/llvm-windows/releases/download/$(version)/clang+llvm-$(version)-win64.zip")
+            add_versions("19.1.7", "c6e058c6012f499811caa1ec037cc1b5c2fd2f8c20cc3315cae602cbd6c81a5e")
+        end
+
+        add_configs("runtimes",   {description = "Set vs compiler runtime.", default = "MT", readonly = true})
+        add_configs("vs_runtime", {description = "Set vs compiler runtime.", default = "MT", readonly = true})
+        add_syslinks("psapi", "shell32", "ole32", "uuid", "advapi32", "ws2_32", "ntdll", "version")
+    else
+        -- self-built
+        add_urls("https://github.com/llvm/llvm-project/releases/download/llvmorg-$(version)/llvm-project-$(version).src.tar.xz")
+        add_versions("19.1.7", "82401fea7b79d0078043f7598b835284d6650a75b93e64b6f761ea7b63097501")
+
+        add_deps("ninja")
+        add_deps("zlib", "zstd", {optional = true})
+        set_policy("package.cmake_generator.ninja", true)
+    end
+
+    -- workaround to fix "error: undefined symbol: __mulodi4" (armeabi-v7a, r22, windows)
+    if is_plat("android") then
+        add_syslinks("compiler_rt-extras")
+    end
+
+    -- error: undefined symbol: backtrace
+    if is_plat("bsd") then
+        add_syslinks("execinfo")
+    end
+
+    add_deps("cmake")
+    on_load(function (package)
+        local constants = import('constants')
+        package:addenv("PATH", "bin")
+        
+        -- add deps.
+        if not package:is_plat("windows") then -- not prebuilt
+            package:add("deps", "python 3.x", {kind = "binary", host = true})
+            if package:config("libffi") then
+                package:add("deps", "libffi")
+            end
+            if package:config("httplib") then
+                package:add("deps", "cpp-httplib")
+            end
+            if package:config("libcxx") then
+                package:add("deps", "libc++")
+            end
+        end
+
+        -- add links
+        local linkable_projects = {"lldb", "lld", "clang", "polly", "bolt"}
+        table.insert(linkable_projects, "llvm") -- make sure that the base library is last.
+        for _, name in ipairs(linkable_projects) do
+            local cname = name:gsub("-", "_")
+            local ptype = package:config("shared") and "shared" or "static"
+            if cname == "llvm" or package:config(cname) then
+                package:add("links", constants[("get_%s_%s_libraries"):format(cname, ptype)]())
+            end
+        end
+        if package:is_plat("windows") then
+            package:add("links", "LLVM-C")
+        end
+
+    end)
+
+    on_install("windows|x64", function (package)
+        os.cp("*", package:installdir())
+    end)
+
+    on_install("linux", "macosx", "bsd", "android", "iphoneos", "cross", function (package)
+        local constants = import('constants')
+
+        local projects_enabled = {}
+        local runtimes_enabled = {}
+        for _, project in ipairs(constants.get_llvm_known_projects()) do
+            if package:config(project:gsub("-", "_")) then
+                table.insert(projects_enabled, project)
+            end
+        end
+        for _, runtime in ipairs(constants.get_llvm_all_runtimes()) do
+            if package:config(runtime:gsub("-", "_")) then
+                table.insert(runtimes_enabled, runtime)
+            end
+        end
+
+        local configs = {
+            -- common cmake
+            "-DCMAKE_BUILD_TYPE=Release",
+
+            -- llvm
+            "-DLLVM_BUILD_UTILS=OFF",
+            "-DLLVM_INCLUDE_DOCS=OFF",
+            "-DLLVM_INCLUDE_EXAMPLES=OFF",
+            "-DLLVM_INCLUDE_TESTS=OFF",
+            "-DLLVM_INCLUDE_BENCHMARKS=OFF",
+            "-DLLVM_OPTIMIZED_TABLEGEN=ON",
+            "-DLLVM_ENABLE_PROJECTS=" .. table.concat(projects_enabled, ";"),
+            "-DLLVM_ENABLE_RUNTIMES=" .. table.concat(runtimes_enabled, ";"),
+
+            -- disable tools build - to save link time
+            "-DLLVM_BUILD_TOOLS=OFF",
+            "-DCLANG_BUILD_TOOLS=OFF",
+            "-DBOLT_BUILD_TOOLS=OFF",
+            "-DFLANG_BUILD_TOOLS=OFF",
+            "-DLLD_BUILD_TOOLS=OFF"
+        }
+        table.insert(configs, "-DLLVM_BUILD_LLVM_DYLIB=" .. (package:config("shared") and "ON" or "OFF"))
+        table.insert(configs, "-DLLVM_ENABLE_EH=" .. (package:config("exception") and "ON" or "OFF"))
+        table.insert(configs, "-DLLVM_ENABLE_RTTI=" .. (package:config("rtti") and "ON" or "OFF"))
+        table.insert(configs, "-DLLVM_ENABLE_DIA_SDK=" .. (package:config("ms_dia") and "ON" or "OFF"))
+        table.insert(configs, "-DLLVM_ENABLE_LIBCXX=" .. (package:config("libcxx") and "ON" or "OFF"))
+        table.insert(configs, "-DLLVM_ENABLE_LTO=" .. (package:config("lto") and "ON" or "OFF"))
+        table.insert(configs, "-DLLVM_ENABLE_ZSTD=" .. (package:dep("zstd") and "ON" or "OFF"))
+        table.insert(configs, "-DLLVM_ENABLE_ZLIB=" .. (package:dep("zlib") and "ON" or "OFF"))
+        if package:config("libffi") then
+            table.insert(configs, "-DLLVM_ENABLE_FFI=ON")
+            table.insert(configs, "-DFFI_INCLUDE_DIR=" .. package:dep("libffi"):installdir("include"))
+            table.insert(configs, "-DFFI_LIBRARY_DIR=" .. package:dep("libffi"):installdir("lib"))
+        else
+            table.insert(configs, "-DLLVM_ENABLE_FFI=OFF")
+        end
+        if package:config("httplib") then
+            table.insert(configs, "-DLLVM_ENABLE_HTTPLIB=ON")
+            table.insert(configs, "-Dhttplib_ROOT=" .. package:dep("cpp-httplib"):installdir())
+        else
+            table.insert(configs, "-DLLVM_ENABLE_HTTPLIB=OFF")
+        end
+
+        if package:is_plat("android") then
+            local triple
+            if package:is_arch("arm64-v8a") then
+                triple = "aarch64-linux-android"
+            elseif package:arch():startswith("armeabi") then
+                triple = "armv7a-linux-androideabi"
+            elseif package:is_arch("x86") then
+                triple = "i686-linux-android"
+            elseif package:is_arch("x86_64") then
+                triple = "x86_64-linux-android"
+            else
+                raise("unsupported arch(%s) for android!", package:arch())
+            end
+            table.insert(configs, "-DLLVM_HOST_TRIPLE=" .. triple)
+        end
+        if package:is_plat("iphoneos") then
+            local triple
+            if package:is_arch("arm64") then
+                triple = "aarch64-apple-ios"
+            else
+                raise("unsupported arch(%s) for iphoneos!", package:arch())
+            end
+            table.insert(configs, "-DLLVM_HOST_TRIPLE=" .. triple)
+
+            -- LLVM build systems mostly use "Darwin", not if(APPLE)
+            table.insert(configs, "-DCMAKE_SYSTEM_NAME=Darwin")
+        end
+
+        function tryadd_dep(depname, varname)
+            varname = varname or depname
+            local dep = package:dep(depname)
+            if dep and not dep:is_system() then
+                local fetchinfo = dep:fetch({external = false})
+                if fetchinfo then
+                    local includedirs = fetchinfo.includedirs or fetchinfo.sysincludedirs
+                    if includedirs and #includedirs > 0 then
+                        table.insert(configs, "-D" .. varname .. "_INCLUDE_DIR=" .. table.concat(includedirs, " "):gsub("\\", "/"))
+                    end
+                    local libfiles = fetchinfo.libfiles
+                    if libfiles then
+                        table.insert(configs, "-D" .. varname .. "_LIBRARY=" .. table.concat(libfiles, " "):gsub("\\", "/"))
+                    end
+                end
+            end
+        end
+        tryadd_dep("zlib", "ZLIB")
+        tryadd_dep("zstd")
+
+        os.cd("llvm")
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            #include <llvm/IR/LLVMContext.h>
+            #include <llvm/IR/Module.h>
+            void test() {
+                llvm::LLVMContext context;
+                llvm::Module module("test", context);
+            }
+        ]]}, {configs = {languages = 'c++17'}}))
+        if package:config("clang") then
+            assert(package:check_cxxsnippets({test = [[
+                #include <clang/Frontend/CompilerInstance.h>
+                void test() {
+                    clang::CompilerInstance instance;
+                }
+            ]]}, {configs = {languages = 'c++17'}}))
+        end
+    end)


### PR DESCRIPTION
### Differs from `xmake-repo/llvm`
This package is provided as a *library*, not a *toolchain*. (Even if its kind is set to *library*, it still has problems in use.)

### Packaging principles
Keep llvm-project as "default" as possible, that is, keep xrepo as little as possible without making choices for the user.

### Should splitting packages?
I discussed splitting the package with @star-hengxing in the telegram group, but I later thought that LLVM was more like a whole, so I didn't split it. If there are more opinions, we can discuss it.