### PR TITLE
Auto-update libsvm to v336

### DIFF
--- a/packages/l/libsvm/xmake.lua
+++ b/packages/l/libsvm/xmake.lua
@@ -6,6 +6,7 @@ package("libsvm")
 
     add_urls("https://github.com/cjlin1/libsvm/archive/refs/tags/$(version).tar.gz",
              "https://github.com/cjlin1/libsvm.git")
+    add_versions("v336", "fb90fe1cfa257af59d24cb96c4c033e4541d384952227faa4fbe014eb7e0ac9f")
     add_versions("v335", "f864faaf0e6606aa5eb89b48d76b77db43b501c3b0b1842ae036f9d754e675d9")
     add_versions("v334", "3ecbf010c0b8f3bb44d6f359884b726ff30540fee9633242ede49d4dbfd7e93e")
     add_versions("v333", "ee898ca11cef85b09e059b278b3ab4ff58cd38f70169829e75b4a3cb9ddc5013")


### PR DESCRIPTION
New version of libsvm detected (package version: v335, last github version: v336)