### PR TITLE
readline: extend platform support

### DIFF
--- a/packages/n/ncurses/xmake.lua
+++ b/packages/n/ncurses/xmake.lua
@@ -45,6 +45,8 @@ package("ncurses")
             "--with-gpm=no",
             "--without-tests",
             "--without-ada",
+            "--enable-pc-files",
+            "--with-pkg-config-libdir=" .. path.unix(package:installdir("lib", "pkgconfig")):gsub("^(%a):", "/%1"),
         }
 
         table.insert(configs, "--with-debug=" .. (package:is_debug() and "yes" or "no"))

--- a/packages/n/ncurses/xmake.lua
+++ b/packages/n/ncurses/xmake.lua
@@ -45,7 +45,12 @@ package("ncurses")
         table.insert(configs, "--with-debug=" .. (package:is_debug() and "yes" or "no"))
         table.insert(configs, "--with-shared=" .. (package:config("shared") and "yes" or "no"))
         table.insert(configs, "--enable-widec=" .. (package:config("widec") and "yes" or "no"))
-        import("package.tools.autoconf").install(package, configs, {arflags = {"-curvU"}})
+
+        local cflags = {}
+        if package:version():le("6.5") then
+            table.insert(cflags, "-std=c17")
+        end
+        import("package.tools.autoconf").install(package, configs, {cflags = cflags, arflags = {"-curvU"}})
     end)
 
     on_test(function (package)

--- a/packages/r/readline/patches/8.2.13/mingw_fd_set.patch
+++ b/packages/r/readline/patches/8.2.13/mingw_fd_set.patch
@@ -1,0 +1,26 @@
+diff --git a/input.c b/input.c
+index 6f038d4..da4da45 100644
+--- a/input.c
++++ b/input.c
+@@ -818,7 +820,7 @@ rl_getc (FILE *stream)
+       /* We know at this point that _rl_caught_signal == 0 */
+ 
+ #if defined (__MINGW32__)
+-      if (isatty (fd)
++      if (isatty (fd))
+ 	return (_getch ());	/* "There is no error return." */
+ #endif
+       result = 0;
+diff --git a/rlprivate.h b/rlprivate.h
+index d87d07a..cb9cf17 100644
+--- a/rlprivate.h
++++ b/rlprivate.h
+@@ -303,7 +303,7 @@ extern int _rl_pushed_input_available (void);
+ 
+ extern int _rl_timeout_init (void);
+ extern int _rl_timeout_handle_sigalrm (void);
+-#if defined (_POSIXSELECT_H_)
++#if defined (RL_TIMEOUT_USE_SELECT)
+ /* use as a sentinel for fd_set, struct timeval,  and sigset_t definitions */
+ extern int _rl_timeout_select (int, fd_set *, fd_set *, fd_set *, const struct timeval *, const sigset_t *);
+ #endif

--- a/packages/r/readline/xmake.lua
+++ b/packages/r/readline/xmake.lua
@@ -13,7 +13,7 @@ package("readline")
     add_deps("ncurses")
 
     on_install("linux", "macosx", function (package)
-        local configs = {"--with-curses"}
+        local configs = {"--with-curses", "--disable-install-examples"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
         import("package.tools.autoconf").install(package, configs)

--- a/packages/r/readline/xmake.lua
+++ b/packages/r/readline/xmake.lua
@@ -16,12 +16,6 @@ package("readline")
         local configs = {"--with-curses"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
-        if package:is_debug() then
-            table.insert(configs, "--enable-debug")
-        end
-        if package:config("pic") ~= false then
-            table.insert(configs, "--with-pic")
-        end
         import("package.tools.autoconf").install(package, configs)
     end)
 

--- a/packages/r/readline/xmake.lua
+++ b/packages/r/readline/xmake.lua
@@ -6,6 +6,7 @@ package("readline")
     add_urls("https://ftpmirror.gnu.org/readline/readline-$(version).tar.gz",
              "https://ftp.gnu.org/gnu/readline/readline-$(version).tar.gz")
 
+    add_versions("8.2.13", "0e5be4d2937e8bd9b7cd60d46721ce79f88a33415dd68c2d738fb5924638f656")
     add_versions("8.2", "3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35")
     add_versions("8.1", "f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02")
 

--- a/packages/r/readline/xmake.lua
+++ b/packages/r/readline/xmake.lua
@@ -10,18 +10,40 @@ package("readline")
     add_versions("8.2", "3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35")
     add_versions("8.1", "f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02")
 
+    if is_plat("mingw", "cygwin", "msys") then
+        add_patches("8.2.13", "patches/8.2.13/mingw_fd_set.patch", "3b5576e51471b248f5c89e0d4c01ac0bc443a239169fa19e25980f9a923f659a")
+    end
+
     add_deps("ncurses")
 
-    on_install("linux", "macosx", function (package)
+    on_install("!wasm and !iphoneos and @!windows", function (package)
         local configs = {"--with-curses", "--disable-install-examples"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
+
+        io.replace("support/shobj-conf", "-Wl,-rpath,$(libdir)", "", {plain = true}) -- Remove RPATH from shared objects (FS#14366)
+        local makefile_inputs = {"Makefile.in", "shlib/Makefile.in"}
+        local SHLIB_LIBS = package:dep("ncurses"):config("widec") and "-lncursesw" or "-lncurses"
+        for _, makefile_input in ipairs(makefile_inputs) do
+            io.replace(makefile_input, "@SHLIB_LIBS@", SHLIB_LIBS, {plain = true})
+        end
+        if is_host("windows") then
+            -- Avoid issues with /c/dir style paths
+            for _, makefile_input in ipairs(makefile_inputs) do
+                io.replace(makefile_input, "@BUILD_DIR@", path.unix(os.curdir()), {plain = true}) -- C:/dir
+            end
+        end
 
         local cflags = {}
         if package:version():le("8.2.13") then
             table.insert(cflags, "-std=c17")
         end
-        import("package.tools.autoconf").install(package, configs, {cflags = cflags})
+        if package:is_plat("mingw", "cygwin", "msys") then
+            table.insert(cflags, "-DNEED_EXTERN_PC=1") -- Use extern PC variable from ncurses
+            table.join2(cflags, {"-D__USE_MINGW_ALARM", "-D_POSIX"}) -- Make mingw-w64 provide a dummy alarm() function
+            io.replace("support/shobj-conf", "--export-all", "--export-all-symbols", {plain = true})
+        end
+        import("package.tools.autoconf").install(package, configs, {cflags = cflags, packagedeps = {"ncurses"}})
     end)
 
     on_test(function (package)

--- a/packages/r/readline/xmake.lua
+++ b/packages/r/readline/xmake.lua
@@ -16,7 +16,12 @@ package("readline")
         local configs = {"--with-curses", "--disable-install-examples"}
         table.insert(configs, "--enable-shared=" .. (package:config("shared") and "yes" or "no"))
         table.insert(configs, "--enable-static=" .. (package:config("shared") and "no" or "yes"))
-        import("package.tools.autoconf").install(package, configs)
+
+        local cflags = {}
+        if package:version():le("8.2.13") then
+            table.insert(cflags, "-std=c17")
+        end
+        import("package.tools.autoconf").install(package, configs, {cflags = cflags})
     end)
 
     on_test(function (package)


### PR DESCRIPTION
This PR improves platform support for `readline`.

**Side Note: Impact of `CFLAGS` on `autotools` Optimization Levels**

A noteworthy behavior was identified with `autotools`-based builds:
Setting the `CFLAGS` environment variable overrides the default compiler flags that `autoconf` would otherwise establish. Critically, if these user-supplied `CFLAGS` lack optimization specifications (e.g., `-O2`), the build process defaults to the compiler's base optimization level, typically `-O0`.

This is distinct from CMake's approach, where build-type-specific flags (e.g., `CMAKE_C_FLAGS_RELEASE`) are additive to `CMAKE_C_FLAGS`, generally ensuring optimized release builds. The `autotools` behavior can inadvertently result in packages being built without intended optimizations if `CFLAGS` is set.