### PR TITLE
Auto-update sol2 to v3.5.0

### DIFF
--- a/packages/s/sol2/xmake.lua
+++ b/packages/s/sol2/xmake.lua
@@ -15,7 +15,7 @@ package("sol2")
 
     add_configs("includes_lua", {description = "Should this package includes the Lua package (set to false if you're shipping a custom Lua)", default = true, type = "boolean"})
 
-    add_patches(">=3.3.0", path.join(os.scriptdir(), "patches", "3.3.0", "optional.patch"), "8440f25e5dedc29229c3def85aa6f24e0eb165d4c390fd0e1312452a569a01a6")
+    add_patches("3.3.x", path.join(os.scriptdir(), "patches", "3.3.0", "optional.patch"), "8440f25e5dedc29229c3def85aa6f24e0eb165d4c390fd0e1312452a569a01a6")
 
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::sol2")

--- a/packages/s/sol2/xmake.lua
+++ b/packages/s/sol2/xmake.lua
@@ -6,6 +6,7 @@ package("sol2")
     set_urls("https://github.com/ThePhD/sol2/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ThePhD/sol2.git")
 
+    add_versions("v3.5.0", "86c0f6d2836b184a250fc2907091c076bf53c9603dd291eaebade36cc342e13c")
     add_versions("v3.3.1", "ad121461047d52b449aa84234a6b578fa3ed95d67d1a0703902eba72417f61bb")
     add_versions("v3.3.0", "b82c5de030e18cb2bcbcefcd5f45afd526920c517a96413f0b59b4332d752a1e")
     add_versions("v3.2.3", "f74158f92996f476786be9c9e83f8275129bb1da2a8d517d050421ac160a4b9e")


### PR DESCRIPTION
New version of sol2 detected (package version: v3.3.1, last github version: v3.5.0)