### PR TITLE
Auto-update rmlui to 6.1

### DIFF
--- a/packages/r/rmlui/xmake.lua
+++ b/packages/r/rmlui/xmake.lua
@@ -6,6 +6,7 @@ package("rmlui")
     add_urls("https://github.com/mikke89/RmlUi/archive/refs/tags/$(version).tar.gz",
              "https://github.com/mikke89/RmlUi.git")
 
+    add_versions("6.1", "b6088bf31858d31bfe657caecf49fd12d5a34f9a37fa1c3061757410c4eb0089")
     add_versions("6.0", "aba3d4b8691076750eee6bf52d722db7880dfe74c18aebd8c6d676e43175fb78")
     add_versions("5.1", "0d28177118f0777e42864b2b7ddfc2937e81eb0dc4c52fc034c71a0c93516626")
     add_versions("5.0", "1f6eac0e140c35275df32088579fc3a0087fa523082c21c28d5066bd6d18882a")


### PR DESCRIPTION
New version of rmlui detected (package version: 6.0, last github version: 6.1)