### PR TITLE
taocpp-json: add new package

### DIFF
--- a/packages/t/taocpp-json/xmake.lua
+++ b/packages/t/taocpp-json/xmake.lua
@@ -17,7 +17,7 @@ package("taocpp-json")
 pkg_check_modules(pegtl REQUIRED pegtl)]], {plain = true})
         io.replace("CMakeLists.txt",
             [[target_link_libraries(taocpp-json INTERFACE taocpp::pegtl)]],
-            [[target_include_directories(taocpp-json ${pegtl_INCLUDE_DIRS})]], {plain = true})
+            [[target_include_directories(taocpp-json PRIVATE ${pegtl_INCLUDE_DIRS})]], {plain = true})
         local configs = {
             "-DTAOCPP_JSON_BUILD_TESTS=OFF",
             "-DTAOCPP_JSON_BUILD_EXAMPLES=OFF",

--- a/packages/t/taocpp-json/xmake.lua
+++ b/packages/t/taocpp-json/xmake.lua
@@ -8,9 +8,16 @@ package("taocpp-json")
     add_versions("2025.03.11", "11a31e12eda35c1322f9cf6ebb4cca0653d579dc")
 
     add_deps("cmake")
+    add_deps("pkgconf")
     add_deps("pegtl 54a2e32bf4593ed86782b4882702286cc8d621f9")
 
     on_install(function (package)
+        io.replace("CMakeLists.txt",
+            [[find_package(pegtl ${TAOCPP_JSON_PEGTL_MIN_VERSION} QUIET CONFIG)]], [[include(FindPkgConfig)
+pkg_check_modules(pegtl REQUIRED pegtl)]], {plain = true})
+        io.replace("CMakeLists.txt",
+            [[target_link_libraries(taocpp-json INTERFACE taocpp::pegtl)]],
+            [[target_include_directories(${pegtl_INCLUDE_DIRS})]], {plain = true})
         local configs = {
             "-DTAOCPP_JSON_BUILD_TESTS=OFF",
             "-DTAOCPP_JSON_BUILD_EXAMPLES=OFF",

--- a/packages/t/taocpp-json/xmake.lua
+++ b/packages/t/taocpp-json/xmake.lua
@@ -17,7 +17,7 @@ package("taocpp-json")
 pkg_check_modules(pegtl REQUIRED pegtl)]], {plain = true})
         io.replace("CMakeLists.txt",
             [[target_link_libraries(taocpp-json INTERFACE taocpp::pegtl)]],
-            [[target_include_directories(${pegtl_INCLUDE_DIRS})]], {plain = true})
+            [[target_include_directories(taocpp-json ${pegtl_INCLUDE_DIRS})]], {plain = true})
         local configs = {
             "-DTAOCPP_JSON_BUILD_TESTS=OFF",
             "-DTAOCPP_JSON_BUILD_EXAMPLES=OFF",

--- a/packages/t/taocpp-json/xmake.lua
+++ b/packages/t/taocpp-json/xmake.lua
@@ -1,0 +1,30 @@
+package("taocpp-json")
+    set_kind("library", {headeronly = true})
+    set_homepage("https://github.com/taocpp/json")
+    set_description("C++ header-only JSON library")
+    set_license("MIT")
+
+    add_urls("https://github.com/taocpp/json.git")
+    add_versions("2025.03.11", "11a31e12eda35c1322f9cf6ebb4cca0653d579dc")
+
+    add_deps("cmake")
+    add_deps("pegtl 54a2e32bf4593ed86782b4882702286cc8d621f9")
+
+    on_install(function (package)
+        local configs = {
+            "-DTAOCPP_JSON_BUILD_TESTS=OFF",
+            "-DTAOCPP_JSON_BUILD_EXAMPLES=OFF",
+            "-DTAOCPP_JSON_BUILD_PERFORMANCE=OFF",
+            "-DTAOCPP_JSON_INSTALL=ON"
+        }
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            #include <tao/json.hpp>
+            void test() {
+                const tao::json::value v = tao::json::from_file( "filename.json" );
+            }
+        ]]}, {configs = {languages = "c++17"}}))
+    end)

--- a/packages/t/taocpp-json/xmake.lua
+++ b/packages/t/taocpp-json/xmake.lua
@@ -17,7 +17,7 @@ package("taocpp-json")
 pkg_check_modules(pegtl REQUIRED pegtl)]], {plain = true})
         io.replace("CMakeLists.txt",
             [[target_link_libraries(taocpp-json INTERFACE taocpp::pegtl)]],
-            [[target_include_directories(taocpp-json PRIVATE ${pegtl_INCLUDE_DIRS})]], {plain = true})
+            [[target_include_directories(taocpp-json INTERFACE ${pegtl_INCLUDE_DIRS})]], {plain = true})
         local configs = {
             "-DTAOCPP_JSON_BUILD_TESTS=OFF",
             "-DTAOCPP_JSON_BUILD_EXAMPLES=OFF",

--- a/packages/t/taocpp-json/xmake.lua
+++ b/packages/t/taocpp-json/xmake.lua
@@ -4,7 +4,7 @@ package("taocpp-json")
     set_description("C++ header-only JSON library")
     set_license("MIT")
 
-    add_urls("https://github.com/taocpp/json.git")
+    add_urls("https://github.com/taocpp/json.git", {submodules = false})
     add_versions("2025.03.11", "11a31e12eda35c1322f9cf6ebb4cca0653d579dc")
 
     add_deps("cmake")


### PR DESCRIPTION
Latest pegtl release wont work, since too old.
```
C:\Users\Admin\AppData\Local\.xmake\packages\j\json\2025.03.11\36a027cd729542b880966f8d2d7625bd\include/tao/json/jaxn/internal/grammar.hpp: In static member function 'static bool tao::json::jaxn::internal::rules::sor_value_impl<String, Binary>::match_must(Input&, States&& ...)':
C:\Users\Admin\AppData\Local\.xmake\packages\j\json\2025.03.11\36a027cd729542b880966f8d2d7625bd\include/tao/json/jaxn/internal/grammar.hpp:245:77: error: 'optional' is not a member of 'tao::pegtl::rewind_mode' [-Wtemplate-body]
  245 |             return Control< must< Rule > >::template match< A, rewind_mode::optional, Action, Control >( in, st... );
```
