### PR TITLE
libomp: add mingw platform support

### DIFF
--- a/packages/l/libomp/patches/001-cast-to-make-gcc-happy.patch
+++ b/packages/l/libomp/patches/001-cast-to-make-gcc-happy.patch
@@ -1,0 +1,40 @@
+--- openmp/runtime/src/kmp_atomic.cpp.orig	2021-05-07 01:45:33.857000200 +0200
++++ openmp/runtime/src/kmp_atomic.cpp	2021-05-07 01:45:38.757999800 +0200
+@@ -646,15 +646,15 @@
+ 
+ static inline kmp_cmplx128_a4_t operator+(kmp_cmplx128_a4_t &lhs,
+                                           kmp_cmplx128_a4_t &rhs) {
+-  return lhs.q + rhs.q;
++  return (kmp_cmplx128_a4_t)(lhs.q + rhs.q);
+ }
+ static inline kmp_cmplx128_a4_t operator-(kmp_cmplx128_a4_t &lhs,
+                                           kmp_cmplx128_a4_t &rhs) {
+-  return lhs.q - rhs.q;
++  return (kmp_cmplx128_a4_t)(lhs.q - rhs.q);
+ }
+ static inline kmp_cmplx128_a4_t operator*(kmp_cmplx128_a4_t &lhs,
+                                           kmp_cmplx128_a4_t &rhs) {
+-  return lhs.q * rhs.q;
++  return (kmp_cmplx128_a4_t)(lhs.q * rhs.q);
+ }
+ static inline kmp_cmplx128_a4_t operator/(kmp_cmplx128_a4_t &lhs,
+                                           kmp_cmplx128_a4_t &rhs) {
+@@ -663,15 +663,15 @@
+ 
+ static inline kmp_cmplx128_a16_t operator+(kmp_cmplx128_a16_t &lhs,
+                                            kmp_cmplx128_a16_t &rhs) {
+-  return lhs.q + rhs.q;
++  return (kmp_cmplx128_a16_t)(lhs.q + rhs.q);
+ }
+ static inline kmp_cmplx128_a16_t operator-(kmp_cmplx128_a16_t &lhs,
+                                            kmp_cmplx128_a16_t &rhs) {
+-  return lhs.q - rhs.q;
++  return (kmp_cmplx128_a16_t)(lhs.q - rhs.q);
+ }
+ static inline kmp_cmplx128_a16_t operator*(kmp_cmplx128_a16_t &lhs,
+                                            kmp_cmplx128_a16_t &rhs) {
+-  return lhs.q * rhs.q;
++  return kmp_cmplx128_a16_t(lhs.q * rhs.q);
+ }
+ static inline kmp_cmplx128_a16_t operator/(kmp_cmplx128_a16_t &lhs,
+                                            kmp_cmplx128_a16_t &rhs) {

--- a/packages/l/libomp/patches/002-hacks-for-static-linking.patch
+++ b/packages/l/libomp/patches/002-hacks-for-static-linking.patch
@@ -1,0 +1,32 @@
+--- a/runtime/CMakeLists.txt
++++ b/runtime/CMakeLists.txt
+@@ -335,10 +335,6 @@
+   set(LIBOMP_ENABLE_SHARED FALSE)
+ endif()
+ 
+-if(WIN32 AND NOT LIBOMP_ENABLE_SHARED)
+-  libomp_error_say("Static libraries requested but not available on Windows")
+-endif()
+-
+ if(LIBOMP_USE_ITT_NOTIFY AND NOT LIBOMP_ENABLE_SHARED)
+   message(STATUS "ITT Notify not supported for static libraries - forcing ITT Notify off")
+   set(LIBOMP_USE_ITT_NOTIFY FALSE)
+--- a/runtime/src/CMakeLists.txt
++++ b/runtime/src/CMakeLists.txt
+@@ -284,14 +284,14 @@
+       set(LIBOMP_IMP_LIB_FILE ${LIBOMP_DEFAULT_LIB_NAME}${CMAKE_IMPORT_LIBRARY_SUFFIX})
+       set(LIBOMP_GENERATED_IMP_LIB_FILENAME ${LIBOMP_DEFAULT_LIB_NAME}${LIBOMP_LIBRARY_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+     endif()
+-  else()
++  elseif(LIBOMP_ENABLE_SHARED)
+     set(LIBOMP_IMP_LIB_FILE ${LIBOMP_LIB_NAME}${CMAKE_IMPORT_LIBRARY_SUFFIX})
+     set(LIBOMP_GENERATED_IMP_LIB_FILENAME ${LIBOMP_LIB_FILE}${CMAKE_STATIC_LIBRARY_SUFFIX})
++    set_target_properties(omp PROPERTIES ARCHIVE_OUTPUT_NAME ${LIBOMP_GENERATED_IMP_LIB_FILENAME})
+   endif()
+   set_target_properties(omp PROPERTIES
+     VERSION ${LIBOMP_VERSION_MAJOR}.${LIBOMP_VERSION_MINOR} # uses /version flag
+     IMPORT_PREFIX "" IMPORT_SUFFIX "" # control generated import library name when building omp
+-    ARCHIVE_OUTPUT_NAME ${LIBOMP_GENERATED_IMP_LIB_FILENAME}
+   )
+ 
+   set(LIBOMP_IMP_LIB_TARGET omp)

--- a/packages/l/libomp/xmake.lua
+++ b/packages/l/libomp/xmake.lua
@@ -11,6 +11,11 @@ package("libomp")
 
     add_resources("19.1.0", "llvm_cmake", "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.0/cmake-19.1.0.src.tar.xz", "dc78b6a9ac8a097ca6ac0f23c06821d65e6ea3bf666026f529994c1d01056ae7")
 
+    if is_plat("mingw", "msys") then
+        add_patches("19.1.0", "patches/001-cast-to-make-gcc-happy.patch", "11352ffbe7559a7170f2abd52b3552c877fbcf8fc82cff77b421e8b130a4dd66")
+        add_patches("19.1.0", "patches/002-hacks-for-static-linking.patch", "08e39ea52a99204528740196a13cc29daf1b65a6e230fbd7bdd745dde5d11ef3")
+    end
+
     add_configs("shared", {description = "Build shared library.", default = true, type = "boolean"})
 
     on_fetch("macosx", "linux", function (package, opt)
@@ -20,8 +25,12 @@ package("libomp")
     end)
 
     add_deps("cmake")
+    if is_plat("mingw", "msys") then
+        add_deps("uasm")
+    end
 
     add_links("omp")
+
     if is_plat("macosx") then
         add_extsources("brew::libomp")
     elseif is_plat("linux") then
@@ -43,7 +52,7 @@ package("libomp")
         end
     end)
 
-    on_install("macosx", "linux", "cross", "android", function (package)
+    on_install("macosx", "linux", "cross", "android", "mingw", "msys", function (package)
         local version = package:version()
         if version:ge("19.0") then
             local llvm_cmake = package:resourcedir("llvm_cmake")
@@ -56,6 +65,12 @@ package("libomp")
 
         local configs = {"-DOPENMP_STANDALONE_BUILD=ON", "-DOPENMP_ENABLE_LIBOMPTARGET=OFF", "-DLIBOMP_INSTALL_ALIASES=OFF"}
         local shared = package:config("shared")
+        if package:is_plat("mingw", "msys") then
+            if package:is_arch("x86_64", "x64") then
+                table.insert(configs, "-DLIBOMP_ASMFLAGS=-win64")
+            end
+            table.insert(configs, "-DCMAKE_ASM_MASM_COMPILER=" .. path.join(package:dep("uasm"):installdir("bin"), "uasm.exe"))
+        end
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (shared and "ON" or "OFF"))
         table.insert(configs, "-DLIBOMP_ENABLE_SHARED=" .. (shared and "ON" or "OFF"))
         table.insert(configs, "-DLIBOMP_OMPD_GDB_SUPPORT=" .. (package:is_cross() and "OFF" or "ON"))

--- a/packages/l/libomp/xmake.lua
+++ b/packages/l/libomp/xmake.lua
@@ -69,7 +69,7 @@ package("libomp")
             if package:is_arch("x86_64", "x64") then
                 table.insert(configs, "-DLIBOMP_ASMFLAGS=-win64")
             end
-            if package:is_subhost("macosx") then
+            if is_subhost("macosx") then
                 table.insert(configs, "-DCMAKE_ASM_MASM_COMPILER=" .. path.join(package:dep("uasm"):installdir("bin"), "uasm"))
             else
                 table.insert(configs, "-DCMAKE_ASM_MASM_COMPILER=" .. path.join(package:dep("uasm"):installdir("bin"), "uasm.exe"))

--- a/packages/l/libomp/xmake.lua
+++ b/packages/l/libomp/xmake.lua
@@ -69,7 +69,11 @@ package("libomp")
             if package:is_arch("x86_64", "x64") then
                 table.insert(configs, "-DLIBOMP_ASMFLAGS=-win64")
             end
-            table.insert(configs, "-DCMAKE_ASM_MASM_COMPILER=" .. path.join(package:dep("uasm"):installdir("bin"), "uasm.exe"))
+            if package:is_subhost("macosx") then
+                table.insert(configs, "-DCMAKE_ASM_MASM_COMPILER=" .. path.join(package:dep("uasm"):installdir("bin"), "uasm"))
+            else
+                table.insert(configs, "-DCMAKE_ASM_MASM_COMPILER=" .. path.join(package:dep("uasm"):installdir("bin"), "uasm.exe"))
+            end
         end
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (shared and "ON" or "OFF"))
         table.insert(configs, "-DLIBOMP_ENABLE_SHARED=" .. (shared and "ON" or "OFF"))

--- a/packages/l/libomp/xmake.lua
+++ b/packages/l/libomp/xmake.lua
@@ -71,6 +71,8 @@ package("libomp")
             end
             if is_subhost("macosx") then
                 table.insert(configs, "-DCMAKE_ASM_MASM_COMPILER=" .. path.join(package:dep("uasm"):installdir("bin"), "uasm"))
+                io.replace("runtime/cmake/LibompHandleFlags.cmake", [[/safeseh]], [[-safeseh]], {plain = true})
+                io.replace("runtime/cmake/LibompHandleFlags.cmake", [[/coff]], [[-coff]], {plain = true})
             else
                 table.insert(configs, "-DCMAKE_ASM_MASM_COMPILER=" .. path.join(package:dep("uasm"):installdir("bin"), "uasm.exe"))
             end


### PR DESCRIPTION
Attempt to add `MinGW` support to `omp` package.
Might improve https://github.com/xmake-io/xmake-repo/pull/7206 MinGW build.
Note, MacOS@MinGW much more likely supposed to use uasm.exe from MinGW environment rather use uasm from Mac OS environment. Yet I believe according to our recent discussion MinGW support is in a progress to be improved, so I decided to fallback for uasm by Mac OS environment. (I do not have another way to solve this).

