### PR TITLE
Auto-update blake3 to 1.8.2

### DIFF
--- a/packages/b/blake3/xmake.lua
+++ b/packages/b/blake3/xmake.lua
@@ -6,6 +6,7 @@ package("blake3")
     add_urls("https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/$(version).tar.gz",
              "https://github.com/BLAKE3-team/BLAKE3.git")
 
+    add_versions("1.8.2", "6b51aefe515969785da02e87befafc7fdc7a065cd3458cf1141f29267749e81f")
     add_versions("1.8.1", "fc2aac36643db7e45c3653fd98a2a745e6d4d16ff3711e4b7abd3b88639463dd")
     add_versions("1.6.1", "1f2fbd93790694f1ad66eef26e23c42260a1916927184d78d8395ff1a512d285")
     add_versions("1.5.5", "6feba0750efc1a99a79fb9a495e2628b5cd1603e15f56a06b1d6cb13ac55c618")


### PR DESCRIPTION
New version of blake3 detected (package version: 1.8.1, last github version: 1.8.2)