### PR TITLE
Auto-update fmt to 11.2.0

### DIFF
--- a/packages/f/fmt/xmake.lua
+++ b/packages/f/fmt/xmake.lua
@@ -6,6 +6,7 @@ package("fmt")
     set_urls("https://github.com/fmtlib/fmt/releases/download/$(version)/fmt-$(version).zip",
              "https://github.com/fmtlib/fmt.git")
 
+    add_versions("11.2.0", "203eb4e8aa0d746c62d8f903df58e0419e3751591bb53ff971096eaa0ebd4ec3")
     add_versions("11.1.4", "49b039601196e1a765e81c5c9a05a61ed3d33f23b3961323d7322e4fe213d3e6")
     add_versions("11.1.3", "7df2fd3426b18d552840c071c977dc891efe274051d2e7c47e2c83c3918ba6df")
     add_versions("11.1.2", "ef54df1d4ba28519e31bf179f6a4fb5851d684c328ca051ce5da1b52bf8b1641")


### PR DESCRIPTION
New version of fmt detected (package version: 11.1.4, last github version: 11.2.0)