### PR TITLE
protobuf-cpp: update to 31.0

### DIFF
--- a/packages/p/protobuf-cpp/patches/31.0/gcc15.patch
+++ b/packages/p/protobuf-cpp/patches/31.0/gcc15.patch
@@ -1,0 +1,10 @@
+--- src/google/protobuf/port_def.2.inc	2025-06-02 14:48:16.547634929 +0800
++++ src/google/protobuf/port_def.inc	2025-06-02 14:51:10.612262509 +0800
+@@ -236,6 +236,7 @@
+ #endif
+ #if ABSL_HAVE_CPP_ATTRIBUTE(clang::musttail) && !defined(__arm__) &&  \
+     !defined(_ARCH_PPC) && !defined(__wasm__) &&                      \
++    !(defined(__GNUC__) && __GNUC__ >= 15) && \
+     !(defined(_MSC_VER) && defined(_M_IX86)) && !defined(__i386__)
+ // Compilation fails on ARM32: b/195943306
+ // Compilation fails on powerpc64le: b/187985113

--- a/packages/p/protobuf-cpp/patches/31.0/gcc15.patch
+++ b/packages/p/protobuf-cpp/patches/31.0/gcc15.patch
@@ -1,5 +1,5 @@
---- src/google/protobuf/port_def.2.inc	2025-06-02 14:48:16.547634929 +0800
-+++ src/google/protobuf/port_def.inc	2025-06-02 14:51:10.612262509 +0800
+--- a/src/google/protobuf/port_def.inc	2025-06-02 14:48:16.547634929 +0800
++++ b/src/google/protobuf/port_def.inc	2025-06-02 14:51:10.612262509 +0800
 @@ -236,6 +236,7 @@
  #endif
  #if ABSL_HAVE_CPP_ATTRIBUTE(clang::musttail) && !defined(__arm__) &&  \

--- a/packages/p/protobuf-cpp/patches/31.0/msvc2019-arm64.patch
+++ b/packages/p/protobuf-cpp/patches/31.0/msvc2019-arm64.patch
@@ -1,6 +1,6 @@
 --- a/upb/hash/common.c	2025-06-02 14:39:32.082862245 +0800
 +++ b/upb/hash/common.c	2025-06-02 14:42:34.036621441 +0800
-@@ -43,6 +43,15 @@
+@@ -43,8 +43,18 @@
  #elif defined(__GNUC__)
  #define UPB_FAST_POPCOUNT32(i) __builtin_popcount(i)
  #elif defined(_MSC_VER)

--- a/packages/p/protobuf-cpp/patches/31.0/msvc2019-arm64.patch
+++ b/packages/p/protobuf-cpp/patches/31.0/msvc2019-arm64.patch
@@ -1,0 +1,18 @@
+--- upb/hash/common.2.c	2025-06-02 14:39:32.082862245 +0800
++++ upb/hash/common.c	2025-06-02 14:42:34.036621441 +0800
+@@ -43,6 +43,15 @@
+ #elif defined(__GNUC__)
+ #define UPB_FAST_POPCOUNT32(i) __builtin_popcount(i)
+ #elif defined(_MSC_VER)
++#if defined(_M_ARM64)
++unsigned int UPB_FAST_POPCOUNT32(unsigned int x) {
++	unsigned int c = 0;
++	for(; x; c++) {
++		x &= x - 1;
++	}
++	return c;
++}
++#else
+ #define UPB_FAST_POPCOUNT32(i) __popcnt(i)
+ #endif
+ 

--- a/packages/p/protobuf-cpp/patches/31.0/msvc2019-arm64.patch
+++ b/packages/p/protobuf-cpp/patches/31.0/msvc2019-arm64.patch
@@ -1,5 +1,5 @@
---- upb/hash/common.2.c	2025-06-02 14:39:32.082862245 +0800
-+++ upb/hash/common.c	2025-06-02 14:42:34.036621441 +0800
+--- a/upb/hash/common.c	2025-06-02 14:39:32.082862245 +0800
++++ b/upb/hash/common.c	2025-06-02 14:42:34.036621441 +0800
 @@ -43,6 +43,15 @@
  #elif defined(__GNUC__)
  #define UPB_FAST_POPCOUNT32(i) __builtin_popcount(i)

--- a/packages/p/protobuf-cpp/patches/31.0/msvc2019-arm64.patch
+++ b/packages/p/protobuf-cpp/patches/31.0/msvc2019-arm64.patch
@@ -15,4 +15,7 @@
 +#else
  #define UPB_FAST_POPCOUNT32(i) __popcnt(i)
  #endif
++#endif
  
+ UPB_INLINE int _upb_popcnt32(uint32_t i) {
+ #ifdef UPB_FAST_POPCOUNT32

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -157,9 +157,9 @@ package("protobuf-cpp")
             "-DCMAKE_POLICY_DEFAULT_CMP0057=NEW",
             "-Dprotobuf_BUILD_TESTS=OFF",
             "-Dprotobuf_LOCAL_DEPENDENCIES_ONLY=ON",
-            "-Dprotobuf_BUILD_PROTOC_BINARIES=ON",
             "-Dprotobuf_DEBUG_POSTFIX=''",
         }
+        table.insert(configs, "-Dprotobuf_BUILD_PROTOC_BINARIES=" .. ((not package:is_plat("android")) and "ON" or "OFF"))
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-Dprotobuf_DISABLE_RTTI=" .. (package:config("rtti") and "OFF" or "ON"))
@@ -169,9 +169,13 @@ package("protobuf-cpp")
         end
 
         table.insert(configs, "-Dprotobuf_WITH_ZLIB=" .. (package:config("zlib") and "ON" or "OFF"))
-        table.insert(configs, "-Dprotobuf_BUILD_LIBUPB=" .. (package:config("upb") and "ON" or "OFF"))
+        table.insert(configs, "-Dprotobuf_BUILD_LIBUPB=" .. ((package:config("upb") or version:ge("31.0") and not is_plat("android")) and "ON" or "OFF"))
         if version:ge("31.0) then
-            configs[9] = "-Dprotobuf_BUILD_LIBUPB=ON"
+            configs[10] = "-Dprotobuf_BUILD_LIBUPB=ON"
+        end
+        if package_is_plat("android") then
+            configs[4] = "-Dprotobuf_BUILD_PROTOC_BINARIES=OFF"
+            configs[10] = "-Dprotobuf_BUILD_LIBUPB=OFF"
         end
 
         local opt = {}

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -38,7 +38,7 @@ package("protobuf-cpp")
     add_patches("3.17.3", path.join(os.scriptdir(), "patches", "3.17.3", "field_access_listener.patch"), "ac9bdf49611b01e563fe74b2aaf1398214129454c3e18f1198245549eb281e85")
     add_patches("3.19.4", path.join(os.scriptdir(), "patches", "3.19.4", "vs_runtime.patch"), "8e73e585d29f3b9dca3c279df0b11b3ee7651728c07f51381a69e5899b93c367")
     -- https://github.com/msys2/MINGW-packages/blob/e77de8e92025175ffa0a217c3444249aa6f8f4a9/mingw-w64-protobuf/0004-fix-build-with-gcc-15.patch#L7
-    add_patches("31.0", path.join(os.scriptdir(), "patches", "31.0", "gcc15.patch"), "f00dae841275ad384891e90a8c144bc8a3d4cc76155a85662af8919b251ab986")
+    add_patches("31.0", path.join(os.scriptdir(), "patches", "31.0", "gcc15.patch"), "6475e824fabf7835f77e0410830c80b23e4c7a71fa5d7f4867ee7235942b167f")
 
     add_configs("rtti", {description = "Enable runtime type information", default = true, type = "boolean"})
     add_configs("zlib", {description = "Enable zlib", default = false, type = "boolean"})
@@ -62,7 +62,7 @@ package("protobuf-cpp")
             local msvc = package:toolchain("msvc")
             local vs = msvc:config("vs")
             if vs and tonumber(vs) < 2022 and package:is_arch("arm64") then
-                package:add("patches", "31.0", path.join(os.scriptdir(), "patches", "31.0", "msvc2019-arm64.patch"), "bbebb83c8540a219d21cb43c508252d1cf22c7cfecd2857221122eb59cfcf506")
+                package:add("patches", "31.0", path.join(os.scriptdir(), "patches", "31.0", "msvc2019-arm64.patch"), "b9aacb581cca9ccc12270ba1ce7eaa66029283d5ff0c0df8f02d2704cb6675a1")
             end
         end
         

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -170,13 +170,6 @@ package("protobuf-cpp")
 
         table.insert(configs, "-Dprotobuf_WITH_ZLIB=" .. (package:config("zlib") and "ON" or "OFF"))
         table.insert(configs, "-Dprotobuf_BUILD_LIBUPB=" .. ((package:config("upb") or version:ge("31.0") and not is_plat("android")) and "ON" or "OFF"))
-        if version:ge("31.0) then
-            configs[10] = "-Dprotobuf_BUILD_LIBUPB=ON"
-        end
-        if package_is_plat("android") then
-            configs[4] = "-Dprotobuf_BUILD_PROTOC_BINARIES=OFF"
-            configs[10] = "-Dprotobuf_BUILD_LIBUPB=OFF"
-        end
 
         local opt = {}
         opt.buildir = "build"

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -34,11 +34,11 @@ package("protobuf-cpp")
     add_versions("3.17.3", "fe65f4bfbd6cbb8c23de052f218cbe4ebfeb72c630847e0cca63eb27616c952a")
     add_versions("3.19.4", "a11a262a395f999f9dca83e195cc15b6c23b6d5e74133f8e3250ad0950485da1")
 
-    add_patches("3.11.2", path.join(os.scriptdir(), "patches", "3.11.2", "ndk-link-log.diff"), "5564ae57562a2d6262e0837afd9645a6be2d4b52a52b7212fa6452f11f50af4a")
-    add_patches("3.17.3", path.join(os.scriptdir(), "patches", "3.17.3", "field_access_listener.patch"), "ac9bdf49611b01e563fe74b2aaf1398214129454c3e18f1198245549eb281e85")
-    add_patches("3.19.4", path.join(os.scriptdir(), "patches", "3.19.4", "vs_runtime.patch"), "8e73e585d29f3b9dca3c279df0b11b3ee7651728c07f51381a69e5899b93c367")
+    add_patches("3.11.2", "patches/3.11.2/ndk-link-log.diff", "5564ae57562a2d6262e0837afd9645a6be2d4b52a52b7212fa6452f11f50af4a")
+    add_patches("3.17.3", "patches/3.17.3/field_access_listener.patch", "ac9bdf49611b01e563fe74b2aaf1398214129454c3e18f1198245549eb281e85")
+    add_patches("3.19.4", "patches/3.19.4/vs_runtime.patch", "8e73e585d29f3b9dca3c279df0b11b3ee7651728c07f51381a69e5899b93c367")
     -- https://github.com/msys2/MINGW-packages/blob/e77de8e92025175ffa0a217c3444249aa6f8f4a9/mingw-w64-protobuf/0004-fix-build-with-gcc-15.patch#L7
-    add_patches("31.0", path.join(os.scriptdir(), "patches", "31.0", "gcc15.patch"), "6475e824fabf7835f77e0410830c80b23e4c7a71fa5d7f4867ee7235942b167f")
+    add_patches("31.0", "patches/31.0/gcc15.patch", "6475e824fabf7835f77e0410830c80b23e4c7a71fa5d7f4867ee7235942b167f")
 
     add_configs("rtti", {description = "Enable runtime type information", default = true, type = "boolean"})
     add_configs("zlib", {description = "Enable zlib", default = false, type = "boolean"})

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -41,7 +41,7 @@ package("protobuf-cpp")
     add_configs("rtti", {description = "Enable runtime type information", default = true, type = "boolean"})
     add_configs("zlib", {description = "Enable zlib", default = false, type = "boolean"})
     add_configs("lite", {description = "Build lite version", default = true, type = "boolean", readonly = true})
-    add_configs("upb", {description = "Build upb", default = false, type = "boolean"})
+    add_configs("upb", {description = "Build upb", default = not is_plat("android"), type = "boolean"})
     add_configs("bin", {description = "Build libprotoc and protoc compiler", default = not is_plat("android"), type = "boolean"})
 
     if is_plat("mingw") and is_subhost("msys") then

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -144,7 +144,7 @@ package("protobuf-cpp")
                     io.replace("upb/hash/common.c", [[#elif defined(_MSC_VER)
 #define UPB_FAST_POPCOUNT32(i) __popcnt(i)]], [[#elif defined(_MSC_VER)
 #if defined(_M_ARM64)
-unsigned int __popcnt(unsigned int x) {
+unsigned int UPB_FAST_POPCOUNT32(unsigned int x) {
   unsigned int c = 0;
   for (; x; ++c) {
     x &= x - 1;

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -58,13 +58,11 @@ package("protobuf-cpp")
 
     on_load(function (package)
         -- Fix MSVC 2019 arm64 error LNK2019: unresolved external symbol __popcnt referenced in function _upb_log2_table_size
-        if package:version():gt("30.2") then
-            if package:is_plat("windows") then
-                local msvc = package:toolchain("msvc")
-                local vs = msvc:config("vs")
-                if vs and tonumber(vs) < 2022 and package:is_arch("arm64") then
-                    package:add("patches", "31.0", path.join(os.scriptdir(), "patches", "31.0", "msvc2019-arm64.patch"), "bbebb83c8540a219d21cb43c508252d1cf22c7cfecd2857221122eb59cfcf506")
-                end
+        if package:is_plat("windows") then
+            local msvc = package:toolchain("msvc")
+            local vs = msvc:config("vs")
+            if vs and tonumber(vs) < 2022 and package:is_arch("arm64") then
+                package:add("patches", "31.0", path.join(os.scriptdir(), "patches", "31.0", "msvc2019-arm64.patch"), "bbebb83c8540a219d21cb43c508252d1cf22c7cfecd2857221122eb59cfcf506")
             end
         end
         

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -42,7 +42,7 @@ package("protobuf-cpp")
     add_configs("zlib", {description = "Enable zlib", default = false, type = "boolean"})
     add_configs("lite", {description = "Build lite version", default = true, type = "boolean", readonly = true})
     add_configs("upb", {description = "Build upb", default = not is_plat("android"), type = "boolean"})
-    add_configs("bin", {description = "Build libprotoc and protoc compiler", default = not is_plat("android"), type = "boolean"})
+    add_configs("tools", {description = "Build libprotoc and protoc compiler", default = not is_plat("android"), type = "boolean"})
 
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::protobuf")
@@ -183,7 +183,7 @@ unsigned int UPB_FAST_POPCOUNT32(unsigned int x) {
             "-Dprotobuf_LOCAL_DEPENDENCIES_ONLY=ON",
             "-Dprotobuf_DEBUG_POSTFIX=''",
         }
-        table.insert(configs, "-Dprotobuf_BUILD_PROTOC_BINARIES=" .. (package:config("bin") and "ON" or "OFF"))
+        table.insert(configs, "-Dprotobuf_BUILD_PROTOC_BINARIES=" .. (package:config("tools") and "ON" or "OFF"))
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-Dprotobuf_DISABLE_RTTI=" .. (package:config("rtti") and "OFF" or "ON"))

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -42,6 +42,7 @@ package("protobuf-cpp")
     add_configs("zlib", {description = "Enable zlib", default = false, type = "boolean"})
     add_configs("lite", {description = "Build lite version", default = true, type = "boolean", readonly = true})
     add_configs("upb", {description = "Build upb", default = false, type = "boolean"})
+    add_configs("bin", {description = "Build libprotoc and protoc compiler", default = not is_plat("android"), type = "boolean"})
 
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::protobuf")
@@ -182,7 +183,7 @@ unsigned int UPB_FAST_POPCOUNT32(unsigned int x) {
             "-Dprotobuf_LOCAL_DEPENDENCIES_ONLY=ON",
             "-Dprotobuf_DEBUG_POSTFIX=''",
         }
-        table.insert(configs, "-Dprotobuf_BUILD_PROTOC_BINARIES=" .. ((not package:is_plat("android")) and "ON" or "OFF"))
+        table.insert(configs, "-Dprotobuf_BUILD_PROTOC_BINARIES=" .. (package:config("bin") and "ON" or "OFF"))
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-Dprotobuf_DISABLE_RTTI=" .. (package:config("rtti") and "OFF" or "ON"))
@@ -192,7 +193,7 @@ unsigned int UPB_FAST_POPCOUNT32(unsigned int x) {
         end
 
         table.insert(configs, "-Dprotobuf_WITH_ZLIB=" .. (package:config("zlib") and "ON" or "OFF"))
-        table.insert(configs, "-Dprotobuf_BUILD_LIBUPB=" .. ((package:config("upb") or version:ge("31.0") and not is_plat("android")) and "ON" or "OFF"))
+        table.insert(configs, "-Dprotobuf_BUILD_LIBUPB=" .. (package:config("upb") and "ON" or "OFF"))
 
         local opt = {}
         opt.buildir = "build"

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -170,6 +170,9 @@ package("protobuf-cpp")
 
         table.insert(configs, "-Dprotobuf_WITH_ZLIB=" .. (package:config("zlib") and "ON" or "OFF"))
         table.insert(configs, "-Dprotobuf_BUILD_LIBUPB=" .. (package:config("upb") and "ON" or "OFF"))
+        if version:ge("31.0) then
+            configs[9] = "-Dprotobuf_BUILD_LIBUPB=ON"
+        end
 
         local opt = {}
         opt.buildir = "build"

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -62,7 +62,7 @@ package("protobuf-cpp")
             local msvc = package:toolchain("msvc")
             local vs = msvc:config("vs")
             if vs and tonumber(vs) < 2022 and package:is_arch("arm64") then
-                package:add("patches", "31.0", path.join(os.scriptdir(), "patches", "31.0", "msvc2019-arm64.patch"), "35f3be9c1537075252ec9d8e97a50a7f6d4b2f400baf055b40a114d7b2a623e7")
+                package:add("patches", "31.0", path.join(os.scriptdir(), "patches", "31.0", "msvc2019-arm64.patch"), "3b3fa6e7936df5f10da1bb0303060736a40d55e55055f7bc3b376d7a697c093d")
             end
         end
         

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -134,11 +134,10 @@ package("protobuf-cpp")
     end)
 
     on_install(function (package)
-        import("core.tool.toolchain")
         -- Fix MSVC 2019 arm64 error LNK2019: unresolved external symbol __popcnt referenced in function _upb_log2_table_size
         if package:version():gt("30.2") then
             if package:is_plat("windows") then
-                local msvc = toolchain.load("msvc", {plat = package:plat(), arch = package:arch()})
+                local msvc = package:toolchain("msvc")
                 local vs = msvc:config("vs")
                 if vs and tonumber(vs) < 2022 and package:is_arch("arm64") then
                     io.replace("upb/hash/common.c", [[#elif defined(_MSC_VER)

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -13,6 +13,7 @@ package("protobuf-cpp")
     end})
 
     -- TODO: Use x.y.z version? https://protobuf.dev/support/version-support
+    add_versions("31.0", "3fea4fad0fd2d89e0e79937bc4b3083d483d7e5bc5fec2b8a4158916cd9478dd")
     add_versions("30.2", "6544e5ceec7f29d00397193360435ca8b3c4e843de3cf5698a99d36b72d65342")
     add_versions("29.3", "e9b9ac1910b1041065839850603caf36e29d3d3d230ddf52bd13778dd31b9046")
     add_versions("29.2", "60c1ab4befe9d0a975c2344b5511bf6b44f91ec3e1426c878f56bf30a0589c43")

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -62,7 +62,7 @@ package("protobuf-cpp")
             local msvc = package:toolchain("msvc")
             local vs = msvc:config("vs")
             if vs and tonumber(vs) < 2022 and package:is_arch("arm64") then
-                package:add("patches", "31.0", path.join(os.scriptdir(), "patches", "31.0", "msvc2019-arm64.patch"), "b9aacb581cca9ccc12270ba1ce7eaa66029283d5ff0c0df8f02d2704cb6675a1")
+                package:add("patches", "31.0", path.join(os.scriptdir(), "patches", "31.0", "msvc2019-arm64.patch"), "35f3be9c1537075252ec9d8e97a50a7f6d4b2f400baf055b40a114d7b2a623e7")
             end
         end
         

--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -38,7 +38,7 @@ package("protobuf-cpp")
     add_patches("3.17.3", path.join(os.scriptdir(), "patches", "3.17.3", "field_access_listener.patch"), "ac9bdf49611b01e563fe74b2aaf1398214129454c3e18f1198245549eb281e85")
     add_patches("3.19.4", path.join(os.scriptdir(), "patches", "3.19.4", "vs_runtime.patch"), "8e73e585d29f3b9dca3c279df0b11b3ee7651728c07f51381a69e5899b93c367")
     -- Fix MSVC 2019 arm64 error LNK2019: unresolved external symbol __popcnt referenced in function _upb_log2_table_size
-    add_patches("31.0", path.join(os.scriptdir(), "patches", "31.0", "vs2019-arm64.patch"), "bbebb83c8540a219d21cb43c508252d1cf22c7cfecd2857221122eb59cfcf506")
+    add_patches("31.0", path.join(os.scriptdir(), "patches", "31.0", "msvc2019-arm64.patch"), "bbebb83c8540a219d21cb43c508252d1cf22c7cfecd2857221122eb59cfcf506")
     -- https://github.com/msys2/MINGW-packages/blob/e77de8e92025175ffa0a217c3444249aa6f8f4a9/mingw-w64-protobuf/0004-fix-build-with-gcc-15.patch#L7
     add_patches("31.0", path.join(os.scriptdir(), "patches", "31.0", "gcc15.patch"), "f00dae841275ad384891e90a8c144bc8a3d4cc76155a85662af8919b251ab986")
 


### PR DESCRIPTION
升级 protobuf-cpp 到 31.0
目前在 `-p linux -a x86_64` `-p linux -a arm64` `-p android -a arm64-v8a` 中测试没有问题，其它平台未知