### PR TITLE
Auto-update aws-c-s3 to v0.7.15

### DIFF
--- a/packages/a/aws-c-s3/xmake.lua
+++ b/packages/a/aws-c-s3/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-s3")
     add_urls("https://github.com/awslabs/aws-c-s3/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-s3.git")
 
+    add_versions("v0.7.15", "458b32811069e34186cfcef6c2d63a02b34657e70e880e1c0706976ce4b58389")
     add_versions("v0.7.14", "1a8cd98612f5d08ac12f1c0ab7235e1750faf8fb0e7680662101626b81963a66")
     add_versions("v0.7.12", "096ac66bc830c8a29cb12652db095e03a2ed5b15645baa4d7c78de419a0d6a54")
     add_versions("v0.7.7", "843571de8cd504428bd4ef9ff574e3c91b51ae010813111757e1cfca951cf35e")


### PR DESCRIPTION
New version of aws-c-s3 detected (package version: v0.7.14, last github version: v0.7.15)