### PR TITLE
Auto-update aws-c-mqtt to v0.12.3

### DIFF
--- a/packages/a/aws-c-mqtt/xmake.lua
+++ b/packages/a/aws-c-mqtt/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-mqtt")
     add_urls("https://github.com/awslabs/aws-c-mqtt/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-mqtt.git")
 
+    add_versions("v0.12.3", "c2ea5d3b34692c5b71ec4ff3efd8277af01f16706970e8851373c361abaf1d72")
     add_versions("v0.12.1", "04abe47c798bf9dcb95e25ea9acd62a35a3f22e58b61c16912a6275c2f8230fe")
     add_versions("v0.11.0", "3854664c13896b6de3d56412f928435a4933259cb7fe62b10c1f497e6999333c")
     add_versions("v0.10.7", "197bb549f7b121d05d59bb58dd641b56fdf80337d027f0a69146196bd8f92604")


### PR DESCRIPTION
New version of aws-c-mqtt detected (package version: v0.12.1, last github version: v0.12.3)