### PR TITLE
Auto-update qwindowkit to 1.4.0

### DIFF
--- a/packages/q/qwindowkit/xmake.lua
+++ b/packages/q/qwindowkit/xmake.lua
@@ -6,6 +6,7 @@ package("qwindowkit")
     add_urls("https://github.com/stdware/qwindowkit/archive/refs/tags/$(version).tar.gz",
              "https://github.com/stdware/qwindowkit.git")
 
+    add_versions("1.4.0", "6d518d55a8e80243b625dc872b2dd93d753339829fa13e6e2ae071e6c145ed6c")
     add_versions("1.1", "a0102ee4c4fdd08ce35c29a5b9a27384005028b2ab6094f61e467c35917b8c5e")
     add_versions("1.2", "f06b4befc54c6e2c764dbec8a970ce7ffbe561e76a52ea121dca84598f4035b8")
 


### PR DESCRIPTION
New version of qwindowkit detected (package version: 1.2, last github version: 1.4.0)