### PR TITLE
Auto-update lief to 0.16.5

### DIFF
--- a/packages/l/lief/patches/0.16.5/cstdint.patch
+++ b/packages/l/lief/patches/0.16.5/cstdint.patch
@@ -1,0 +1,13 @@
+diff --git a/include/LIEF/PE/ResourceNode.hpp b/include/LIEF/PE/ResourceNode.hpp
+index fbea63b40..4db05119a 100644
+--- a/include/LIEF/PE/ResourceNode.hpp
++++ b/include/LIEF/PE/ResourceNode.hpp
+@@ -19,6 +19,7 @@
+ #include <string>
+ #include <vector>
+ #include <memory>
++#include <cstdint>
+ 
+ #include "LIEF/Object.hpp"
+ #include "LIEF/visibility.h"
+ 

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -17,9 +17,10 @@ package("lief")
     add_versions("0.11.5", "6d6d57304a56850958e4ce54f3da2ea2b9eb856ccbab61c6cde9cba15d7c9da5")
     add_versions("0.14.0", "400804e38cb5ce8d15fb52a4db6345f02da7b2e5cb773665712283001482b808")
     add_versions("0.14.1", "92916dcb3178353d863aef4f409186889983c56e025b774741d5316a72ec3a7d")
+
     add_patches("0.15.1", "patches/0.15.1/algorithm.patch", "3e110539c3db037b2b24cd32f97ad8cc6241b1f69d4a65dab9fd6c84e482bbd9")
     add_patches("0.16.0", "https://github.com/lief-project/LIEF/commit/41166332a2435fdb7d2bdc5c73f9ff9b442c5459.patch", "e42e5dd7e4c7a24bf712c1a7c9efa19c9daf835fc85dd35c8ab4b81d1807d833")
-    add_patches("0.16.5", "https://github.com/lief-project/LIEF/commit/5d35ebfbef9fe48209468107c0c382501d353d56.patch", "6f2f1000583db4c24358515fe72b7fa100045aa8272efaf64f96b4a4c62f14bd")
+    add_patches("0.16.5", "patches/0.16.5/cstdint.patch", "67956ae49cc529e2b9f98b20544a721bc539ac500da5358c8357751bfcf9b5bc")
 
     add_configs("elf",    {description = "Enable ELF module.", default = true, type = "boolean"})
     add_configs("pe",     {description = "Enable PE module.", default = true, type = "boolean"})

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -6,6 +6,7 @@ package("lief")
     set_urls("https://github.com/lief-project/LIEF/archive/refs/tags/$(version).tar.gz",
              "https://github.com/lief-project/LIEF.git")
 
+    add_versions("0.16.5", "10ef46bc958d7936feb155040c874504ab0bd40dc59b4678f807691ccd0d138f")
     add_versions("0.16.4", "311fff5ea9ecbe57b8d02e68739b97673cb14763129ce53af3eac8fee6bf845e")
     add_versions("0.16.3", "465121937c0b7885e9ceb0f6fc452a0b06b8cf2b3aabb454bfa9d4cb985d33d3")
     add_versions("0.16.2", "895ce0321b233a6d610ed89ccbe8dc4aa2cf0bb959919a1db0693ba264f3d29a")

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -19,6 +19,7 @@ package("lief")
     add_versions("0.14.1", "92916dcb3178353d863aef4f409186889983c56e025b774741d5316a72ec3a7d")
     add_patches("0.15.1", "patches/0.15.1/algorithm.patch", "3e110539c3db037b2b24cd32f97ad8cc6241b1f69d4a65dab9fd6c84e482bbd9")
     add_patches("0.16.0", "https://github.com/lief-project/LIEF/commit/41166332a2435fdb7d2bdc5c73f9ff9b442c5459.patch", "e42e5dd7e4c7a24bf712c1a7c9efa19c9daf835fc85dd35c8ab4b81d1807d833")
+    add_patches("0.16.5", "https://github.com/lief-project/LIEF/commit/5d35ebfbef9fe48209468107c0c382501d353d56.patch", "6f2f1000583db4c24358515fe72b7fa100045aa8272efaf64f96b4a4c62f14bd")
 
     add_configs("elf",    {description = "Enable ELF module.", default = true, type = "boolean"})
     add_configs("pe",     {description = "Enable PE module.", default = true, type = "boolean"})

--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -21,6 +21,7 @@ package("lief")
     add_patches("0.15.1", "patches/0.15.1/algorithm.patch", "3e110539c3db037b2b24cd32f97ad8cc6241b1f69d4a65dab9fd6c84e482bbd9")
     add_patches("0.16.0", "https://github.com/lief-project/LIEF/commit/41166332a2435fdb7d2bdc5c73f9ff9b442c5459.patch", "e42e5dd7e4c7a24bf712c1a7c9efa19c9daf835fc85dd35c8ab4b81d1807d833")
     add_patches("0.16.5", "patches/0.16.5/cstdint.patch", "67956ae49cc529e2b9f98b20544a721bc539ac500da5358c8357751bfcf9b5bc")
+    add_patches("0.16.5", "https://github.com/lief-project/LIEF/commit/649baec7db4190944b0f4b4b5d5c995e85f46d39.patch", "981866391db64f5bfc18a24c9974fac6e5957c63e09f5af1950e87b9dbac10fc")
 
     add_configs("elf",    {description = "Enable ELF module.", default = true, type = "boolean"})
     add_configs("pe",     {description = "Enable PE module.", default = true, type = "boolean"})


### PR DESCRIPTION
New version of lief detected (package version: 0.16.4, last github version: 0.16.5)