### PR TITLE
tao_idl: add package

### DIFF
--- a/packages/a/ace/xmake.lua
+++ b/packages/a/ace/xmake.lua
@@ -1,6 +1,7 @@
 package("ace")
     set_homepage("https://www.dre.vanderbilt.edu/~schmidt/ACE.html")
     set_description("ACE (ADAPTIVE Communication Environment) is a C++ framework for implementing distributed and networked applications.")
+    set_license("DocumentRef-COPYING:LicenseRef-DOC-License")
 
     add_urls("https://github.com/DOCGroup/ACE_TAO/releases/download/$(version).tar.gz", {version = function (version) 
         return "ACE%2BTAO-" .. version:gsub("%.", "_")  .. "/ACE-" .. version

--- a/packages/a/ace/xmake.lua
+++ b/packages/a/ace/xmake.lua
@@ -1,7 +1,7 @@
 package("ace")
     set_homepage("https://www.dre.vanderbilt.edu/~schmidt/ACE.html")
     set_description("ACE (ADAPTIVE Communication Environment) is a C++ framework for implementing distributed and networked applications.")
-    set_license("DocumentRef-COPYING:LicenseRef-DOC-License")
+    set_license("DOC")
 
     add_urls("https://github.com/DOCGroup/ACE_TAO/releases/download/$(version).tar.gz", {version = function (version) 
         return "ACE%2BTAO-" .. version:gsub("%.", "_")  .. "/ACE-" .. version

--- a/packages/t/tao_idl/xmake.lua
+++ b/packages/t/tao_idl/xmake.lua
@@ -1,0 +1,96 @@
+package("tao_idl")
+    set_kind("binary")
+    set_homepage("https://www.dre.vanderbilt.edu/~schmidt/TAO.html")
+    set_description("tao_idl is TAO's Interface Description Language (IDL) compiler, based on Sun Microsystems' OMG IDL Compiler Front End (CFE) version 1.3, implements most IDL v3 & some IDL v4 features.")
+    set_license("DocumentRef-COPYING:LicenseRef-DOC-License")
+
+    add_urls("https://github.com/DOCGroup/ACE_TAO/releases/download/$(version).tar.gz", {version = function (version) 
+        return "ACE%2BTAO-" .. version:gsub("%.", "_")  .. "/ACE%2BTAO-" .. version
+    end})
+
+    add_versions("8.0.3", "b9130369be615f75042504d1e22ae6bcba20f0068de31787182f46381ec85340")
+
+    add_deps("ace", {configs = {shared = true}})
+
+    on_load(function (package)
+        package:addenv("PATH", "bin")
+    end)
+
+    on_install("windows", function(package)
+        import("package.tools.msbuild")
+        local include_paths = {"..", "include", "be_include", "fe"}
+        local lib_paths = {"../../lib"}
+        -- Fetch *ace* dependency
+        local packagedep = package:dep("ace")
+        if packagedep then
+            local fetchinfo = packagedep:fetch()
+            if fetchinfo then
+                for _, includedir in ipairs(fetchinfo.includedirs or fetchinfo.sysincludedirs) do
+                    table.insert(include_paths, includedir)
+                end
+                for _, linkdir in ipairs(fetchinfo.linkdirs) do
+                    table.insert(lib_paths, linkdir)
+                end
+            end
+        end
+        os.cd("TAO/TAO_IDL")
+        -- Prepare .vcxproj formatted
+        for _, vcxproj in ipairs({
+            "TAO_IDL_FE_vs2022.vcxproj",
+            "TAO_IDL_BE_vs2022.vcxproj",
+            "TAO_IDL_BE_VIS_A_vs2022.vcxproj",
+            "TAO_IDL_BE_VIS_C_vs2022.vcxproj",
+            "TAO_IDL_BE_VIS_E_vs2022.vcxproj",
+            "TAO_IDL_BE_VIS_I_vs2022.vcxproj",
+            "TAO_IDL_BE_VIS_O_vs2022.vcxproj",
+            "TAO_IDL_BE_VIS_S_vs2022.vcxproj",
+            "TAO_IDL_BE_VIS_U_vs2022.vcxproj",
+            "TAO_IDL_BE_VIS_V_vs2022.vcxproj",
+            "TAO_IDL_EXE_vs2022.vcxproj"
+        }) do
+            io.replace(vcxproj,
+                "<AdditionalIncludeDirectories>.-</AdditionalIncludeDirectories>",
+                "<AdditionalIncludeDirectories>" .. table.concat(include_paths, ";") .. "</AdditionalIncludeDirectories>", {plain = false})
+            io.replace(vcxproj,
+                "<AdditionalLibraryDirectories>.-</AdditionalLibraryDirectories>",
+                "<AdditionalLibraryDirectories>" .. table.concat(lib_paths, ";") .. "</AdditionalLibraryDirectories>", {plain = false})
+            if package:has_runtime("MT", "MTd") then
+                -- Allow MT, MTd
+                io.replace(vcxproj, "<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>", "<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>", {plain = true})
+                io.replace(vcxproj, "<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>", "<RuntimeLibrary>MultiThreaded</RuntimeLibrary>", {plain = true})
+            end
+            -- Allow use another Win SDK
+            io.replace(vcxproj, "<WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>", "", {plain = true})
+            -- Disable LTCG
+            io.replace(vcxproj, "<WholeProgramOptimization>true</WholeProgramOptimization>", "", {plain = true})
+        end
+        -- Build & install .exe
+        local configs = { "TAO_IDL_vs2022.sln", 
+        "/t:TAO_IDL_FE;TAO_IDL_BE;TAO_IDL_BE_VIS_A;TAO_IDL_BE_VIS_C;TAO_IDL_BE_VIS_E;TAO_IDL_BE_VIS_I;TAO_IDL_BE_VIS_O;TAO_IDL_BE_VIS_S;TAO_IDL_BE_VIS_U;TAO_IDL_BE_VIS_V;TAO_IDL_EXE"}
+        local arch = package:is_arch("x64") and "x64" or "Win32"
+        if package:is_arch("arm64") then
+            arch = "ARM64"
+        end
+        local mode = package:is_debug() and "Debug" or "Release"
+        table.insert(configs, "/p:Configuration=" .. mode)
+        table.insert(configs, "/p:Platform=" .. arch)
+        -- Wrap vstool so it would build for another vstools
+        local msvc = import("core.tool.toolchain").load("msvc")
+        local vs = msvc:config("vs")
+        local vstool
+        if     vs == "2015" then vstool = "v140"
+        elseif vs == "2017" then vstool = "v141"
+        elseif vs == "2019" then vstool = "v142"
+        elseif vs == "2022" then vstool = "v143"
+        end
+        table.insert(configs, "/p:PlatformToolset=" .. vstool)
+        msbuild.build(package, configs)
+        os.cd("../..")
+        os.cp("**.exe", package:installdir("bin"))
+        os.cp("**.lib", package:installdir("lib"))
+        os.trycp("**.dll", package:installdir("bin"))
+    end)
+
+    on_test(function (package)
+        os.vrun("tao_idl -h")
+    end)

--- a/packages/t/tao_idl/xmake.lua
+++ b/packages/t/tao_idl/xmake.lua
@@ -94,6 +94,8 @@ package("tao_idl")
         os.cp("**.exe", package:installdir("bin"))
         os.cp("**.lib", package:installdir("lib"))
         os.trycp("**.dll", package:installdir("bin"))
+        os.rm(path.join(package:installdir(), "bin", "PXI_Reset.exe"))
+        os.rm(path.join(package:installdir(), "bin", "Reboot_Target.exe"))
     end)
 
     on_test(function (package)

--- a/packages/t/tao_idl/xmake.lua
+++ b/packages/t/tao_idl/xmake.lua
@@ -2,7 +2,7 @@ package("tao_idl")
     set_kind("binary")
     set_homepage("https://www.dre.vanderbilt.edu/~schmidt/TAO.html")
     set_description("tao_idl is TAO's Interface Description Language (IDL) compiler, based on Sun Microsystems' OMG IDL Compiler Front End (CFE) version 1.3, implements most IDL v3 & some IDL v4 features.")
-    set_license("DocumentRef-COPYING:LicenseRef-DOC-License")
+    set_license("DOC")
 
     add_urls("https://github.com/DOCGroup/ACE_TAO/releases/download/$(version).tar.gz", {version = function (version) 
         return "ACE%2BTAO-" .. version:gsub("%.", "_")  .. "/ACE%2BTAO-" .. version

--- a/packages/t/tao_idl/xmake.lua
+++ b/packages/t/tao_idl/xmake.lua
@@ -92,11 +92,8 @@ package("tao_idl")
         end
         os.cd("../..")
         os.cp("**.exe", package:installdir("bin"))
-        print(os.files("**.exe"))
         os.cp("**.lib", package:installdir("lib"))
-        print(os.files("**.lib"))
         os.trycp("**.dll", package:installdir("bin"))
-        print(os.files("**.dll"))
     end)
 
     on_test(function (package)

--- a/packages/t/tao_idl/xmake.lua
+++ b/packages/t/tao_idl/xmake.lua
@@ -34,7 +34,7 @@ package("tao_idl")
             end
         end
         os.cd("TAO/TAO_IDL")
-        -- Prepare .vcxproj formatted
+        -- Prepare .vcxproj using config & de-bundle ace dependency
         for _, vcxproj in ipairs({
             "TAO_IDL_FE_vs2022.vcxproj",
             "TAO_IDL_BE_vs2022.vcxproj",


### PR DESCRIPTION
```
tao_idl -h
tao_idl: usage: tao_idl [[flag|file] ...] [-- file ...]
Legal flags:
 -h | --help | -u       Print this list and exit successfully
 -A...                  local implementation-specific escape
 -Cw                    Warning if identifier spellings differ only in case (default is error)
 -Ce                    Error if identifier spellings differ only in case (default)
 -ae                    Error if anonymous type is seen (default)
 -aw                    Warning if anonymous type is seen (default is error)
 -as                    Silences the anonymous type diagnostic (default is error)
 -d | --dump            Prints a dump of the AST and exits
 -Dname[=value]         defines name for preprocessor
 -E                     runs preprocessor only, prints on stdout
 -Idir                  includes dir in search path for preprocessor
 -t                     Temporary directory to be used by the IDL compiler.
 -Uname                 undefines name for preprocessor
 -v                     traces compilation stages
 -V | --version         prints version info then exits
 -w                     suppresses IDL compiler warning messages
 -Wp,<arg1,...,argn>    passes args to preprocessor
 -Yp,path               defines location of preprocessor
 --idl-version VERSION  Set the version of IDL to use
 --default-idl-version  Print the default IDL version and exit
 --list-idl-versions    Print IDL versions supported and exit
 --syntax-only          Just check the syntax, do not create files
 --bison-trace          Enable Bison Tracing (sets yydebug to 1)
 --dump-builtins        Dump the compiler and user defined IDL.
 --just-dump-builtins   Just dump the compiler defined IDL and exit.
 --unknown-annotations ARG      Set reaction to unknown annotations. ARG must be one of the following:
                                warn-once       The default, warn once per unique local name
                                warn-all        Warn for all unknown annotations
                                error           Causes the process to exit with a failed return status
                                ignore          Don't report unknown annotations
 -Wb,export_macro=<macro name>                  sets export macro for all files
 -Wb,export_include=<include path>              sets export include file for all files
 -Wb,stub_export_macro=<macro name>             sets export macro for client files only
 -Wb,stub_export_include=<include path>         sets export include file for client only
 -Wb,stub_export_file=<filename>                sets export file for client only
 -Wb,skel_export_macro=<macro name>             sets export macro for server files only
 -Wb,skel_export_include=<include path>         sets export include file for server only
 -Wb,skel_export_file=<include path>            sets export file for server only
 -Wb,anyop_export_macro=<macro name>            sets export macro for typecode/Any operator files only, when -GA option is used
 -Wb,anyop_export_include=<include path>        sets export include file for typecode/Any operator files only, when -GA option is used
 -Wb,svnt_export_macro=<macro name>             sets export macro for CIAO servant files only, when -Gsv option is used
 -Wb,svnt_export_include=<include path>         sets export include file for CIAO servant files only, when -Gsv option is used
 -Wb,exec_export_macro=<macro name>             sets export macro for CIAO executor impl files only, when -Gex option is used
 -Wb,exec_export_include=<include path>         sets export include file for CIAO executor impl files only, when -Gex option is used
 -Wb,conn_export_macro=<macro name>             sets export macro for CIAO connector impl files only, when -Gcn option is used
 -Wb,conn_export_include=<include path>         sets export include file for CIAO connector impl files only, when -Gcn option is used
 -Wb,pch_include=<include path>                 sets include file for precompiled header mechanism
 -Wb,pre_include=<include path>                 sets include file generate before any other includes
 -Wb,post_include=<include path>                sets include file generated at the end of the file
 -Wb,include_guard=<include path>               guard to prevent the generated client header file
 -Wb,safe_include=<include path>                include that should be used instead of the own generated client header file
 -Wb,unique_include=<include path>              include that should be generated as only contents of the generated client header file.
 -Wb,stripped_filename=<filename>               filename that should be used as stripped_filename instead of input filename.
 -Wb,container_type=<type>                      type of container we generated
 -Wb,obv_opt_accessor                           optimizes access to base class data in valuetypes
 -Wb,versioning_begin                   Set text that opens a a "versioned" namespace
 -Wb,versioning_end                     Set text that closes a a "versioned" namespace
 -Wb,versioning_include                 Set text that will be used as include for a "versioned" namespace
 -Wb,no_fixed_err                       Don't generate an error when the fixed type is used
 -b                     Use a clonable argument type for oneway methods.
 -ci                    Client inline file name ending. Default is C.inl
 -cs                    Client stub's file name ending. Default is C.cpp
 -g <gperf_path>        Path for the GPERF program. Default is $ACE_ROOT/bin/ace_gperf
 -GC                    Generate the AMI classes
 -GH                    Generate the AMH classes
 -GM                    Generate the AMI4CCM classes
 -Gce                   Generate code optimized for CORBA/e
 -Gmc                   Generate code optimized for Minimum CORBA
 -Gcl                   Generate code optimized for LwCCM
 -Gcm                   Generate code optimized for noevent CCM
 -Gd                    Generate the code for direct collocation. Default is thru-POA collocation
 -Gos                   Generate std::ostream insertion operators.
 -GI[h|s|b|e|c|a|d]     Generate Implementation Files
                        h - Implementation header file name ending. Default is I.h
                        s - Implementation skeleton file name ending. Default is I.cpp
                        b - Prefix to the implementation class names. Default is 'no prefix'
                        e - Suffix to the implementation class names. Default is _i
                        c - Generate copy constructors in the servant implementation template files (off by default)
                        a - Generate assignment operators in the servant implementation template files (off by default)
                        d - Generate debug (source file/line#) information. (off by default)
 -Gp                    Generate the code for thru-POA collocation (default)
 -Gsp                   Generate the code for Smart Proxies
 -Gstl                  Generate the alternate C++ mapping for IDL strings and sequences
 -Gt                    enable optimized TypeCode support (unopt by default)
 -GT                    generate tie class (and file) generation (disabled by default)
                        No effect if TypeCode generation is suppressed
 -GA                    generate Any operator and type codes in *A.{h,cpp} (generated in *C.{h,cpp} by default)
 -Guc                   generate uninlined constant if declared in a module (inlined by default)
 -Gsd                   generate static description operations which can be useful for template programming (not generated by default)
 -Gse                   generate explicit export of sequence's template base class (not generated by default)
 -Gsv                   generate CIAO servant code (not generated by default)
 -Glem                  generate CIAO executor IDL (not generated by default)
 -Gex                   generate CIAO executor implementation code (not generated by default)
 -Gexr                  generate CIAO executor implementation code with an ACE_Reactor implementation (not generated by default)
 -Gcn                   generate CIAO connector implementation code (not generated by default)
 -Gts                   generate DDS type support IDL (not generated by default)
 -Gxhst                 generate export header file for stub (not generated by default)
 -Gxhsk                 generate export header file for skeleton (not generated by default)
 -Gxhsv                 generate export header file for CIAO servant (not generated by default)
 -Gxhex                 generate export header file for CIAO executor (not generated by default)
 -Gxhcn                 generate export header file for CIAO connector (not generated by default)
 -GX                    generate empty A.h file
 -hc                    Client's header file name ending. Default is C.h
 -hs                    Server's header file name ending. Default is S.h
 -hT                    Server's template hdr file name ending. Default is S_T.h
 -H perfect_hash        To force perfect hashed operation lookup strategy (default)
 -H dynamic_hash        To force dynamic hashed operation lookup strategy. Default is perfect hashing
 -H linear_search       To force linear search operation lookup strategy
 -H binary_search       To force binary search operation lookup strategy
 -in                    To generate <>s for standard #include'd files (non-changing files)
 -ic                    To generate ""s for standard #include'd files (changing files)
 -iC <path>             Include path for the generated stub files in *A.h. Can be relative to $TAO_ROOT or $CIAO_ROOT. Default is $TAO_ROOT/tao or current directory
 -o <output_dir>        Output directory for the generated files. Default is current directory
 -oS <output_dir>       Output directory for the generated skeleton files. Default is -o value or current directory
 -oA <output_dir>       Output directory for the generated anyopfiles. Default is -o value or current directory
 -oE <output_dir>       Output directory for the generated executor files, only when -Gex option is used. Default is current directory
 -oN    When -Gex option is used, executor files shouldn't be overwritten if they are already in the output directory.
 -ss                    Server's skeleton file name ending. Default is S.cpp
 -sT                    Server's template skeleton file name ending. Default is S_T.cpp
 -Sa                    suppress Any support (support enabled by default)
 -Sal                   suppress Any support for local interfaces (support enabled by default)
 -Scdr                  suppress CDR support (support enabled by default)
 -Sat                   suppress arg traits generation (arg traits generated by default)
 -St                    suppress TypeCode support (support enabled by default)
 -Sp                    suppress generating Thru POA collocated stubs (enabled by default)
 -Sd                    suppress generating Direct collocated stubs (disable by default)
 -Sm                    disable IDL3 equivalent IDL preprocessing (enabled by default)
 -SS                    suppress generating skeleton implementation (disabled by default)
 -Ssvntc                suppress generating servant implementation (disabled by default)
 -Ssvntt                suppress generating servant template files (disabled by default)
 -Sci                   suppress generating client inline file (disabled by default)
 -Sch                   suppress generating client header file (disabled by default)
 -Scc                   suppress generating client source file (disabled by default)
 -Ssh                   suppress generating skeleton header (disabled by default)
 -Sorb                  suppress generating include of ORB.h (disabled by default)
 -Sfr                   suppress generating valuetype factory registration in CIAO (generated by default)
 -Se                    disable custom header file name endings for files
                        that are found in TAO specific include directories,
                        (i.e. $TAO_ROOT, $TAO_ROOT/tao, $TAO_ROOT/orbsvcs,
                        $TAO_ROOT/CIAO, $TAO_ROOT/CIAO/ciao, $TAO_ROOT/CIAO/ccm)
                         (enabled by default)
 -Sg                    suppress generating of unique header guards (unique guards are generated by default)
 -TS <value>            set tab size for generated files (default is 2 spaces)
  => install tao_idl 8.0.3 .. ok
  ```

