### PR TITLE
Auto-update onnx to v1.18.0

### DIFF
--- a/packages/o/onnx/patches/1.18.0/cmake-abseil.patch
+++ b/packages/o/onnx/patches/1.18.0/cmake-abseil.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0ce8dd4b..daccdbc3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -503,13 +503,13 @@ if(ONNX_USE_LITE_PROTO)
+   if(TARGET protobuf::libprotobuf-lite)
+     target_link_libraries(onnx_proto PUBLIC protobuf::libprotobuf-lite PRIVATE ${protobuf_ABSL_USED_TARGETS})
+   else()
+-    target_link_libraries(onnx_proto PUBLIC ${PROTOBUF_LITE_LIBRARIES})
++    target_link_libraries(onnx_proto PUBLIC ${PROTOBUF_LITE_LIBRARIES} ${protobuf_ABSL_USED_TARGETS})
+   endif()
+ else()
+   if(TARGET protobuf::libprotobuf)
+     target_link_libraries(onnx_proto PUBLIC protobuf::libprotobuf PRIVATE ${protobuf_ABSL_USED_TARGETS})
+   else()
+-    target_link_libraries(onnx_proto PUBLIC ${PROTOBUF_LIBRARIES})
++    target_link_libraries(onnx_proto PUBLIC ${PROTOBUF_LIBRARIES} ${protobuf_ABSL_USED_TARGETS})
+   endif()
+ endif()
+ add_onnx_global_defines(onnx_proto)
+@@ -528,7 +528,7 @@ target_include_directories(onnx PUBLIC
+   $<BUILD_INTERFACE:${ONNX_ROOT}>
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+   $<INSTALL_INTERFACE:include>)
+-target_link_libraries(onnx PUBLIC onnx_proto)
++target_link_libraries(onnx PUBLIC onnx_proto ${protobuf_ABSL_USED_TARGETS})
+ add_onnx_global_defines(onnx)
+ 
+ if(ONNX_BUILD_PYTHON)
+ 

--- a/packages/o/onnx/xmake.lua
+++ b/packages/o/onnx/xmake.lua
@@ -15,7 +15,8 @@ package("onnx")
     add_versions("v1.11.0", "a20f2d9df805b16ac75ab4da0a230d3d1c304127d719e5c66a4e6df514e7f6c0")
     add_versions("v1.12.0", "052ad3d5dad358a33606e0fc89483f8150bb0655c99b12a43aa58b5b7f0cc507")
 
-    add_patches(">=1.16.0", "patches/1.16.0/cmake-abseil.patch", "d8cad2b231ce01aa3263692f88293be3eaa2b380e021eb5288f4c7ea930c19cb")
+    add_patches(">=1.18.0", "patches/1.18.0/cmake-abseil.patch", "f7c57011c7d0c14b6b7fcbfcb99b01a20a5586f22d5a30004fbb899b55c982b6")
+    add_patches(">=1.16.0<=1.17.0", "patches/1.16.0/cmake-abseil.patch", "d8cad2b231ce01aa3263692f88293be3eaa2b380e021eb5288f4c7ea930c19cb")
 
     add_configs("exceptions", {description = "Enable exception handling", default = true, type = "boolean"})
     add_configs("registration", {description = "Enable static registration for onnx operator schemas.", default = true, type = "boolean"})
@@ -33,12 +34,12 @@ package("onnx")
     end)
 
     on_install("!mingw", function (package)
-        local version = package:version()
-
         io.replace("CMakeLists.txt", [[set(ONNX_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})]],
             "set(ONNX_PROTOC_EXECUTABLE protoc)", {plain = true})
         io.replace("cmake/Utils.cmake", "target_compile_options(${lib} PRIVATE $<$<NOT:$<CONFIG:Debug>>:/MT> $<$<CONFIG:Debug>:/MTd>)", "", {plain = true})
         io.replace("cmake/Utils.cmake", "target_compile_options(${lib} PRIVATE $<$<NOT:$<CONFIG:Debug>>:/MD> $<$<CONFIG:Debug>:/MDd>)", "", {plain = true})
+
+        local version = package:version()
 
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
@@ -54,7 +55,7 @@ package("onnx")
 
     on_test(function (package)
         local languages = "c++11"
-        if package:is_plat("windows") or package:gitref() or package:version():ge("1.16.0") then
+        if package:is_plat("windows") or (package:version() or package:version():ge("1.16.0")) then
             languages = "c++17"
         end
         assert(package:check_cxxsnippets({test = [[

--- a/packages/o/onnx/xmake.lua
+++ b/packages/o/onnx/xmake.lua
@@ -6,6 +6,7 @@ package("onnx")
     add_urls("https://github.com/onnx/onnx/archive/refs/tags/$(version).tar.gz",
              "https://github.com/onnx/onnx.git", {submodules = false})
 
+    add_versions("v1.18.0", "b466af96fd8d9f485d1bb14f9bbdd2dfb8421bc5544583f014088fb941a1d21e")
     add_versions("v1.17.0", "8d5e983c36037003615e5a02d36b18fc286541bf52de1a78f6cf9f32005a820e")
     add_versions("v1.16.2", "84fc1c3d6133417f8a13af6643ed50983c91dacde5ffba16cc8bb39b22c2acbb")
     add_versions("v1.16.1", "0e6aa2c0a59bb2d90858ad0040ea1807117cc2f05b97702170f18e6cd6b66fb3")


### PR DESCRIPTION
New version of onnx detected (package version: v1.17.0, last github version: v1.18.0)