### PR TITLE
Auto-update libsais to v2.10.1

### DIFF
--- a/packages/l/libsais/xmake.lua
+++ b/packages/l/libsais/xmake.lua
@@ -5,6 +5,7 @@ package("libsais")
 
     add_urls("https://github.com/IlyaGrebnov/libsais/archive/refs/tags/$(version).tar.gz",
              "https://github.com/IlyaGrebnov/libsais.git")
+    add_versions("v2.10.1", "ecf4611c18fefd8d4377343e4dc3f257ae17a501301a13f7cb7585c836405d39")
     add_versions("v2.10.0", "25c80c99945d7148b61ee4108dbda77e3dda605619ebfc7b880fd074af212b50")
     add_versions("v2.8.7", "c957a6955eac415088a879459c54141a2896edc9b40c457899ed2c4280b994c8")
     add_versions("v2.8.4", "6de93b078a89ea85ee03916a7a9cfb1003a9946dee9d1e780a97c84d80b49476")


### PR DESCRIPTION
New version of libsais detected (package version: v2.10.0, last github version: v2.10.1)