### PR TITLE
Auto-update simple_http to v0.3.0

### DIFF
--- a/packages/s/simple_http/xmake.lua
+++ b/packages/s/simple_http/xmake.lua
@@ -7,6 +7,7 @@ package("simple_http")
     add_urls("https://github.com/fantasy-peak/simple_http/archive/refs/tags/$(version).tar.gz",
              "https://github.com/fantasy-peak/simple_http.git")
 
+    add_versions("v0.3.0", "2ed94c4ed0b8ee5cb512cc95417725a8b37cf1071ee46b4eac4591db27ec9fd3")
     add_versions("v0.2.0", "1c2ab7c2be317f95e34bdbe6c753293495b6743828ec4115b5f3c383c8c95adc")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of simple_http detected (package version: v0.2.0, last github version: v0.3.0)