### PR TITLE
Auto-update dlib to v20.0

### DIFF
--- a/packages/d/dlib/xmake.lua
+++ b/packages/d/dlib/xmake.lua
@@ -6,6 +6,7 @@ package("dlib")
     add_urls("https://github.com/davisking/dlib/archive/refs/tags/$(version).tar.gz",
              "https://github.com/davisking/dlib.git")
 
+    add_versions("v20.0", "705749801c7896f5c19c253b6be639f4cef2c1831a9606955f01b600b3d86d80")
     add_versions("v19.24.9", "65ff8debc3ffea84430bdd4992982082caf505404e16d986b7493c00f96f44e9")
     add_versions("v19.24.8", "819cfd28639fe80ca28039f591a15e01772b7ada479de4a002b95bcb8077ce80")
     add_versions("v19.24.6", "22513c353ec9c153300c394050c96ca9d088e02966ac0f639e989e50318c82d6")


### PR DESCRIPTION
New version of dlib detected (package version: v19.24.9, last github version: v20.0)