### PR TITLE
Auto-update librdkafka to v2.10.0

### DIFF
--- a/packages/l/librdkafka/xmake.lua
+++ b/packages/l/librdkafka/xmake.lua
@@ -4,6 +4,7 @@ package("librdkafka")
 
     add_urls("https://github.com/edenhill/librdkafka/archive/refs/tags/$(version).tar.gz",
              "https://github.com/edenhill/librdkafka.git")
+    add_versions("v2.10.0", "004b1cc2685d1d6d416b90b426a0a9d27327a214c6b807df6f9ea5887346ba3a")
     add_versions("v1.6.2", "b9be26c632265a7db2fdd5ab439f2583d14be08ab44dc2e33138323af60c39db")
     add_versions("v1.8.2-POST2", "d556d07cb88ea689e28c8e058ec3265ab333c9fc5e8f4ac0b7509bb5ae0e9f25")
 


### PR DESCRIPTION
New version of librdkafka detected (package version: v1.8.2-POST2, last github version: v2.10.0)