### PR TITLE
add opencv android

### DIFF
--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -241,11 +241,11 @@ package("opencv")
             package:add("links", reallink)
         end
         if package:is_plat("android") then
-            local linkdir = (package:config("shared") and "libs" or "staticlibs")
-            local libname = "lib*." .. (package:config("shared") and "so" or "a")
-            local libfiles = {}
-            table.join2(libfiles, os.files(path.join(package:installdir(), "sdk/native", linkdir, package:targetarch(), libname)))
-            table.join2(libfiles, os.files(path.join(package:installdir(), "sdk/native/3rdparty/libs", package:targetarch(), libname)))
+            for _, suffix in ipairs({"*.a", "*.so"}) do
+                for _, f in ipairs(os.files(path.join(package:installdir(path.join("sdk/native/3rdparty/libs", package:targetarch())), suffix))) do
+                    package:add("links", path.basename(f):match("lib(.+)"))
+                end
+            end
             for _, f in ipairs(libfiles) do
                 if not f:match("opencv_.+") then
                     package:add("links", path.basename(f):match("lib(.+)"))

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -179,7 +179,7 @@ package("opencv")
             table.insert(configs, "-DBUILD_WITH_STATIC_CRT=" .. (package:has_runtime("MT", "MTd") and "ON" or "OFF"))
             if package:is_arch("arm64") then
                 -- https://github.com/opencv/opencv/issues/25052
-                table.insert(configs, "-DCPU_BASELINE=NEON")
+                table.insert(configs, "-DCPU_NEON_FP16_SUPPORTED=OFF")
                 -- https://github.com/opencv/opencv/issues/24235
                 table.insert(configs, "-DOPENCV_SKIP_SYSTEM_PROCESSOR_DETECTION=ON")
                 table.insert(configs, "-DAARCH64=ON")

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -193,6 +193,7 @@ package("opencv")
                 table.insert(configs, "-DCMAKE_SYSTEM_NAME=Android")
                 -- from https://github.com/opencv/opencv/issues/15769#issuecomment-549570072
                 table.insert(configs, "-DBUILD_ANDROID_EXAMPLES=OFF")
+                table.insert(configs, "-DBUILD_ANDROID_PROJECTS=OFF")
             end
 
             -- In case of android we prefer to set CMAKE_ANDROID_ARCH_ABI rather than CMAKE_SYSTEM_PROCESSOR

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -85,12 +85,6 @@ package("opencv")
             if     package:is_arch("x86")   then arch = "x86"
             elseif package:is_arch("arm64") then arch = "ARM64"
             end
-            -- Workaround for arm64
-            if package:is_arch("arm64") and not os.isdir("ARM64") then
-                if     os.isdir("x64") then arch = "x64"
-                elseif os.isdir("x86") then arch = "x86"
-                end
-            end
             local linkdir = (package:config("shared") and "lib" or "staticlib")
             local vs = package:toolchain("msvc"):config("vs")
             local vc_ver = "vc13"
@@ -259,6 +253,12 @@ package("opencv")
             local arch = "x64"
             if     package:is_arch("x86")   then arch = "x86"
             elseif package:is_arch("arm64") then arch = "ARM64"
+            end
+            -- Workaround for arm64
+            if package:is_arch("arm64") and not os.isdir("ARM64") then
+                if     os.isdir("x64") then arch = "x64"
+                elseif os.isdir("x86") then arch = "x86"
+                end
             end
             local linkdir = (package:config("shared") and "lib" or "staticlib")
             local vs = package:toolchain("msvc"):config("vs")

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -179,7 +179,7 @@ package("opencv")
             table.insert(configs, "-DBUILD_WITH_STATIC_CRT=" .. (package:has_runtime("MT", "MTd") and "ON" or "OFF"))
             if package:is_arch("arm64") then
                 -- https://github.com/opencv/opencv/issues/25052
-                table.insert(configs, "-DCPU_NEON_FP16_SUPPORTED=OFF")
+                table.insert(configs, "-DCPU_BASELINE=NEON")
                 -- https://github.com/opencv/opencv/issues/24235
                 table.insert(configs, "-DOPENCV_SKIP_SYSTEM_PROCESSOR_DETECTION=ON")
                 table.insert(configs, "-DAARCH64=ON")

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -100,7 +100,6 @@ package("opencv")
             local linkdir = (package:config("shared") and "lib" or "staticlib")
             package:add("linkdirs", path.join(arch, "mingw", linkdir))
         elseif package:is_plat("android") then
-            local arch = package:targetarch()
             local linkdir = (package:config("shared") and "libs" or "staticlibs")
             package:add("linkdirs", path.join("sdk/native", linkdir, package:targetarch()))
             package:add("linkdirs", path.join("sdk/native/3rdparty/libs", package:targetarch()))

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -251,7 +251,6 @@ package("opencv")
                     package:add("links", path.basename(f):match("lib(.+)"))
                 end
             end
-            package:addenv("PATH", "bin")
 
         elseif package:is_plat("windows") then
             local arch = "x64"

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -19,6 +19,8 @@ package("opencv")
     add_versions("4.2.0", "9ccb2192d7e8c03c58fee07051364d94ed7599363f3b0dce1c5e6cc11c1bb0ec")
     add_versions("3.4.9", "b7ea364de7273cfb3b771a0d9c111b8b8dfb42ff2bcd2d84681902fb8f49892a")
 
+    add_patches("4.11.0", "https://github.com/opencv/opencv/commit/767dd838d3074409fd72a4d76c320b1370e95943.diff", "376dd90500ab7205084fd4298ff26137ce9678b00233ad20ca2189ef9eca3a58")
+
     add_resources("4.11.0", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/4.11.0.tar.gz", "2dfc5957201de2aa785064711125af6abb2e80a64e2dc246aca4119b19687041")
     add_resources("4.10.0", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/4.10.0.tar.gz", "65597f8fb8dc2b876c1b45b928bbcc5f772ddbaf97539bf1b737623d0604cba1")
     add_resources("4.9.0", "opencv_contrib", "https://github.com/opencv/opencv_contrib/archive/4.9.0.tar.gz", "8952c45a73b75676c522dd574229f563e43c271ae1d5bbbd26f8e2b6bc1a4dae")

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -142,7 +142,7 @@ package("opencv")
             local vs = package:toolchain("msvc"):config("vs")
             assert(tonumber(vs) >= 2022, "opencv requires Visual Studio 2022 and later for arm targets")
             local vs_sdkver = package:toolchain("msvc"):config("vs_sdkver")
-            assert(vs_sdkver and semver.match(vs_sdkver):eq("10.0.26100") and not os.is_arch("arm.*"), "package(opencv): requires host arch to be arm for vs_sdkver 10.0.26100")
+            assert(vs_sdkver and semver.match(vs_sdkver):eq("10.0.26100") and not os.arch():find("arm64.*"), "package(opencv): requires host arch to be arm for vs_sdkver 10.0.26100")
         end)
     end
 

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -246,8 +246,8 @@ package("opencv")
             table.join2(libfiles, os.files(path.join(package:installdir(), "sdk/native", linkdir, package:targetarch(), "lib*.a")))
             table.join2(libfiles, os.files(path.join(package:installdir(), "sdk/native/3rdparty/libs", package:targetarch(), "lib*.a")))
             for _, f in ipairs(libfiles) do
-                if f:match("lib.+") then
-                    package:add("links", path.basename(f))
+                if not f:match("opencv_.+") then
+                    package:add("links", path.basename(f):match("lib(.+)"))
                 end
             end
             package:addenv("PATH", "bin")

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -246,12 +246,6 @@ package("opencv")
                     package:add("links", path.basename(f):match("lib(.+)"))
                 end
             end
-            for _, f in ipairs(libfiles) do
-                if not f:match("opencv_.+") then
-                    package:add("links", path.basename(f):match("lib(.+)"))
-                end
-            end
-
         elseif package:is_plat("windows") then
             local arch = "x64"
             if     package:is_arch("x86")   then arch = "x86"

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -142,7 +142,7 @@ package("opencv")
             local vs = package:toolchain("msvc"):config("vs")
             assert(tonumber(vs) >= 2022, "opencv requires Visual Studio 2022 and later for arm targets")
             local vs_sdkver = package:toolchain("msvc"):config("vs_sdkver")
-            assert(vs_sdkver and semver.match(vs_sdkver):eq("10.0.26100") and not os.arch():find("arm64.*"), "package(opencv): requires host arch to be arm for vs_sdkver 10.0.26100")
+            assert(vs_sdkver and semver.match(vs_sdkver):eq("10.0.26100") and os.arch() == "arm64", "package(opencv): requires host arch to be arm for vs_sdkver 10.0.26100")
         end)
     end
 

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -101,7 +101,7 @@ package("opencv")
             package:add("linkdirs", path.join(arch, "mingw", linkdir))
         elseif package:is_plat("android") then
             local arch = package:targetarch()
-            local linkdir = (package:config("shared") and "lib" or "staticlibs")
+            local linkdir = (package:config("shared") and "libs" or "staticlibs")
             package:add("linkdirs", path.join("sdk/native", linkdir, package:targetarch()))
             package:add("linkdirs", path.join("sdk/native/3rdparty/libs", package:targetarch()))
             package:add("includedirs", "sdk/native/jni/include")

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -103,6 +103,7 @@ package("opencv")
             local arch = package:targetarch()
             local linkdir = (package:config("shared") and "lib" or "staticlibs")
             package:add("linkdirs", path.join("sdk/native", linkdir, package:targetarch()))
+            package:add("includedirs", "sdk/native/jni/include")
         elseif package:version():ge("4.0") then
             package:add("includedirs", "include/opencv4")
             package:add("linkdirs", "lib", "lib/opencv4/3rdparty")
@@ -243,8 +244,9 @@ package("opencv")
             local linkdir = (package:config("shared") and "lib" or "staticlibs")
             local libfiles = {}
             table.join2(libfiles, os.files(path.join(package:installdir(), "sdk/native", linkdir, package:targetarch(), "lib*.a")))
+            table.join2(libfiles, os.files(path.join(package:installdir(), "sdk/native/3rdparty/libs", package:targetarch(), "lib*.a")))
             for _, f in ipairs(libfiles) do
-                if f:match("libopencv_.+") then
+                if f:match("lib.+") then
                     package:add("links", path.basename(f))
                 end
             end

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -177,6 +177,9 @@ package("opencv")
             if package:is_arch("arm64") then
                 -- https://github.com/opencv/opencv/issues/25052
                 table.insert(configs, "-DCPU_NEON_FP16_SUPPORTED=OFF")
+                -- https://github.com/opencv/opencv/issues/24235
+                table.insert(configs, "-DOPENCV_SKIP_SYSTEM_PROCESSOR_DETECTION=ON")
+                table.insert(configs, "-DAARCH64=ON")
             end
         end
         if package:is_cross() or (package:is_plat("mingw") and not package:is_arch(os.arch())) then

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -142,7 +142,7 @@ package("opencv")
             local vs = package:toolchain("msvc"):config("vs")
             assert(tonumber(vs) >= 2022, "opencv requires Visual Studio 2022 and later for arm targets")
             local vs_sdkver = package:toolchain("msvc"):config("vs_sdkver")
-            assert(vs_sdkver and semver.match(vs_sdkver):gt("10.0.26100"), "package(opencv): need vs_sdkver > 10.0.26100")
+            assert(vs_sdkver and semver.match(vs_sdkver):eq("10.0.26100") and not os.is_arch("arm.*"), "package(opencv): requires host arch to be arm for vs_sdkver 10.0.26100")
         end)
     end
 

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -85,6 +85,12 @@ package("opencv")
             if     package:is_arch("x86")   then arch = "x86"
             elseif package:is_arch("arm64") then arch = "ARM64"
             end
+            -- Workaround for arm64
+            if package:is_arch("arm64") and not os.isdir("ARM64") then
+                if     os.isdir("x64") then arch = "x64"
+                elseif os.isdir("x86") then arch = "x86"
+                end
+            end
             local linkdir = (package:config("shared") and "lib" or "staticlib")
             local vs = package:toolchain("msvc"):config("vs")
             local vc_ver = "vc13"

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -226,7 +226,9 @@ package("opencv")
                 shflags = {"-Wl,-Bsymbolic"}
             end
         end
-        import("package.tools.cmake").install(package, configs, {buildir = "bd", shflags = shflags, ldflags = ldflags})
+        local envs = {}
+        envs.OPENCV_DUMP_CONFIG = 1
+        import("package.tools.cmake").install(package, configs, {envs = envs, buildir = "bd", shflags = shflags, ldflags = ldflags})
         for _, link in ipairs({"opencv_phase_unwrapping", "opencv_surface_matching", "opencv_saliency",
                                "opencv_wechat_qrcode", "opencv_mcc", "opencv_face",
                                "opencv_img_hash", "opencv_videostab", "opencv_structured_light", "opencv_intensity_transform",

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -135,15 +135,13 @@ package("opencv")
 
     if on_check then
         on_check("windows|arm64", function (package)
-            import("core.tool.toolchain")
             import("core.base.semver")
             if package:version() and package:version():lt("4.10.0") then
                 raise("current opencv version does not support windows/arm64!")
             end
             local vs = package:toolchain("msvc"):config("vs")
             assert(tonumber(vs) >= 2022, "opencv requires Visual Studio 2022 and later for arm targets")
-            local msvc = toolchain.load("msvc", {plat = package:plat(), arch = package:arch()})
-            local vs_sdkver = msvc:config("vs_sdkver")
+            local vs_sdkver = package:toolchain("msvc"):config("vs_sdkver")
             assert(vs_sdkver and semver.match(vs_sdkver):gt("10.0.26100"), "package(opencv): need vs_sdkver > 10.0.26100")
         end)
     end

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -255,9 +255,9 @@ package("opencv")
             elseif package:is_arch("arm64") then arch = "ARM64"
             end
             -- Workaround for arm64
-            if package:is_arch("arm64") and not os.isdir("ARM64") then
-                if     os.isdir("x64") then arch = "x64"
-                elseif os.isdir("x86") then arch = "x86"
+            if package:is_arch("arm64") and not os.isdir(path.join(package:installdir(), "ARM64")) then
+                if     os.isdir(path.join(package:installdir(), "x64")) then arch = "x64"
+                elseif os.isdir(path.join(package:installdir(), "x86")) then arch = "x86"
                 end
             end
             local linkdir = (package:config("shared") and "lib" or "staticlib")

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -135,11 +135,16 @@ package("opencv")
 
     if on_check then
         on_check("windows|arm64", function (package)
+            import("core.tool.toolchain")
+            import("core.base.semver")
             if package:version() and package:version():lt("4.10.0") then
                 raise("current opencv version does not support windows/arm64!")
             end
             local vs = package:toolchain("msvc"):config("vs")
             assert(tonumber(vs) >= 2022, "opencv requires Visual Studio 2022 and later for arm targets")
+            local msvc = toolchain.load("msvc", {plat = package:plat(), arch = package:arch()})
+            local vs_sdkver = msvc:config("vs_sdkver")
+            assert(vs_sdkver and semver.match(vs_sdkver):gt("10.0.26100"), "package(opencv): need vs_sdkver > 10.0.26100")
         end)
     end
 

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -259,10 +259,9 @@ package("opencv")
             elseif package:is_arch("arm64") then arch = "ARM64"
             end
             -- Workaround for arm64
-            if package:is_arch("arm64") and not os.isdir(path.join(package:installdir(), "ARM64")) then
-                if     os.isdir(path.join(package:installdir(), "x64")) then arch = "x64"
-                elseif os.isdir(path.join(package:installdir(), "x86")) then arch = "x86"
-                end
+            if package:is_arch("arm64") then
+                os.trymv(path.join(package:installdir(), "x64"), path.join(package:installdir(), "ARM64"))
+                os.trymv(path.join(package:installdir(), "x86"), path.join(package:installdir(), "ARM64"))
             end
             local linkdir = (package:config("shared") and "lib" or "staticlib")
             local vs = package:toolchain("msvc"):config("vs")

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -241,10 +241,11 @@ package("opencv")
             package:add("links", reallink)
         end
         if package:is_plat("android") then
-            local linkdir = (package:config("shared") and "lib" or "staticlibs")
+            local linkdir = (package:config("shared") and "libs" or "staticlibs")
+            local libname = "lib*." .. (package:config("shared") and "so" or "a")
             local libfiles = {}
-            table.join2(libfiles, os.files(path.join(package:installdir(), "sdk/native", linkdir, package:targetarch(), "lib*.a")))
-            table.join2(libfiles, os.files(path.join(package:installdir(), "sdk/native/3rdparty/libs", package:targetarch(), "lib*.a")))
+            table.join2(libfiles, os.files(path.join(package:installdir(), "sdk/native", linkdir, package:targetarch(), libname)))
+            table.join2(libfiles, os.files(path.join(package:installdir(), "sdk/native/3rdparty/libs", package:targetarch(), libname)))
             for _, f in ipairs(libfiles) do
                 if not f:match("opencv_.+") then
                     package:add("links", path.basename(f):match("lib(.+)"))

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -180,8 +180,13 @@ package("opencv")
             if package:is_arch("arm64") then
                 -- https://github.com/opencv/opencv/issues/25052
                 table.insert(configs, "-DCPU_NEON_FP16_SUPPORTED=OFF")
+                -- Newest Windows ARM worker issue
+                if package:has_runtime("MT", "MTd") then
+                    table.insert(configs, "-DCPU_NEON_DOTPROD_SUPPORTED=OFF")
+                end
                 -- https://github.com/opencv/opencv/issues/24235
                 table.insert(configs, "-DOPENCV_SKIP_SYSTEM_PROCESSOR_DETECTION=ON")
+                -- Enforce ARM64 without check
                 table.insert(configs, "-DAARCH64=ON")
             end
         end
@@ -226,9 +231,7 @@ package("opencv")
                 shflags = {"-Wl,-Bsymbolic"}
             end
         end
-        local envs = {}
-        envs.OPENCV_DUMP_CONFIG = 1
-        import("package.tools.cmake").install(package, configs, {envs = envs, buildir = "bd", shflags = shflags, ldflags = ldflags})
+        import("package.tools.cmake").install(package, configs, {buildir = "bd", shflags = shflags, ldflags = ldflags})
         for _, link in ipairs({"opencv_phase_unwrapping", "opencv_surface_matching", "opencv_saliency",
                                "opencv_wechat_qrcode", "opencv_mcc", "opencv_face",
                                "opencv_img_hash", "opencv_videostab", "opencv_structured_light", "opencv_intensity_transform",

--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -103,6 +103,7 @@ package("opencv")
             local arch = package:targetarch()
             local linkdir = (package:config("shared") and "lib" or "staticlibs")
             package:add("linkdirs", path.join("sdk/native", linkdir, package:targetarch()))
+            package:add("linkdirs", path.join("sdk/native/3rdparty/libs", package:targetarch()))
             package:add("includedirs", "sdk/native/jni/include")
         elseif package:version():ge("4.0") then
             package:add("includedirs", "include/opencv4")


### PR DESCRIPTION
- Add support of Android opencv in xrepo
- Disabling Android tests `-DBUILD_ANDROID_EXAMPLES=OFF` as it causes issues. see https://github.com/opencv/opencv/issues/15769#issuecomment-549570072
- Got issues from Android-Determine.cmake (cmake 3.28) : Android: Unknown processor CMAKE_SYSTEM_PROCESSOR=arm64-v8a, looking into the file it appears that we should map arm64-v8a to aarch64 by passing it to -DCMAKE_SYSTEM_PROCESSOR=aarch64
[Need to way a clean way to handle it] ==> done: setting the `DCMAKE_ANDROID_ARCH_ABI` instead of `DCMAKE_SYSTEM_PROCESSOR` for Android seems the right way to do it.

Testing locally by running `xmake l scripts/test.lua -v -D --shallow -p android --ndk=~/android-ndk-r28b --ndk_sdkver=32 -a arm64-v8a opencv`
and for shared:
`xmake l scripts/test.lua -v -D --shallow -p android --ndk=~/android-ndk-r27c --ndk_sdkver=32 -a arm64-v8a -k shared opencv`

