### PR TITLE
Auto-update hiredis to v1.3.0

### DIFF
--- a/packages/h/hiredis/xmake.lua
+++ b/packages/h/hiredis/xmake.lua
@@ -5,6 +5,7 @@ package("hiredis")
 
     add_urls("https://github.com/redis/hiredis/archive/refs/tags/$(version).tar.gz",
              "https://github.com/redis/hiredis.git")
+    add_versions("v1.3.0", "25cee4500f359cf5cad3b51ed62059aadfc0939b05150c1f19c7e2829123631c")
     add_versions("v1.0.2", "e0ab696e2f07deb4252dda45b703d09854e53b9703c7d52182ce5a22616c3819")
     add_versions("v1.1.0", "fe6d21741ec7f3fc9df409d921f47dfc73a4d8ff64f4ac6f1d95f951bf7f53d6")
     add_versions("v1.2.0", "82ad632d31ee05da13b537c124f819eb88e18851d9cb0c30ae0552084811588c")


### PR DESCRIPTION
New version of hiredis detected (package version: v1.2.0, last github version: v1.3.0)