### PR TITLE
Auto-update zint to 2.15.0

### DIFF
--- a/packages/z/zint/xmake.lua
+++ b/packages/z/zint/xmake.lua
@@ -6,6 +6,7 @@ package("zint")
     set_urls("https://github.com/zint/zint/archive/refs/tags/$(version).tar.gz",
              "https://github.com/zint/zint.git")
 
+    add_versions("2.15.0", "529ce50566f8421f1707333c201097c490273f93b5de45f4d21231a11d3722cf")
     add_versions("2.14.0", "affc3e334e8ee0fc5552aabbc5f1360d4d6d9c6f86285c1e138e3efbbdc4abcb")
 
     add_configs("png", {description = "Build with PNG support", default = false, type = "boolean"})


### PR DESCRIPTION
New version of zint detected (package version: 2.14.0, last github version: 2.15.0)