### PR TITLE
Auto-update libigl to v2.6.0

### DIFF
--- a/packages/l/libigl/xmake.lua
+++ b/packages/l/libigl/xmake.lua
@@ -6,6 +6,7 @@ package("libigl")
 
     add_urls("https://github.com/libigl/libigl/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libigl/libigl.git")
+    add_versions("v2.6.0", "fe3bf58571cccbef774947261284ccf6b7fdf04fcab5f7181e31931e42a0b14f")
     add_versions("v2.2.0", "b336e548d718536956e2d6958a0624bc76d50be99039454072ecdc5cf1b2ede5")
     add_versions("v2.3.0", "9d6de3bdb9c1cfc61a0a0616fd96d14ef8465995600328c196fa672ee4579b70")
     add_versions("v2.4.0", "f3f53ee6f1e9a6c529378c6b0439cd2cfc0e30b2178b483fe6bea169ce6deb22")


### PR DESCRIPTION
New version of libigl detected (package version: v2.5.0, last github version: v2.6.0)