### PR TITLE
Auto-update libvips to v8.16.1

### DIFF
--- a/packages/l/libiconv/xmake.lua
+++ b/packages/l/libiconv/xmake.lua
@@ -6,7 +6,6 @@ package("libiconv")
     set_urls("https://ftpmirror.gnu.org/gnu/libiconv/libiconv-$(version).tar.gz",
              "https://ftp.gnu.org/gnu/libiconv/libiconv-$(version).tar.gz")
 
-    add_versions("1.18", "3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8")
     add_versions("1.17", "8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313")
     add_versions("1.16", "e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04")
     add_versions("1.15", "ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178")
@@ -59,10 +58,12 @@ package("libiconv")
             table.insert(configs, "--enable-debug")
         end
 
+        local opt = {}
         if package:version():lt("1.18") then
+            opt.cxflags = "-std=c99"
             os.vrunv("make", {"-f", "Makefile.devel", "CFLAGS=" .. (package:config("cflags") or "")})
         end
-        import("package.tools.autoconf").install(package, configs)
+        import("package.tools.autoconf").install(package, configs, opt)
     end)
 
     on_test(function (package)

--- a/packages/l/libiconv/xmake.lua
+++ b/packages/l/libiconv/xmake.lua
@@ -1,11 +1,12 @@
 package("libiconv")
-
     set_homepage("https://www.gnu.org/software/libiconv")
     set_description("Character set conversion library.")
     set_license("LGPL-2.0")
 
     set_urls("https://ftpmirror.gnu.org/gnu/libiconv/libiconv-$(version).tar.gz",
              "https://ftp.gnu.org/gnu/libiconv/libiconv-$(version).tar.gz")
+
+    add_versions("1.18", "3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8")
     add_versions("1.17", "8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313")
     add_versions("1.16", "e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04")
     add_versions("1.15", "ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178")
@@ -57,7 +58,10 @@ package("libiconv")
         if package:debug() then
             table.insert(configs, "--enable-debug")
         end
-        os.vrunv("make", {"-f", "Makefile.devel", "CFLAGS=" .. (package:config("cflags") or "")})
+
+        if package:version():lt("1.18") then
+            os.vrunv("make", {"-f", "Makefile.devel", "CFLAGS=" .. (package:config("cflags") or "")})
+        end
         import("package.tools.autoconf").install(package, configs)
     end)
 

--- a/packages/l/libvips/xmake.lua
+++ b/packages/l/libvips/xmake.lua
@@ -6,6 +6,7 @@ package("libvips")
     add_urls("https://github.com/libvips/libvips/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libvips/libvips.git")
 
+    add_versions("v8.16.1", "df960c3df02da8ae16ee19e79c9428e955d178242a8f06064e07e0c417238e6e")
     add_versions("v8.16.0", "d28d7bf7e3f8fa17390c255ace4a05a1c56459e1f6015319f4847ea0733593b3")
     add_versions("v8.15.5", "bf11abb23da9152241ba52621efe418995c7f315fd0baf2e125323d28efd8780")
     add_versions("v8.15.4", "16afc1bf2218a98c1dc35ec4d94ef61d66c293eeb2b399fd40282dfb2211ea95")


### PR DESCRIPTION
New version of libvips detected (package version: v8.16.0, last github version: v8.16.1)