### PR TITLE
Auto-update pahomqttcpp to v1.5.3

### DIFF
--- a/packages/p/pahomqttcpp/xmake.lua
+++ b/packages/p/pahomqttcpp/xmake.lua
@@ -6,6 +6,7 @@ package("pahomqttcpp")
     add_urls("https://github.com/eclipse/paho.mqtt.cpp/archive/refs/tags/$(version).zip",
              "https://github.com/eclipse/paho.mqtt.cpp.git", {submodules = false})
 
+    add_versions("v1.5.3", "16b3786d265aa03693f472d72e74bac749204a97310108f8e162bff26123ba51")
     add_versions("v1.5.2", "121ddfc8f35080f01ddf5c0e6557593cc34380623566d78639335d050ce20fb2")
     add_versions("v1.5.1", "ad80c9cdf4c2e557fe0afb95e3170c818bd8f072c7efe6f19e174814d482c131")
     add_versions("v1.5.0", "0805f9d8003b80d3d389930bfb8d369c56cdea402effa76b6c1c61ba5aa0d804")


### PR DESCRIPTION
New version of pahomqttcpp detected (package version: v1.5.2, last github version: v1.5.3)