### PR TITLE
Auto-update yy-thunks to 1.1.7

### DIFF
--- a/packages/y/yy-thunks/xmake.lua
+++ b/packages/y/yy-thunks/xmake.lua
@@ -14,6 +14,7 @@ package("yy-thunks")
     })
     add_urls("https://github.com/Chuyu-Team/YY-Thunks/releases/download/v$(version)/YY-Thunks-$(version)-Binary.zip")
 
+    add_versions("1.1.7", "c3066f3f074ebc2a89b2def5f427bdea238dee17349d2bab579af519781691ab")
     add_versions("1.1.6", "fa4de6bda69f476907f780f63f3dda792537a2e3236cd23043a490c6b91cb0b5")
     add_versions("1.1.5", "e6e2bb6e6b46f8b2b4af4cff2b2b754b123837a3c72f1cd5d7a5bfdf3c0df82a")
     add_versions("1.1.4", "f9850a35d1f2b0cae15e64da516de0ec5e798c060b320e91788aa33b853e85ba")


### PR DESCRIPTION
New version of yy-thunks detected (package version: 1.1.6, last github version: 1.1.7)