### PR TITLE
Auto-update minizip-ng to 4.0.10

### DIFF
--- a/packages/m/minizip-ng/xmake.lua
+++ b/packages/m/minizip-ng/xmake.lua
@@ -6,6 +6,7 @@ package("minizip-ng")
     add_urls("https://github.com/zlib-ng/minizip-ng/archive/refs/tags/$(version).tar.gz",
              "https://github.com/zlib-ng/minizip-ng.git")
 
+    add_versions("4.0.10", "c362e35ee973fa7be58cc5e38a4a6c23cc8f7e652555daf4f115a9eb2d3a6be7")
     add_versions("4.0.8", "c3e9ceab2bec26cb72eba1cf46d0e2c7cad5d2fe3adf5df77e17d6bbfea4ec8f")
     add_versions("4.0.7", "a87f1f734f97095fe1ef0018217c149d53d0f78438bcb77af38adc21dff2dfbc")
     add_versions("4.0.6", "e96ed3866706a67dbed05bf035e26ef6b60f408e1381bf0fe9af17fe2c0abebc")


### PR DESCRIPTION
New version of minizip-ng detected (package version: 4.0.8, last github version: 4.0.10)