### PR TITLE
libflac: update to 1.5.0

### DIFF
--- a/packages/l/libflac/patches/1.5.0/android_fseek.diff
+++ b/packages/l/libflac/patches/1.5.0/android_fseek.diff
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9396130dcc..0b09f40509 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -122,14 +122,17 @@ else()
+ endif()
+ 
+ 
+-if(ANDROID AND CMAKE_SYSTEM_VERSION VERSION_LESS 24 AND (CMAKE_SYSTEM_PROCESSOR MATCHES "i686" OR CMAKE_SYSTEM_PROCESSOR MATCHES "armv7-a"))
++if(ANDROID AND CMAKE_SYSTEM_PROCESSOR MATCHES "armv7-a|i686")
+     # fseeko/ftello may link, but it's not usable before Android API 24 on 32-bit Android
+     # https://android.googlesource.com/platform/bionic/+/main/docs/32-bit-abi.md
+-    message(STATUS "Disabling fseeko/ftello for 32-bit Android before API 24")
+-    set(HAVE_FSEEKO 0 CACHE INTERNAL "")
+-else()
+-    check_function_exists(fseeko HAVE_FSEEKO)
++    # The API level can be in different variables, subject to actual toolchain.
++    string(REPLACE "android-" "" api_level "${ANDROID_PLATFORM}")
++    if(NOT (CMAKE_SYSTEM_VERSION GREATER_EQUAL "24" OR api_level GREATER_EQUAL "24"))
++        message(STATUS "Disabling fseeko/ftello for 32-bit Android before API 24")
++        set(HAVE_FSEEKO 0 CACHE INTERNAL "")
++    endif()
+ endif()
++check_function_exists(fseeko HAVE_FSEEKO)
+ 
+ check_c_source_compiles("int main() { return __builtin_bswap16 (0) ; }" HAVE_BSWAP16)
+ check_c_source_compiles("int main() { return __builtin_bswap32 (0) ; }" HAVE_BSWAP32)

--- a/packages/l/libflac/patches/1.5.0/cmake.patch
+++ b/packages/l/libflac/patches/1.5.0/cmake.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9396130..90443bc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -197,6 +197,10 @@ include_directories("include")
+ include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+ add_definitions(-DHAVE_CONFIG_H)
+ 
++if(WIN32 AND NOT BUILD_SHARED_LIBS)
++    add_definitions(-DFLAC__NO_DLL)
++endif()
++
+ if(MSVC)
+     add_definitions(
+         -D_CRT_SECURE_NO_WARNINGS

--- a/packages/l/libflac/xmake.lua
+++ b/packages/l/libflac/xmake.lua
@@ -15,6 +15,8 @@ package("libflac")
     add_patches("1.4.2", "patches/1.4.2/cmake.patch", "0a99382d5d7bd33078572b6cc3af08ee7e5e3618c80754a5fdc400bd69f4e470")
     add_patches("1.3.3", "patches/1.3.3/cmake.patch", "49baa40ab70d63e74cfc3f0cc2f13824545a618ceaeffdd51d3333d90b37fd32")
 
+    add_patches("1.5.0", "https://patch-diff.githubusercontent.com/raw/xiph/flac/pull/831.diff", "75377f3a309094d91ff2e56727df09a00baa23cbec44b03193253cfec9b5324a")
+
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::flac")
     elseif is_plat("linux") then
@@ -33,10 +35,6 @@ package("libflac")
         if not package:config("shared") then
             package:add("defines", "FLAC__NO_DLL")
         end
-    end)
-
-    on_load("android", function (package)
-        package:add("defines", "HAVE_FSEEKO")
     end)
 
     on_install("windows", "linux", "macosx", "iphoneos", "mingw", "android", "wasm", function (package)

--- a/packages/l/libflac/xmake.lua
+++ b/packages/l/libflac/xmake.lua
@@ -35,6 +35,10 @@ package("libflac")
         end
     end)
 
+    on_load("android", function (package)
+        package:add("defines", "HAVE_FSEEKO")
+    end)
+
     on_install("windows", "linux", "macosx", "iphoneos", "mingw", "android", "wasm", function (package)
 
         local configs = {}

--- a/packages/l/libflac/xmake.lua
+++ b/packages/l/libflac/xmake.lua
@@ -15,7 +15,9 @@ package("libflac")
     add_patches("1.4.2", "patches/1.4.2/cmake.patch", "0a99382d5d7bd33078572b6cc3af08ee7e5e3618c80754a5fdc400bd69f4e470")
     add_patches("1.3.3", "patches/1.3.3/cmake.patch", "49baa40ab70d63e74cfc3f0cc2f13824545a618ceaeffdd51d3333d90b37fd32")
 
-    add_patches("1.5.0", "https://patch-diff.githubusercontent.com/raw/xiph/flac/pull/831.diff", "75377f3a309094d91ff2e56727df09a00baa23cbec44b03193253cfec9b5324a")
+    if is_plat("android") then
+        add_patches("1.5.0", "patches/1.5.0/android_fseek.diff", "75377f3a309094d91ff2e56727df09a00baa23cbec44b03193253cfec9b5324a")
+    end
 
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::flac")
@@ -23,6 +25,10 @@ package("libflac")
         add_extsources("pacman::flac", "apt::libflac++-dev", "apt::libflac-dev")
     elseif is_plat("macosx") then
         add_extsources("brew::flac")
+    end
+
+    if is_plat("wasm") then
+        add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
     end
 
     add_deps("cmake", "libogg")
@@ -38,8 +44,7 @@ package("libflac")
     end)
 
     on_install("windows", "linux", "macosx", "iphoneos", "mingw", "android", "wasm", function (package)
-
-        local configs = {"-DCMAKE_POLICY_DEFAULT_CMP0057=NEW"}
+        local configs = {}
         table.insert(configs, "-DBUILD_CXXLIBS=OFF")
         table.insert(configs, "-DBUILD_DOCS=OFF")
         table.insert(configs, "-DBUILD_PROGRAMS=OFF")

--- a/packages/l/libflac/xmake.lua
+++ b/packages/l/libflac/xmake.lua
@@ -39,7 +39,7 @@ package("libflac")
 
     on_install("windows", "linux", "macosx", "iphoneos", "mingw", "android", "wasm", function (package)
 
-        local configs = {}
+        local configs = {"-DCMAKE_POLICY_DEFAULT_CMP0057=NEW"}
         table.insert(configs, "-DBUILD_CXXLIBS=OFF")
         table.insert(configs, "-DBUILD_DOCS=OFF")
         table.insert(configs, "-DBUILD_PROGRAMS=OFF")

--- a/packages/l/libflac/xmake.lua
+++ b/packages/l/libflac/xmake.lua
@@ -6,9 +6,11 @@ package("libflac")
     set_urls("https://github.com/xiph/flac/archive/$(version).tar.gz",
              "https://github.com/xiph/flac.git")
 
+    add_versions("1.5.0", "aea54ed186ad07a34750399cb27fc216a2b62d0ffcd6dc2e3064a3518c3146f8")
     add_versions("1.4.3", "0a4bb82a30609b606650d538a804a7b40205366ce8fc98871b0ecf3fbb0611ee")
     add_versions("1.4.2", "8e8e0406fb9e1d177bb4ba8cfed3ca3935d37144eac8f0219a03e8c1ed5cc18e")
     add_versions("1.3.3", "668cdeab898a7dd43cf84739f7e1f3ed6b35ece2ef9968a5c7079fe9adfe1689")
+    add_patches("1.5.0", "patches/1.5.0/cmake.patch", "6ce0ff5c6e8be0a68d4abaf9c0801f988f5cb600228ee9e2db812adf6e4cf3c1")
     add_patches("1.4.3", "patches/1.4.2/cmake.patch", "0a99382d5d7bd33078572b6cc3af08ee7e5e3618c80754a5fdc400bd69f4e470")
     add_patches("1.4.2", "patches/1.4.2/cmake.patch", "0a99382d5d7bd33078572b6cc3af08ee7e5e3618c80754a5fdc400bd69f4e470")
     add_patches("1.3.3", "patches/1.3.3/cmake.patch", "49baa40ab70d63e74cfc3f0cc2f13824545a618ceaeffdd51d3333d90b37fd32")

--- a/packages/l/libogg/xmake.lua
+++ b/packages/l/libogg/xmake.lua
@@ -22,7 +22,7 @@ package("libogg")
     end
 
     on_install("windows", "macosx", "linux", "bsd", "mingw", "iphoneos", "android", "cross", "wasm", function (package)
-        local configs = {"-DBUILD_TESTING=OFF"}
+        local configs = {"-DBUILD_TESTING=OFF", "-DCMAKE_POLICY_DEFAULT_CMP0057=NEW"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")


### PR DESCRIPTION
I don't know how to fix shared `Wasm` build, `static` works. Most of time it is `static` only in case of `wasm` build.
For android need to pass `CMP0057` into `libogg` instead.

