### PR TITLE
Update Onednn 3.8.1

### DIFF
--- a/packages/o/onednn/xmake.lua
+++ b/packages/o/onednn/xmake.lua
@@ -6,6 +6,7 @@ package("onednn")
 
     add_urls("https://github.com/oneapi-src/oneDNN/archive/refs/tags/$(version).tar.gz",
              "https://github.com/oneapi-src/oneDNN.git")
+    add_versions("v3.8.1", "4b0638061a789a1efbefdcd2e85eb257c7b432b3b6a71ba8909e19d75f50b163")
     add_versions("v3.8", "06c11b9e4d25ddaaec219f0e93f6bdbbbc27dcf8eb992f76b768a2a056a087a9")
     add_versions("v3.7.2", "21068e8cd2bf4077916bf31452eab5ac9998e620e1b22630a88f79c334857a5c")
     add_versions("v3.7.1", "580f56abe12f2bd9d628a47586b00c516d410b086d7227a800aedc4891f4e93a")


### PR DESCRIPTION
This is a patch release containing the following changes to v3.8:

Fixed correctness issue in reorder primitive with non-trivial strides on Intel CPUs (https://github.com/uxlfoundation/oneDNN/commit/a762d3248ee5e04b2348f3a5aeecfa64da4634d8)
Fixed runtime error in convolution weight gradient on Xe2 architecture-based Intel GPUs (https://github.com/uxlfoundation/oneDNN/commit/a8fac73036f67657f51c10b385f967c64607e802, https://github.com/uxlfoundation/oneDNN/commit/c409ef949ea112e8fc1caf480d55a07247b4a702)
Fixed performance regression in bf16 convolution on Intel Datacenter GPU Max Series (https://github.com/uxlfoundation/oneDNN/commit/98170d0f138458f4b3fcefca773be2ef7e73959f, https://github.com/uxlfoundation/oneDNN/commit/c6bae4aa45dbe9ff9fe4e51173dc301550832e08, https://github.com/uxlfoundation/oneDNN/commit/c5edd53195f6b1465f4ab4857d64a704bb38e8e1, https://github.com/uxlfoundation/oneDNN/commit/bb1a5919fbedd4ce078f2fcf368a3e099f6c3942)
Improved performance of fp16 matmul with fp8 compressed weights on Intel GPUs (https://github.com/uxlfoundation/oneDNN/commit/58f3ec1510a4b10e51e57227229d2b2cfe23f55a, https://github.com/uxlfoundation/oneDNN/commit/abff1764af8a93dda5c9c8be11c5a1a5da31daa7, https://github.com/uxlfoundation/oneDNN/commit/ffd7dd34d837f6ddb50d2b88515c5f45bb18ed4f, https://github.com/uxlfoundation/oneDNN/commit/3b1e855f440a13124d33c05e1ab671eba1401bba, https://github.com/uxlfoundation/oneDNN/commit/2e140de469d28b3f49d3284dc0e215b9b43b718a, https://github.com/uxlfoundation/oneDNN/commit/3429f79274957e4bd9b9c6ec12bcf2a4e8362a5b)
Fixed runtime error in fp16 pooling primitive on Xe2 architecture based Intel GPUs (https://github.com/uxlfoundation/oneDNN/commit/c0f6b6ded756c35d50b383c8078fdec1b3ad2f09)
Improved performance of fp16 matmul with int4 weights and 32 < m <= 64 on Intel GPUs (https://github.com/uxlfoundation/oneDNN/commit/2fa7072a4d632e341a10d883243c0b54359da2fc)
Fixed correctness issues in bf16 matmul with 3 or more dimensional tensors on processors with Intel AMX support (https://github.com/uxlfoundation/oneDNN/commit/dd20965518965ff0f63093c1f90c957cbe9ad3e6, https://github.com/uxlfoundation/oneDNN/commit/ea1b4a169d3fe59a8c8a5d60e5da30a5167e0b52)
Fixed performance regression in fp16 or bf16 matmul with transposed source and weight tensors on Intel Datacenter GPU Max Series (https://github.com/uxlfoundation/oneDNN/commit/e45e1aa4fe44e0ba0cfb74d58272fea59c47f683)
Improved performance of bf16 matmul with int4 weights on Intel GPUs (https://github.com/uxlfoundation/oneDNN/commit/7a15c231c569432ca74f7dd1db260f1f8877980c)
Fixed runtime error in fp16 SDPA subgraph with head size 512 on Intel Core Ultra (Series 2) processor integrated GPU (https://github.com/uxlfoundation/oneDNN/commit/bde698584cbc6ca3f02649c8ff743f9b5d3d527e)

