### PR TITLE
Auto-update boost_reflect to v1.2.6

### DIFF
--- a/packages/b/boost_reflect/xmake.lua
+++ b/packages/b/boost_reflect/xmake.lua
@@ -6,6 +6,7 @@ package("boost_reflect")
     add_urls("https://github.com/boost-ext/reflect/archive/refs/tags/$(version).tar.gz",
              "https://github.com/boost-ext/reflect.git")
 
+    add_versions("v1.2.6", "2991391d326886a20522ee376c04dceb4ad200ffba909bbce9a4cbe655b61ab8")
     add_versions("v1.2.4", "8844faf7e282d9b9841fdee89b3ccfa80a800d7c35b6575c5f64cfa5946e0854")
     add_versions("v1.2.3", "583fe281c3b83f403b7fb18389e64bacc3ca0b30683d550f2ad6159cc0ebb6be")
     add_versions("v1.1.1", "49b20cbc0e5d9f94bcdc96056f8c5d91ee2e45d8642e02cb37e511079671ad48")


### PR DESCRIPTION
New version of boost_reflect detected (package version: v1.2.4, last github version: v1.2.6)