### PR TITLE
Auto-update cpp-channel to v1.3.1

### DIFF
--- a/packages/c/cpp-channel/xmake.lua
+++ b/packages/c/cpp-channel/xmake.lua
@@ -7,6 +7,7 @@ package("cpp-channel")
     add_urls("https://github.com/andreiavrammsd/cpp-channel/archive/refs/tags/$(version).zip",
              "https://github.com/andreiavrammsd/cpp-channel.git")
 
+    add_versions("v1.3.1", "16b1b8d38ef78b35ec99bfb49ae2664181261f9319d1dd09d483d62feee80a2d")
     add_versions("v0.8.3", "095102dd7be6a2087206fc22ec2e32b4eb687f25f8d57d36355290ffb203e4d7")
     add_versions("v0.8.2", "36f234c40d59b90356d37b558a8918a86b128030ad5d42d8c6a627cfe81c8624")
 


### PR DESCRIPTION
New version of cpp-channel detected (package version: v0.8.3, last github version: v1.3.1)