### PR TITLE
Auto-update picobench to 2.08

### DIFF
--- a/packages/p/picobench/xmake.lua
+++ b/packages/p/picobench/xmake.lua
@@ -5,6 +5,7 @@ package("picobench")
     set_license("MIT")
 
     add_urls("https://github.com/iboB/picobench/archive/refs/tags/v$(version).tar.gz")
+    add_versions("2.08", "7002cede527d661bc599a59dcd492ec6a0943f695603f581bf9f0569dcd9c866")
     add_versions("2.07", "c7f8e279cd5138a66a9a417caf1012ed7b15ba2652aec96ef8dd5e6e3e07d7a0")
     add_versions("2.06", "2f5d9b53260322b422a1834bbbe4947109039ee518353a8cc8dd57bbd1999b57")
 


### PR DESCRIPTION
New version of picobench detected (package version: 2.07, last github version: 2.08)