### PR TITLE
half: update to 2.2.1 & Fix Windows Android NDK Github CI

### DIFF
--- a/.github/workflows/android_windows.yml
+++ b/.github/workflows/android_windows.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           minimum-size: 8GB
           maximum-size: 32GB
-          disk-root: "D:"
+          disk-root: "C:"
 
       - name: Prepare
         run: |
@@ -47,4 +47,4 @@ jobs:
         run: |
           $Env:XMAKE_MAIN_REPO = "https://github.com/xmake-io/xmake-repo.git"
           xmake --version
-          xmake l ./scripts/test.lua -D -p android --ndk=D:/a/xmake-repo/xmake-repo/ndk/android-ndk-${{ matrix.ndk }} --ndk_sdkver=${{ matrix.ndk_sdkver }} -a ${{ matrix.arch }}
+          xmake l ./scripts/test.lua -D -p android --ndk=C:/a/xmake-repo/xmake-repo/ndk/android-ndk-${{ matrix.ndk }} --ndk_sdkver=${{ matrix.ndk_sdkver }} -a ${{ matrix.arch }}

--- a/packages/h/half/xmake.lua
+++ b/packages/h/half/xmake.lua
@@ -5,6 +5,7 @@ package("half")
     set_license("MIT")
 
     add_urls("https://downloads.sourceforge.net/project/half/half/$(version)/half-$(version).zip")
+    add_versions("2.2.1", "76ddbf406e9d9b772ec73af2bf925b38b290b4390cc4064720a08d4b4bca0aa9")
     add_versions("2.2.0", "1d1d9e482fb95fcd7cab0953a4bd35e00b86578f11cb6939a067811a055a563b")
 
     on_install("windows", "linux", "macosx", "iphoneos", "android", "bsd", function (package)

--- a/packages/m/mimalloc/xmake.lua
+++ b/packages/m/mimalloc/xmake.lua
@@ -6,7 +6,6 @@ package("mimalloc")
     set_urls("https://github.com/microsoft/mimalloc/archive/refs/tags/$(version).zip",
              "https://github.com/microsoft/mimalloc.git")
 
-    add_versions("v2.2.3", "35fa4a4c094bb97571378192f82b78d65b6322ad7f3c6b0ad272058fa829d28c")
     add_versions("v2.1.7", "fa61cf01e3dd869b35275bfd8be95bfde77f0b65dfa7e34012c09a66e1ea463f")
     add_versions("v2.1.2", "86281c918921c1007945a8a31e5ad6ae9af77e510abfec20d000dd05d15123c7")
     add_versions("v2.0.7", "ddb32937aabddedd0d3a57bf68158d4e53ecf9e051618df3331a67182b8b0508")

--- a/packages/m/mimalloc/xmake.lua
+++ b/packages/m/mimalloc/xmake.lua
@@ -6,6 +6,7 @@ package("mimalloc")
     set_urls("https://github.com/microsoft/mimalloc/archive/refs/tags/$(version).zip",
              "https://github.com/microsoft/mimalloc.git")
 
+    add_versions("v2.2.3", "35fa4a4c094bb97571378192f82b78d65b6322ad7f3c6b0ad272058fa829d28c")
     add_versions("v2.1.7", "fa61cf01e3dd869b35275bfd8be95bfde77f0b65dfa7e34012c09a66e1ea463f")
     add_versions("v2.1.2", "86281c918921c1007945a8a31e5ad6ae9af77e510abfec20d000dd05d15123c7")
     add_versions("v2.0.7", "ddb32937aabddedd0d3a57bf68158d4e53ecf9e051618df3331a67182b8b0508")


### PR DESCRIPTION
https://github.com/xmake-io/xmake-repo/issues/7325
Some sort of solution, maybe not the best one.
Windows Android NDK use `C:` drive instead of `D:` drive.
Indeed Github actions and windows-latest worker change slightly, I think this is cause of this issue.
