### PR TITLE
Auto-update abseil to 20250512.0

### DIFF
--- a/packages/a/abseil/xmake.lua
+++ b/packages/a/abseil/xmake.lua
@@ -6,6 +6,7 @@ package("abseil")
     add_urls("https://github.com/abseil/abseil-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/abseil/abseil-cpp.git")
 
+    add_versions("20250512.0", "7262daa7c1711406248c10f41026d685e88223bc92817d16fb93c19adb57f669")
     add_versions("20250127.1", "b396401fd29e2e679cace77867481d388c807671dc2acc602a0259eeb79b7811")
     add_versions("20200225.1", "0db0d26f43ba6806a8a3338da3e646bb581f0ca5359b3a201d8fb8e4752fd5f8")
     add_versions("20210324.1", "441db7c09a0565376ecacf0085b2d4c2bbedde6115d7773551bc116212c2a8d6")


### PR DESCRIPTION
New version of abseil detected (package version: 20250127.1, last github version: 20250512.0)