### PR TITLE
Auto-update sqlitecpp to 3.3.3

### DIFF
--- a/packages/s/sqlitecpp/xmake.lua
+++ b/packages/s/sqlitecpp/xmake.lua
@@ -6,6 +6,7 @@ package("sqlitecpp")
     set_urls("https://github.com/SRombauts/SQLiteCpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/SRombauts/SQLiteCpp.git")
 
+    add_versions("3.3.3", "33bd4372d83bc43117928ee842be64d05e7807f511b5195f85d30015cad9cac6")
     add_versions("3.3.2", "5aa8eda130d0689bd5ed9b2074714c2dbc610f710483c61ba6cf944cebfe03af")
     add_versions("3.3.1", "71f990f9fb4b004533b6859ce40729af823b87fe691dd99ca084a7fd40db54b9")
     add_versions("3.2.1", "70c67d5680c47460f82a7abf8e6b0329bf2fb10795a982a6d8abc06adb42d693")


### PR DESCRIPTION
New version of sqlitecpp detected (package version: 3.3.2, last github version: 3.3.3)