### PR TITLE
fix rest_rpc

### DIFF
--- a/packages/r/rest_rpc/xmake.lua
+++ b/packages/r/rest_rpc/xmake.lua
@@ -6,8 +6,10 @@ package("rest_rpc")
 
     add_urls("https://github.com/qicosmos/rest_rpc.git")
     add_versions("2023.6.14", "8782f1d341e1dd18f9fe3a77b8335fd17a5ba585")
+    add_versions("2024.7.26", "35761edb55dff9ccdc87000062e84172bbd5b29b")
 
-    add_deps("asio", "msgpack-cxx")
+    add_deps("asio", "msgpack-c")
+    add_defines("MSGPACK_NO_BOOST")
 
     if is_plat("mingw") then
         add_syslinks("ws2_32")


### PR DESCRIPTION
2022年就已经移除boost依赖了
https://github.com/qicosmos/rest_rpc/issues/50