### PR TITLE
pybind11: relocate macOS workaround for `pybind11` from `rule("python.library")` to package

### DIFF
--- a/packages/p/pybind11/xmake.lua
+++ b/packages/p/pybind11/xmake.lua
@@ -19,7 +19,19 @@ package("pybind11")
     add_versions("v2.12.0", "411f77380c43798506b39ec594fc7f2b532a13c4db674fcf2b1ca344efaefb68")
     add_versions("v2.13.1", "a3c9ea1225cb731b257f2759a0c12164db8409c207ea5cf851d4b95679dda072")
 
-    add_deps("cmake", "python 3.x")
+    add_deps("cmake")
+    if is_plat("macosx") then
+        add_deps("python 3.x", {configs = {headeronly = true}})
+    else
+        add_deps("python 3.x")
+    end
+
+    on_load("macosx", function (package)
+        -- fix segmentation fault for macosx
+        -- @see https://github.com/xmake-io/xmake/issues/2177#issuecomment-1209398292
+        package:add("shflags", "-undefined dynamic_lookup", {force = true})
+    end)
+
     on_install("windows|native", "macosx", "linux", function (package)
         import("detect.tools.find_python3")
 

--- a/packages/p/pybind11/xmake.lua
+++ b/packages/p/pybind11/xmake.lua
@@ -25,9 +25,8 @@ package("pybind11")
 
         local configs = {"-DPYBIND11_TEST=OFF"}
         local python = find_python3()
-        local pythondir = path.directory(python)
-        if pythondir and path.is_absolute(pythondir) then
-            table.insert(configs, "-DPython_ROOT_DIR=" .. pythondir)
+        if python and path.is_absolute(python) then
+            table.insert(configs, "-DPython_EXECUTABLE=" .. python)
         end
         import("package.tools.cmake").install(package, configs)
     end)

--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -93,9 +93,9 @@ package("python")
         if version:ge("3.10") then
             -- starting with Python 3.10, Python requires OpenSSL 1.1.1 or newer
             -- see https://peps.python.org/pep-0644/
-            package:add("deps", "openssl >=1.1.1-a", "ca-certificates", {host = true})
+            package:add("deps", "openssl >=1.1.1-a", "ca-certificates", {host = true, private = package:config("headeronly")})
         else
-            package:add("deps", "openssl", "ca-certificates", {host = true})
+            package:add("deps", "openssl", "ca-certificates", {host = true, private = package:config("headeronly")})
         end
 
         -- set includedirs


### PR DESCRIPTION
The current `rule("python.library")` works well with `pybind11`, but it may drop the `-lnanobind` flag when used with `nanobind`, leading to `undefined reference` link errors.

This PR moves the logic specific to `pybind11` from `rule("python.library")` into the `pybind11` package. This change ensures better compatibility with `nanobind` while maintaining the intended behavior for `pybind11`.

After this change, we can safely remove the following lines, allowing `rule("python.library")` to work with `nanobind`:

https://github.com/xmake-io/xmake/blob/2774ecbc0961e1e2b1f995d8937b44c2c90e11c6/xmake/rules/python/xmake.lua#L45-L67
