### PR TITLE
Auto-update mongoose to 7.18

### DIFF
--- a/packages/m/mongoose/xmake.lua
+++ b/packages/m/mongoose/xmake.lua
@@ -8,6 +8,7 @@ package("mongoose")
     add_urls("https://github.com/cesanta/mongoose/archive/refs/tags/$(version).tar.gz",
              "https://github.com/cesanta/mongoose.git")
 
+    add_versions("7.18", "8b661e8aceb00528fc21993afe218b1da0f0154575a61b63ce0791ad8b66b112")
     add_versions("7.17", "b6a6f69912c2cd0c67f85633c6b578d4dcdf385c3628acdcd21de28787c676e5")
     add_versions("7.16", "f2c42135f7bc34b3d10b6401e9326a20ba5dd42d4721b6a526826ba31c1679fd")
     add_versions("7.15", "efcb5aa89b85d40373dcff3241316ddc0f2f130ad7f05c9c964f8cc1e2078a0b")


### PR DESCRIPTION
New version of mongoose detected (package version: 7.17, last github version: 7.18)