### PR TITLE
Fix a dylib problem that fails to find onnxruntime

### DIFF
--- a/packages/o/onnxruntime/xmake.lua
+++ b/packages/o/onnxruntime/xmake.lua
@@ -5,6 +5,7 @@ package("onnxruntime")
 
     add_configs("gpu", {description = "Enable GPU support on windows|x64 and linux|x86_64", default = false, type = "boolean"})
     add_configs("cuda_version", {description = "Specify which CUDA version to use for GPU support", default = "11", type = "string"})
+    add_configs("shared", {description = "Download shared binaries.", default = true, type = "boolean", readonly = true})
 
     if is_plat("windows") then
         if is_arch("x64") then
@@ -110,9 +111,6 @@ package("onnxruntime")
             os.mv("lib/*.dll", package:installdir("bin"))
         end
         os.cp("*", package:installdir())
-        if package:is_plat("macosx") then
-            package:addenv("DYLD_LIBRARY_PATH", path.join(package:installdir(), "lib"))
-        end
     end)
 
     on_test(function (package)

--- a/packages/o/onnxruntime/xmake.lua
+++ b/packages/o/onnxruntime/xmake.lua
@@ -110,6 +110,9 @@ package("onnxruntime")
             os.mv("lib/*.dll", package:installdir("bin"))
         end
         os.cp("*", package:installdir())
+        if package:is_plat("macosx") then
+            package:addenv("DYLD_LIBRARY_PATH", path.join(package:installdir(), "lib"))
+        end
     end)
 
     on_test(function (package)


### PR DESCRIPTION
在 macos 的M2 芯片环境上调试 x86-64 架构的时候会出现dyld[12794]: Library not loaded: @rpath/libonnxruntime.1.16.1.dylib
