### PR TITLE
unzip: fix gcc 15

### DIFF
--- a/packages/u/unzip/xmake.lua
+++ b/packages/u/unzip/xmake.lua
@@ -1,5 +1,4 @@
 package("unzip")
-
     set_kind("binary")
     set_homepage("http://infozip.sourceforge.net/UnZip.html")
     set_description("UnZip is an extraction utility for archives compressed in .zip format.")

--- a/packages/u/unzip/xmake.lua
+++ b/packages/u/unzip/xmake.lua
@@ -14,6 +14,7 @@ package("unzip")
             includes("@builtin/check")
             check_cfuncs("HAVE_LCHMOD", "lchmod", {includes = "sys/stat.h"})
             target("unzip")
+                set_languages("gnu17")
                 set_kind("binary")
                 if not has_config("__HAVE_LCHMOD") then
                     add_defines("NO_LCHMOD")


### PR DESCRIPTION
We re going to fix GCC 15 build for `unzip` very important package.
https://patchwork.yoctoproject.org/project/oe-core/patch/20250319081610.3536475-19-raj.khem@gmail.com/
This could be another solution for GCC 15
```diff
--- a/unix/unxcfg.h
+++ b/unix/unxcfg.h
@@ -117,7 +117,6 @@ typedef struct stat z_stat;
 #  endif
 #else
 #  include <time.h>
-   struct tm *gmtime(), *localtime();
 #endif
 
 #if (defined(BSD4_4) || (defined(SYSV) && defined(MODERN)))
```