### PR TITLE
Auto-update openvdb to v12.0.1

### DIFF
--- a/packages/o/openvdb/xmake.lua
+++ b/packages/o/openvdb/xmake.lua
@@ -6,6 +6,7 @@ package("openvdb")
 
     add_urls("https://github.com/AcademySoftwareFoundation/openvdb/archive/refs/tags/$(version).tar.gz",
              "https://github.com/AcademySoftwareFoundation/openvdb.git")
+    add_versions("v12.0.1", "a3c8724ecadabaf558b6e1bd6f1d695e93b82a7cfdf144b8551e5253340ddce0")
     add_versions("v7.1.0", "0c3588c1ca6e647610738654ec2c6aaf41a203fd797f609fbeab1c9f7c3dc116")
     add_versions("v8.0.1", "a6845da7c604d2c72e4141c898930ac8a2375521e535f696c2cd92bebbe43c4f")
     add_versions("v8.1.0", "3e09d47331429be7409a3a3c27fdd3c297f96d31d2153febe194e664a99d6183")


### PR DESCRIPTION
New version of openvdb detected (package version: v11.0.0, last github version: v12.0.1)