### PR TITLE
Auto-update tree-sitter to v0.25.5

### DIFF
--- a/packages/t/tree-sitter/xmake.lua
+++ b/packages/t/tree-sitter/xmake.lua
@@ -6,6 +6,7 @@ package("tree-sitter")
     add_urls("https://github.com/tree-sitter/tree-sitter/archive/refs/tags/$(version).zip",
              "https://github.com/tree-sitter/tree-sitter.git")
 
+    add_versions("v0.25.5", "67690cf9f5d3a79a1eaaee565545f7b094aaaf4aabbaee786f33458becd30d7d")
     add_versions("v0.25.3", "cae078014ebdb5a470116b814da9def5fb180653e0e47f9dc9b3a0308fd5786e")
     add_versions("v0.24.6", "e0c657c1dfc09297a9277c346f2d8c56912c99c2ad6ec58c31a202d55ba1f1fe")
     add_versions("v0.24.5", "d4646ea3ac5bb5db0ac1eb6ca4dcfe1fb47615adc22ee840048de97cc688c72f")


### PR DESCRIPTION
New version of tree-sitter detected (package version: v0.25.3, last github version: v0.25.5)