### PR TITLE
Auto-update dirent to 1.25

### DIFF
--- a/packages/d/dirent/xmake.lua
+++ b/packages/d/dirent/xmake.lua
@@ -7,6 +7,7 @@ package("dirent")
     add_urls("https://github.com/tronkko/dirent/archive/refs/tags/$(version).tar.gz",
              "https://github.com/tronkko/dirent.git")
 
+    add_versions("1.25", "1c816c911f911161fc8874a308c15f1819c294dd2f94d618063a878723238a06")
     add_versions("1.24", "37009127a65bb1ddc47d06c097321f87f45ca2e998b2ec3bf2e0b2b19649d6f9")
 
     on_install("windows", "mingw", "msys", "cygwin", function (package)


### PR DESCRIPTION
New version of dirent detected (package version: 1.24, last github version: 1.25)