### PR TITLE
Auto-update qdldl to v0.1.8

### DIFF
--- a/packages/q/qdldl/xmake.lua
+++ b/packages/q/qdldl/xmake.lua
@@ -6,6 +6,7 @@ package("qdldl")
     add_urls("https://github.com/osqp/qdldl/archive/refs/tags/$(version).tar.gz",
              "https://github.com/osqp/qdldl.git")
 
+    add_versions("v0.1.8", "ecf113fd6ad8714f16289eb4d5f4d8b27842b6775b978c39def5913f983f6daa")
     add_versions("v0.1.7", "631ae65f367859fa1efade1656e4ba22b7da789c06e010cceb8b29656bf65757")
 
     add_includedirs("include", "include/qdldl")


### PR DESCRIPTION
New version of qdldl detected (package version: v0.1.7, last github version: v0.1.8)