### PR TITLE
Auto-update etl to 20.41.2

### DIFF
--- a/packages/e/etl/xmake.lua
+++ b/packages/e/etl/xmake.lua
@@ -7,6 +7,7 @@ package("etl")
     add_urls("https://github.com/ETLCPP/etl/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ETLCPP/etl.git")
 
+    add_versions("20.41.2", "e977b0d6ea3a31f55de4067a47ca1d60e5c8ddaf841b9b1fca5caf1f4071b206")
     add_versions("20.41.1", "d5069a3d2c2da76c60556a5db745db526ec0e3cd400c8cfcbf79813aabfa9650")
     add_versions("20.41.0", "96f0a7992461d6c7060dbaf76aeab85cb7a1ca6f5efc80526bfe61b24819f000")
     add_versions("20.40.1", "9458a1c26f59883f635610521d7ba95da5d1aecb1ff8804a76f5dd2c52e237aa")


### PR DESCRIPTION
New version of etl detected (package version: 20.41.1, last github version: 20.41.2)