### PR TITLE
Auto-update thrift to v0.22.0

### DIFF
--- a/packages/t/thrift/xmake.lua
+++ b/packages/t/thrift/xmake.lua
@@ -6,6 +6,7 @@ package("thrift")
     add_urls("https://github.com/apache/thrift/archive/refs/tags/$(version).tar.gz",
              "https://github.com/apache/thrift.git")
 
+    add_versions("v0.22.0", "c4649c5879dd56c88f1e7a1c03e0fbfcc3b2a2872fb81616bffba5aa8a225a37")
     add_versions("v0.21.0", "31e46de96a7b36b8b8a457cecd2ee8266f81a83f8e238a9d324d8c6f42a717bc")
     add_versions("v0.20.0", "cd7b829d3d9d87f9f7d708e004eef7629789591ee1d416f4741913bc33e5c27d")
     add_versions("v0.19.0", "6428911db505702c51f7d993155a4a4c8afee83fdd021b52f2eccd8d34780629")


### PR DESCRIPTION
New version of thrift detected (package version: v0.21.0, last github version: v0.22.0)