### PR TITLE
Auto-update cppjieba to v5.6.0

### DIFF
--- a/packages/c/cppjieba/xmake.lua
+++ b/packages/c/cppjieba/xmake.lua
@@ -7,6 +7,7 @@ package("cppjieba")
     add_urls("https://github.com/yanyiwu/cppjieba/archive/refs/tags/$(version).tar.gz",
              "https://github.com/yanyiwu/cppjieba.git", {submodules = false})
 
+    add_versions("v5.6.0", "e6e517b778e0f4a99cbed1ee3eaa041616b74bc685e03a6ca08887ad9cedfe49")
     add_versions("v5.5.0", "5919269a0929399616ef7b38240c3a12cfe3323ea4c7c101976ce8ffb9c1c7dc")
     add_versions("v5.4.1", "ee5b542dfd24713256e612588f0f2fbecba802c324da6cd2231792c02f9c062c")
     add_versions("v5.4.0", "6358e7f961e601ee6a01ce968bd07dad4e455a2c8721520d0304cc94b2d029ee")


### PR DESCRIPTION
New version of cppjieba detected (package version: v5.5.0, last github version: v5.6.0)