### PR TITLE
Auto-update aws-c-mqtt to v0.13.2

### DIFF
--- a/packages/a/aws-c-mqtt/xmake.lua
+++ b/packages/a/aws-c-mqtt/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-mqtt")
     add_urls("https://github.com/awslabs/aws-c-mqtt/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-mqtt.git")
 
+    add_versions("v0.13.2", "8d22b181e4c90f5c683e786aadb9fb59a30a699c332e96e16595216ef9058c2f")
     add_versions("v0.12.3", "c2ea5d3b34692c5b71ec4ff3efd8277af01f16706970e8851373c361abaf1d72")
     add_versions("v0.12.1", "04abe47c798bf9dcb95e25ea9acd62a35a3f22e58b61c16912a6275c2f8230fe")
     add_versions("v0.11.0", "3854664c13896b6de3d56412f928435a4933259cb7fe62b10c1f497e6999333c")


### PR DESCRIPTION
New version of aws-c-mqtt detected (package version: v0.12.3, last github version: v0.13.2)