### PR TITLE
expresscpp: fix build

### DIFF
--- a/packages/e/expresscpp/patches/v0.20.0/fix-build.diff
+++ b/packages/e/expresscpp/patches/v0.20.0/fix-build.diff
@@ -1,3 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6e2240a..037f3c4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -216,6 +216,11 @@ target_link_libraries(${PROJECT_NAME}
+                       PUBLIC nlohmann_json::nlohmann_json
+                              $<TARGET_NAME_IF_EXISTS:Boost::system>
+                       PRIVATE fmt::fmt)
++if(MINGW)
++  target_link_libraries(
++    ${PROJECT_NAME}
++    PRIVATE ws2_32 mswsock)
++endif()
+ target_compile_options(
+   ${PROJECT_NAME}
+   PRIVATE $<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall>
 diff --git a/include/expresscpp/url.hpp b/include/expresscpp/url.hpp
 index fcccc9d..ad0e7af 100644
 --- a/include/expresscpp/url.hpp

--- a/packages/e/expresscpp/patches/v0.20.0/fix-build.diff
+++ b/packages/e/expresscpp/patches/v0.20.0/fix-build.diff
@@ -1,0 +1,24 @@
+diff --git a/include/expresscpp/url.hpp b/include/expresscpp/url.hpp
+index fcccc9d..ad0e7af 100644
+--- a/include/expresscpp/url.hpp
++++ b/include/expresscpp/url.hpp
+@@ -1,6 +1,7 @@
+ #pragma once
+ 
+ #include <string>
++#include <cstdint>
+ 
+ #include "expresscpp/exports.hpp"
+ 
+diff --git a/src/middleware/serve_static_provider.cpp b/src/middleware/serve_static_provider.cpp
+index 3d8d30e..f328992 100644
+--- a/src/middleware/serve_static_provider.cpp
++++ b/src/middleware/serve_static_provider.cpp
+@@ -1,6 +1,7 @@
+ #include "expresscpp/middleware/serve_static_provider.hpp"
+ 
+ #include <filesystem>
++#include <fstream>
+ 
+ #include "expresscpp/console.hpp"
+ #include "expresscpp/impl/session.hpp"

--- a/packages/e/expresscpp/xmake.lua
+++ b/packages/e/expresscpp/xmake.lua
@@ -1,5 +1,4 @@
 package("expresscpp")
-
     set_homepage("https://github.com/expresscpp/expresscpp.git")
     set_description("Fast, unopinionated, minimalist web framework for C++ Perfect for building REST APIs.")
     set_license("MIT")
@@ -9,18 +8,20 @@ package("expresscpp")
 
     add_versions("v0.20.0", "55f10531e4ba162ec768cf9c745ccc7b5a0930c7ad9974b268ad40246276baa8")
 
+    add_patches("v0.20.0", "patches/v0.20.0/fix-build.diff", "e5513fd419c36bfdbfcf12f0f6874350d307587d97acb2a51ece41280630ba0c")
+
     add_deps("cmake")
     add_deps("nlohmann_json", "fmt", {configs = {cmake = true}})
-    add_deps("boost", {configs = {system = true}})
+    add_deps("boost", {configs = {asio = true}})
 
-    if is_plat("linux") then
+    if is_plat("linux", "bsd") then
         add_syslinks("pthread")
     end
 
-    on_install("linux", "macosx", function (package)
+    on_install(function (package)
         local configs = {}
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         import("package.tools.cmake").install(package, configs)
     end)
 

--- a/packages/e/expresscpp/xmake.lua
+++ b/packages/e/expresscpp/xmake.lua
@@ -16,9 +16,11 @@ package("expresscpp")
 
     if is_plat("linux", "bsd") then
         add_syslinks("pthread")
+    elseif is_plat("windows", "mingw") then
+        add_syslinks("ws2_32", "mswsock")
     end
 
-    on_install(function (package)
+    on_install("!wasm and !windows", function (package)
         local configs = {}
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))

--- a/packages/e/expresscpp/xmake.lua
+++ b/packages/e/expresscpp/xmake.lua
@@ -8,7 +8,7 @@ package("expresscpp")
 
     add_versions("v0.20.0", "55f10531e4ba162ec768cf9c745ccc7b5a0930c7ad9974b268ad40246276baa8")
 
-    add_patches("v0.20.0", "patches/v0.20.0/fix-build.diff", "e5513fd419c36bfdbfcf12f0f6874350d307587d97acb2a51ece41280630ba0c")
+    add_patches("v0.20.0", "patches/v0.20.0/fix-build.diff", "09bc180fd8b52f0323d16f1f96bb3a07e2b2fdbe2a48a7a6731637a940d13157")
 
     add_deps("cmake")
     add_deps("nlohmann_json", "fmt", {configs = {cmake = true}})
@@ -16,8 +16,6 @@ package("expresscpp")
 
     if is_plat("linux", "bsd") then
         add_syslinks("pthread")
-    elseif is_plat("windows", "mingw") then
-        add_syslinks("ws2_32", "mswsock")
     end
 
     on_install("!wasm and !windows", function (package)

--- a/packages/e/expresscpp/xmake.lua
+++ b/packages/e/expresscpp/xmake.lua
@@ -16,6 +16,8 @@ package("expresscpp")
 
     if is_plat("linux", "bsd") then
         add_syslinks("pthread")
+    elseif is_plat("windows", "mingw") then
+        add_syslinks("ws2_32", "mswsock")
     end
 
     on_install("!wasm and !windows", function (package)


### PR DESCRIPTION
Fix build for Linux gcc15
Windows:  error: C:\a\xmake-repo\xmake-repo\packages\e\expresscpp\xmake.lua:29: ...gramdir\core\sandbox\modules\import\core\tool\linker.lua:75: @programdir\modules\core\tools\link.lua:193: LINK : fatal error LNK1104: cannot open file 'libboost_filesystem-vc143-mt-a64-1_88.lib'
I do not know how to fix this one.
