### PR TITLE
Auto-update pulsar to 3.7.1

### DIFF
--- a/packages/p/pulsar/xmake.lua
+++ b/packages/p/pulsar/xmake.lua
@@ -5,6 +5,7 @@ package("pulsar")
 
     add_urls("https://github.com/apache/pulsar-client-cpp/archive/refs/tags/v$(version).tar.gz")
 
+    add_versions("3.7.1", "72be6d311b62464b758f2789689dd81469f1abce02b46bef4f0958312117cb71")
     add_versions("3.6.0", "321e288e60b340155d9a9ad8eb823738047f5055a71a8a345c93ddbe3d023741")
     add_versions("3.5.1", "279debf04b566321ff4fe2c5bd5bef8547a20b2bdbc6943cb027224ce6b45ec4")
     add_versions("3.5.0", "21d71a36666264418e3c5d3bc745628228b258daf659e6389bb9c9584409a27e")


### PR DESCRIPTION
New version of pulsar detected (package version: 3.6.0, last github version: 3.7.1)