### PR TITLE
Auto-update grpc to v1.72.0

### DIFF
--- a/packages/g/grpc/xmake.lua
+++ b/packages/g/grpc/xmake.lua
@@ -6,6 +6,7 @@ package("grpc")
     add_urls("https://github.com/grpc/grpc/archive/refs/tags/$(version).zip",
              "https://github.com/grpc/grpc.git")
 
+    add_versions("v1.72.0", "ed5298b95ca6d1c2fb2410071e64c944cda23a98179902d701cad42edeb39c5d")
     add_versions("v1.69.0", "987763312292c8a6088108173ccde2b336a40f35ae22b5b7b3744e44929aaf9f")
     add_versions("v1.51.3", "17720fd0a690e904a468b4b3dae6fa5ec40b0d1f4d418e2ca092e2f92f06fce0")
     add_versions("v1.62.1", "f672a3a3b370f2853869745110dabfb6c13af93e17ffad4676a0b95b5ec204af")


### PR DESCRIPTION
New version of grpc detected (package version: v1.69.0, last github version: v1.72.0)