### PR TITLE
Auto-update d3d12-memory-allocator to v3.0.1

### DIFF
--- a/packages/d/d3d12-memory-allocator/xmake.lua
+++ b/packages/d/d3d12-memory-allocator/xmake.lua
@@ -5,6 +5,7 @@ package("d3d12-memory-allocator")
 
     add_urls("https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/archive/refs/tags/$(version).tar.gz",
              "https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git")
+    add_versions("v3.0.1", "5182c59068e31183490f5c28b7257e6d46bdeb91c215eb54eb88b2ed4683f4a2")
     add_versions("v2.0.1", "7ce1f1dfb8821d0116eccf425b3558e6d4b28d192f4efb6e6bdb3d916d853574")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of d3d12-memory-allocator detected (package version: v2.0.1, last github version: v3.0.1)