### PR TITLE
libelf: use `add_resources` instead of `http.download`

### DIFF
--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -31,8 +31,8 @@ package("libelf")
             package:add("defines", "__libelf_u64_t=uint64_t")
             package:add("defines", "__libelf_i64_t=int64_t")
         end
-        os.cp(path.join(package:resourcedir("config"), ".", "config.guess"), "config.guess")
-        os.cp(path.join(package:resourcedir("config"), ".", "config.sub"), "config.sub")
+        os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
+        os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")
         import("package.tools.autoconf").install(package, configs, {cxflags = cxflags})
     end)
 

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -10,10 +10,12 @@ package("libelf")
     add_resources("0.8.13", "config", "https://dev.gentoo.org/~sam/distfiles/sys-devel/gnuconfig/gnuconfig-20240728.tar.xz", "6e3a7389d780cb0cf81bec0bba96ca278d5b76afd548352f70b4a444344430b7")
 
     add_includedirs("include", "include/libelf")
+    
+    if is_subhost("windows") then
+        add_deps("autotools")
+    end
 
-    add_deps("autotools")
-
-    on_install("cross", "linux", "android@linux,macosx", function (package)
+    on_install("cross", "linux", "android", function (package)
         local configs = {"--disable-dependency-tracking",
                          "--disable-compat"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
@@ -33,7 +35,9 @@ package("libelf")
             package:add("defines", "__libelf_u64_t=uint64_t")
             package:add("defines", "__libelf_i64_t=int64_t")
         end
-        os.rm("configure")
+        if is_subhost("windows") then
+            os.rm("configure")
+        end
         os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
         os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")
         import("package.tools.autoconf").install(package, configs, {cxflags = cxflags})

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -10,10 +10,11 @@ package("libelf")
     add_resources("0.8.13", "config", "https://dev.gentoo.org/~sam/distfiles/sys-devel/gnuconfig/gnuconfig-20240728.tar.xz", "6e3a7389d780cb0cf81bec0bba96ca278d5b76afd548352f70b4a444344430b7")
 
     add_includedirs("include", "include/libelf")
+    if not is_subhost("windows") then
+        add_deps("autotools")
+    end
 
-    add_deps("autotools")
-
-    on_install("cross", "linux", "android@linux,macosx", function (package)
+    on_install("cross", "linux", "android", function (package)
         local configs = {"--disable-dependency-tracking",
                          "--disable-compat"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
@@ -33,9 +34,11 @@ package("libelf")
             package:add("defines", "__libelf_u64_t=uint64_t")
             package:add("defines", "__libelf_i64_t=int64_t")
         end
-        os.rm("configure")
-        os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
-        os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")
+        if not is_subhost("windows") then
+            os.rm("configure")
+            os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
+            os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")
+        end
         import("package.tools.autoconf").install(package, configs, {cxflags = cxflags})
     end)
 

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -7,7 +7,7 @@ package("libelf")
 
     add_versions("0.8.13", "591a9b4ec81c1f2042a97aa60564e0cb79d041c52faa7416acb38bc95bd2c76d")
 
-    add_resources("0.8.13", "config", "http://distfiles.exherbo.org/distfiles/gnuconfig-20240728.tar.gz", "a34b169e0cd5a1f4febcfe17d52f2c78f80add2887fdd33f233c12acffbd25b3")
+    add_resources("0.8.13", "config", "https://dev.gentoo.org/~sam/distfiles/sys-devel/gnuconfig/gnuconfig-20240728.tar.xz", "6e3a7389d780cb0cf81bec0bba96ca278d5b76afd548352f70b4a444344430b7")
 
     add_includedirs("include", "include/libelf")
 

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -11,7 +11,9 @@ package("libelf")
 
     add_includedirs("include", "include/libelf")
 
-    on_install("cross", "linux", "android", function (package)
+    add_deps("autotools")
+
+    on_install("cross", "linux", "android@linux,macosx", function (package)
         local configs = {"--disable-dependency-tracking",
                          "--disable-compat"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
@@ -31,6 +33,7 @@ package("libelf")
             package:add("defines", "__libelf_u64_t=uint64_t")
             package:add("defines", "__libelf_i64_t=int64_t")
         end
+        os.rm("configure")
         os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
         os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")
         import("package.tools.autoconf").install(package, configs, {cxflags = cxflags})

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -33,11 +33,9 @@ package("libelf")
             package:add("defines", "__libelf_u64_t=uint64_t")
             package:add("defines", "__libelf_i64_t=int64_t")
         end
-        if not is_subhost("windows") then
-            os.rm("configure")
-            os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
-            os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")
-        end
+        os.rm("configure")
+        os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
+        os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")
         import("package.tools.autoconf").install(package, configs, {cxflags = cxflags})
     end)
 

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -7,8 +7,7 @@ package("libelf")
 
     add_versions("0.8.13", "591a9b4ec81c1f2042a97aa60564e0cb79d041c52faa7416acb38bc95bd2c76d")
 
-    add_resources("0.8.13", "guess", "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=00b15927496058d23e6258a28d8996f87cf1f191", "e3d148130e9151735f8b9a8e69a70d06890ece51468a9762eb7ac0feddddcc2f")
-    add_resources("0.8.13", "sub", "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=00b15927496058d23e6258a28d8996f87cf1f191", "11c54f55c3ac99e5d2c3dc2bb0bcccbf69f8223cc68f6b2438daa806cf0d16d8")
+    add_resources("0.8.13", "config", "https://git.savannah.gnu.org/gitweb/?p=config.git;a=snapshot;h=00b15927496058d23e6258a28d8996f87cf1f191;sf=tgz", "a34b169e0cd5a1f4febcfe17d52f2c78f80add2887fdd33f233c12acffbd25b3")
 
     add_includedirs("include", "include/libelf")
 
@@ -32,8 +31,8 @@ package("libelf")
             package:add("defines", "__libelf_u64_t=uint64_t")
             package:add("defines", "__libelf_i64_t=int64_t")
         end
-        os.cp(path.join(package:resourcedir("guess"), "../config.sub"), "config.guess")
-        os.cp(path.join(package:resourcedir("sub"), "../config.sub"), "config.sub")
+        os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
+        os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")
         import("package.tools.autoconf").install(package, configs, {cxflags = cxflags})
     end)
 

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -31,6 +31,7 @@ package("libelf")
             package:add("defines", "__libelf_u64_t=uint64_t")
             package:add("defines", "__libelf_i64_t=int64_t")
         end
+        os.rm("configure")
         os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
         os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")
         import("package.tools.autoconf").install(package, configs, {cxflags = cxflags})

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -38,6 +38,7 @@ package("libelf")
             os.rm("configure")
         else
             io.replace("lib/Makefile.in", [[$(SHELL) $(top_srcdir)/mkinstalldirs $(instroot)$$dir;]], [["$(SHELL)" "$(top_srcdir)/mkinstalldirs" "$(instroot)$$dir";]], {plain = true})
+            io.replace("po/Makefile.in", [[$(SHELL) $(top_srcdir)/mkinstalldirs $(instroot)$$dir;]], [["$(SHELL)" "$(top_srcdir)/mkinstalldirs" "$(instroot)$$dir";]], {plain = true})
         end
         os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
         os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -1,17 +1,18 @@
 package("libelf")
-
     set_homepage("https://web.archive.org/web/20181111033959/www.mr511.de/software/english.html")
     set_description("ELF object file access library")
 
     set_urls("https://github.com/xmake-mirror/libelf/releases/download/$(version)/libelf-$(version).tar.gz",
              "https://github.com/xmake-mirror/libelf.git")
+
     add_versions("0.8.13", "591a9b4ec81c1f2042a97aa60564e0cb79d041c52faa7416acb38bc95bd2c76d")
+
+    add_resources("0.8.13", "guess", "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=00b15927496058d23e6258a28d8996f87cf1f191", "e3d148130e9151735f8b9a8e69a70d06890ece51468a9762eb7ac0feddddcc2f")
+    add_resources("0.8.13", "sub", "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=00b15927496058d23e6258a28d8996f87cf1f191", "11c54f55c3ac99e5d2c3dc2bb0bcccbf69f8223cc68f6b2438daa806cf0d16d8")
 
     add_includedirs("include", "include/libelf")
 
-    add_deps("autotools")
-
-    on_install("cross", "linux", "android@linux,macosx", function (package)
+    on_install("cross", "linux", "android", function (package)
         local configs = {"--disable-dependency-tracking",
                          "--disable-compat"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
@@ -31,18 +32,8 @@ package("libelf")
             package:add("defines", "__libelf_u64_t=uint64_t")
             package:add("defines", "__libelf_i64_t=int64_t")
         end
-        os.rm("configure", "config.guess", "config.sub")
-        local automake = package:dep("automake")
-        if automake and not automake:is_system() then
-            local automake_dir = path.join(automake:installdir(), "share", "automake-*")
-            os.cp(path.join(automake_dir, "config.guess"), ".")
-            os.cp(path.join(automake_dir, "config.sub"), ".")
-        else
-            import("net.http")
-            import("core.base.global")
-            http.download("http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD", path.join(package:buildir(), "config.guess"), {insecure = global.get("insecure-ssl")})
-            http.download("http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD", path.join(package:buildir(), "config.sub"), {insecure = global.get("insecure-ssl")})
-        end
+        os.cp(path.join(package:resourcedir("guess"), "../config.sub"), "config.guess")
+        os.cp(path.join(package:resourcedir("sub"), "../config.sub"), "config.sub")
         import("package.tools.autoconf").install(package, configs, {cxflags = cxflags})
     end)
 

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -31,8 +31,8 @@ package("libelf")
             package:add("defines", "__libelf_u64_t=uint64_t")
             package:add("defines", "__libelf_i64_t=int64_t")
         end
-        os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
-        os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")
+        os.cp(path.join(package:resourcedir("config"), ".", "config.guess"), "config.guess")
+        os.cp(path.join(package:resourcedir("config"), ".", "config.sub"), "config.sub")
         import("package.tools.autoconf").install(package, configs, {cxflags = cxflags})
     end)
 

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -36,6 +36,8 @@ package("libelf")
         end
         if not is_subhost("windows") then
             os.rm("configure")
+        else
+            io.replace("lib/Makefile.in", [[$(SHELL) $(top_srcdir)/mkinstalldirs $(instroot)$$dir;]], [["$(SHELL)" "$(top_srcdir)/mkinstalldirs" "$(instroot)$$dir";]], {plain = true})
         end
         os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
         os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -7,7 +7,7 @@ package("libelf")
 
     add_versions("0.8.13", "591a9b4ec81c1f2042a97aa60564e0cb79d041c52faa7416acb38bc95bd2c76d")
 
-    add_resources("0.8.13", "config", "https://git.savannah.gnu.org/gitweb/?p=config.git;a=snapshot;h=00b15927496058d23e6258a28d8996f87cf1f191;sf=tgz", "a34b169e0cd5a1f4febcfe17d52f2c78f80add2887fdd33f233c12acffbd25b3")
+    add_resources("0.8.13", "config", "http://distfiles.exherbo.org/distfiles/gnuconfig-20240728.tar.gz", "a34b169e0cd5a1f4febcfe17d52f2c78f80add2887fdd33f233c12acffbd25b3")
 
     add_includedirs("include", "include/libelf")
 

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -42,6 +42,7 @@ package("libelf")
             io.replace("configure", [[{ echo "configure: error: installation or configuration problem: C compiler cannot create executables." 1>&2; exit 1; }]], [[ac_cv_prog_cc_works=yes]], {plain = true})
             io.replace("configure", [[libelf_cv_int64=no]], [[libelf_cv_int64='long']], {plain = true})
             io.replace("configure", [[libelf_cv_int32=no]], [[libelf_cv_int32='int']], {plain = true})
+            io.replace("configure", [[libelf_cv_int16=no]], [[libelf_cv_int16='short']], {plain = true})
         end
         os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
         os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -10,7 +10,7 @@ package("libelf")
 
     add_includedirs("include", "include/libelf")
     
-    if is_subhost("windows") then
+    if not is_subhost("windows") then
         add_deps("autotools")
     end
 
@@ -34,7 +34,7 @@ package("libelf")
             package:add("defines", "__libelf_u64_t=uint64_t")
             package:add("defines", "__libelf_i64_t=int64_t")
         end
-        if is_subhost("windows") then
+        if not is_subhost("windows") then
             os.rm("configure")
         end
         os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -40,6 +40,8 @@ package("libelf")
             io.replace("lib/Makefile.in", [[$(SHELL) $(top_srcdir)/mkinstalldirs $(instroot)$$dir;]], [["$(SHELL)" "$(top_srcdir)/mkinstalldirs" "$(instroot)$$dir";]], {plain = true})
             io.replace("po/Makefile.in", [[$(SHELL) $(top_srcdir)/mkinstalldirs $(instroot)$$dir;]], [["$(SHELL)" "$(top_srcdir)/mkinstalldirs" "$(instroot)$$dir";]], {plain = true})
             io.replace("configure", [[{ echo "configure: error: installation or configuration problem: C compiler cannot create executables." 1>&2; exit 1; }]], [[ac_cv_prog_cc_works=yes]], {plain = true})
+            io.replace("configure", [[libelf_cv_int64=no]], [[libelf_cv_int64='long']], {plain = true})
+            io.replace("configure", [[libelf_cv_int32=no]], [[libelf_cv_int32='int']], {plain = true})
         end
         os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
         os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -39,6 +39,7 @@ package("libelf")
         else
             io.replace("lib/Makefile.in", [[$(SHELL) $(top_srcdir)/mkinstalldirs $(instroot)$$dir;]], [["$(SHELL)" "$(top_srcdir)/mkinstalldirs" "$(instroot)$$dir";]], {plain = true})
             io.replace("po/Makefile.in", [[$(SHELL) $(top_srcdir)/mkinstalldirs $(instroot)$$dir;]], [["$(SHELL)" "$(top_srcdir)/mkinstalldirs" "$(instroot)$$dir";]], {plain = true})
+            io.replace("configure", [[{ echo "configure: error: installation or configuration problem: C compiler cannot create executables." 1>&2; exit 1; }]], [[ac_cv_prog_cc_works=yes]], {plain = true})
         end
         os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
         os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -6,7 +6,6 @@ package("libelf")
              "https://github.com/xmake-mirror/libelf.git")
 
     add_versions("0.8.13", "591a9b4ec81c1f2042a97aa60564e0cb79d041c52faa7416acb38bc95bd2c76d")
-
     add_resources("0.8.13", "config", "https://dev.gentoo.org/~sam/distfiles/sys-devel/gnuconfig/gnuconfig-20240728.tar.xz", "6e3a7389d780cb0cf81bec0bba96ca278d5b76afd548352f70b4a444344430b7")
 
     add_includedirs("include", "include/libelf")

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -31,7 +31,6 @@ package("libelf")
             package:add("defines", "__libelf_u64_t=uint64_t")
             package:add("defines", "__libelf_i64_t=int64_t")
         end
-        os.rm("configure")
         os.cp(path.join(package:resourcedir("config"), "config.guess"), "config.guess")
         os.cp(path.join(package:resourcedir("config"), "config.sub"), "config.sub")
         import("package.tools.autoconf").install(package, configs, {cxflags = cxflags})

--- a/packages/l/libelf/xmake.lua
+++ b/packages/l/libelf/xmake.lua
@@ -10,11 +10,10 @@ package("libelf")
     add_resources("0.8.13", "config", "https://dev.gentoo.org/~sam/distfiles/sys-devel/gnuconfig/gnuconfig-20240728.tar.xz", "6e3a7389d780cb0cf81bec0bba96ca278d5b76afd548352f70b4a444344430b7")
 
     add_includedirs("include", "include/libelf")
-    if not is_subhost("windows") then
-        add_deps("autotools")
-    end
 
-    on_install("cross", "linux", "android", function (package)
+    add_deps("autotools")
+
+    on_install("cross", "linux", "android@linux,macosx", function (package)
         local configs = {"--disable-dependency-tracking",
                          "--disable-compat"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))


### PR DESCRIPTION
- [x] Wrap into reliable add_resource method.
- [x] Get windows@android back

https://github.com/xmake-io/xmake-repo/pull/7022#issuecomment-2842433195

