### PR TITLE
Auto-update robin-map to v1.4.0

### DIFF
--- a/packages/r/robin-map/xmake.lua
+++ b/packages/r/robin-map/xmake.lua
@@ -6,6 +6,7 @@ package("robin-map")
     set_license("MIT")
 
     add_urls("https://github.com/Tessil/robin-map/archive/refs/tags/$(version).tar.gz")
+    add_versions("v1.4.0", "7930dbf9634acfc02686d87f615c0f4f33135948130b8922331c16d90a03250c")
     add_versions("v1.3.0", "a8424ad3b0affd4c57ed26f0f3d8a29604f0e1f2ef2089f497f614b1c94c7236")
     add_versions("v1.2.2", "c72767ecea2a90074c7efbe91620c8f955af666505e22782e82813c652710821")
     add_versions("v1.2.1", "2b54d2c1de2f73bea5c51d5dcbd64813a08caf1bfddcfdeee40ab74e9599e8e3")

--- a/packages/r/robin-map/xmake.lua
+++ b/packages/r/robin-map/xmake.lua
@@ -1,11 +1,12 @@
 package("robin-map")
-
     set_kind("library", {headeronly = true})
     set_homepage("https://github.com/Tessil/robin-map")
     set_description("A C++ implementation of a fast hash map and hash set using robin hood hashing")
     set_license("MIT")
 
-    add_urls("https://github.com/Tessil/robin-map/archive/refs/tags/$(version).tar.gz")
+    add_urls("https://github.com/Tessil/robin-map/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/Tessil/robin-map.git")
+
     add_versions("v1.4.0", "7930dbf9634acfc02686d87f615c0f4f33135948130b8922331c16d90a03250c")
     add_versions("v1.3.0", "a8424ad3b0affd4c57ed26f0f3d8a29604f0e1f2ef2089f497f614b1c94c7236")
     add_versions("v1.2.2", "c72767ecea2a90074c7efbe91620c8f955af666505e22782e82813c652710821")
@@ -18,6 +19,12 @@ package("robin-map")
     end)
 
     on_test(function (package)
+        local languages
+        if package:version() and package:version():ge("1.4.0") then
+            languages = "c++17"
+        else
+            languages = "c++11"
+        end
         assert(package:check_cxxsnippets({test = [[
             void test() {
                 tsl::robin_map<int, int> map = {{1, 1}, {2, 1}, {3, 1}};
@@ -25,5 +32,5 @@ package("robin-map")
                     it.value() = 2;
                 }
             }
-        ]]}, {configs = {languages = "c++11"}, includes = "tsl/robin_map.h"}))
+        ]]}, {configs = {languages = languages}, includes = "tsl/robin_map.h"}))
     end)


### PR DESCRIPTION
New version of robin-map detected (package version: v1.3.0, last github version: v1.4.0)