### PR TITLE
Auto-update libde265 to 1.0.16

### DIFF
--- a/packages/l/libde265/xmake.lua
+++ b/packages/l/libde265/xmake.lua
@@ -18,7 +18,7 @@ package("libde265")
 
     add_deps("cmake")
 
-    on_load("windows", function (package)
+    on_load("windows", "mingw", "msys", function (package)
         if not package:config("shared") then
             package:add("defines", "LIBDE265_STATIC_BUILD")
         end
@@ -31,19 +31,7 @@ package("libde265")
         table.insert(configs, "-DDISABLE_SSE=" .. (package:is_arch("x86", "x64", "x86_64") and "OFF" or "ON"))
         table.insert(configs, "-DENABLE_ENCODER=" .. (package:config("tools") and "ON" or "OFF"))
         table.insert(configs, "-DENABLE_DECODER=" .. (package:config("tools") and "ON" or "OFF"))
-        if package:is_plat("windows") then
-            table.insert(configs, "-DCMAKE_COMPILE_PDB_OUTPUT_DIRECTORY=''")
-        end
         import("package.tools.cmake").install(package, configs)
-
-        if package:is_plat("windows") and package:is_debug() then
-            local dir = package:installdir(package:config("shared") and "bin" or "lib")
-            os.vcp(path.join(package:buildir(), "libde265/**.pdb"), dir)
-            if package:config("tools") then
-                os.vcp(path.join(package:buildir(), "enc265/*.pdb"), package:installdir("bin"))
-                os.vcp(path.join(package:buildir(), "dec265/*.pdb"), package:installdir("bin"))
-            end
-        end
     end)
 
     on_test(function (package)

--- a/packages/l/libde265/xmake.lua
+++ b/packages/l/libde265/xmake.lua
@@ -6,6 +6,7 @@ package("libde265")
     add_urls("https://github.com/strukturag/libde265/releases/download/v$(version)/libde265-$(version).tar.gz",
              "https://github.com/strukturag/libde265.git")
 
+    add_versions("1.0.16", "b92beb6b53c346db9a8fae968d686ab706240099cdd5aff87777362d668b0de7")
     add_versions("1.0.15", "00251986c29d34d3af7117ed05874950c875dd9292d016be29d3b3762666511d")
     add_versions("1.0.8", "24c791dd334fa521762320ff54f0febfd3c09fc978880a8c5fbc40a88f21d905")
 


### PR DESCRIPTION
New version of libde265 detected (package version: 1.0.15, last github version: 1.0.16)