### PR TITLE
Auto-update kahip to v3.19

### DIFF
--- a/packages/k/kahip/xmake.lua
+++ b/packages/k/kahip/xmake.lua
@@ -6,6 +6,7 @@ package("kahip")
 
     add_urls("https://github.com/KaHIP/KaHIP/archive/refs/tags/$(version).tar.gz",
              "https://github.com/KaHIP/KaHIP.git")
+    add_versions("v3.19", "ab128104d198061b4dcad76f760aca240b96de781c1b586235ee4f12fd6829c6")
     add_versions("v3.18", "e5003fa324362255d837899186cd0c3e42d376664f0d555e7e7a1d51334817c9")
     add_versions("v3.17", "3aa5fedf5a69fd3771ac97b4dbcc40f6f8a45f6c8b64e30d85c95cee124e38c3")
     add_versions("v3.16", "b0ef72a26968d37d9baa1304f7a113b61e925966a15e86578d44e26786e76c75")


### PR DESCRIPTION
New version of kahip detected (package version: v3.18, last github version: v3.19)