### PR TITLE
bandit: new package

### DIFF
--- a/packages/b/bandit/patches/2023.08.05/debundle-snowhouse.patch
+++ b/packages/b/bandit/patches/2023.08.05/debundle-snowhouse.patch
@@ -1,0 +1,13 @@
+diff --git a/bandit/adapters/snowhouse.h b/bandit/adapters/snowhouse.h
+index f3d9fde..ee3844c 100644
+--- a/bandit/adapters/snowhouse.h
++++ b/bandit/adapters/snowhouse.h
+@@ -3,7 +3,7 @@
+ 
+ #include <bandit/adapters/interface.h>
+ #include <bandit/assertion_exception.h>
+-#include <bandit/assertion_frameworks/snowhouse/snowhouse.h>
++#include <snowhouse/snowhouse.h>
+ 
+ namespace bandit {
+   namespace adapter {

--- a/packages/b/bandit/xmake.lua
+++ b/packages/b/bandit/xmake.lua
@@ -1,0 +1,30 @@
+package("bandit")
+    set_kind("library", {headeronly = true})
+    set_homepage("https://banditcpp.github.io/bandit/")
+    set_description("Human-friendly unit testing for C++11")
+
+    add_urls("https://github.com/banditcpp/bandit.git", {submodules = false})
+
+    add_versions("2023.08.05", "f297efd8aecc6e9ce8f84e33264898bf77f9cb73")
+    add_patches("2023.08.05", "patches/2023.08.05/debundle-snowhouse.patch", "66d5f6beb2a2f099b7e22ed6b7993f70ee01630e0df10f149c4d0e792b3a42a0")
+
+    add_deps("snowhouse")
+
+    on_install(function (package)
+        os.cp("bandit", package:installdir("include"))
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            #include <bandit/bandit.h>
+            using namespace bandit;
+            go_bandit([](){
+                AssertThat(123, snowhouse::Equals(123));
+            });
+            void test() {
+                int argc;
+                char* argv[2];
+                bandit::run(argc, argv);
+            }
+        ]]}, {configs = {languages = "c++11"}}))
+    end)


### PR DESCRIPTION
Latest release tag does not support snowhouse 5.0.0, so workaround is to use latest changes commit.

