### PR TITLE
Update libmem to 5.0.5 add MinGW support and add clang-cl support

### DIFF
--- a/packages/k/keystone/patches/0.9.2/fix-gcc15.diff
+++ b/packages/k/keystone/patches/0.9.2/fix-gcc15.diff
@@ -1,0 +1,94 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 938d4983..9ce08362 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ # Keystone Assembler Engine (www.keystone-engine.org)
+ # By Nguyen Anh Quynh, 2016
+ 
+-cmake_minimum_required(VERSION 2.8.7)
++cmake_minimum_required(VERSION 3.10.0)
+ project(keystone)
+ 
+ set(KEYSTONE_VERSION_MAJOR 0)
+@@ -15,23 +15,6 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+   set(CMAKE_BUILD_TYPE "Debug")
+ endif()
+ 
+-if (POLICY CMP0022)
+-  cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
+-endif()
+-
+-if (POLICY CMP0051)
+-  # CMake 3.1 and higher include generator expressions of the form
+-  # $<TARGETLIB:obj> in the SOURCES property.  These need to be
+-  # stripped everywhere that access the SOURCES property, so we just
+-  # defer to the OLD behavior of not including generator expressions
+-  # in the output for now.
+-  cmake_policy(SET CMP0051 OLD)
+-endif()
+-
+-if (POLICY CMP0063)
+-  set(CMAKE_POLICY_DEFAULT_CMP0063 NEW) # automatic when 3.3.2 is required
+-endif()
+-
+ if (CMAKE_VERSION VERSION_LESS 3.1.20141117)
+   set(cmake_3_2_USES_TERMINAL)
+ else()
+diff --git a/kstool/CMakeLists.txt b/kstool/CMakeLists.txt
+index d28da481..25113821 100644
+--- a/kstool/CMakeLists.txt
++++ b/kstool/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ # Kstool for Keystone assembler engine.
+ # By Nguyen Anh Quynh, 2016
+ 
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.10.0)
+ 
+ project(kstool)
+ 
+diff --git a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
+index d926b082..518613a5 100644
+--- a/llvm/CMakeLists.txt
++++ b/llvm/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ # See docs/CMake.html for instructions about how to build LLVM with CMake.
+ 
+-cmake_minimum_required(VERSION 2.8.7)
++cmake_minimum_required(VERSION 3.10.0)
+ 
+ set(LLVM_INSTALL_TOOLCHAIN_ONLY ON)
+ 
+@@ -9,19 +9,6 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+   set(CMAKE_BUILD_TYPE "Debug")
+ endif()
+ 
+-if(POLICY CMP0022)
+-  cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
+-endif()
+-
+-if (POLICY CMP0051)
+-  # CMake 3.1 and higher include generator expressions of the form
+-  # $<TARGETLIB:obj> in the SOURCES property.  These need to be
+-  # stripped everywhere that access the SOURCES property, so we just
+-  # defer to the OLD behavior of not including generator expressions
+-  # in the output for now.
+-  cmake_policy(SET CMP0051 OLD)
+-endif()
+-
+ if(CMAKE_VERSION VERSION_LESS 3.1.20141117)
+   set(cmake_3_2_USES_TERMINAL)
+ else()
+diff --git a/llvm/include/llvm/ADT/STLExtras.h b/llvm/include/llvm/ADT/STLExtras.h
+index 3346de93..a2adf853 100644
+--- a/llvm/include/llvm/ADT/STLExtras.h
++++ b/llvm/include/llvm/ADT/STLExtras.h
+@@ -21,6 +21,7 @@
+ #include <algorithm> // for std::all_of
+ #include <cassert>
+ #include <cstddef> // for std::size_t
++#include <cstdint>
+ #include <cstdlib> // for qsort
+ #include <functional>
+ #include <iterator>

--- a/packages/k/keystone/xmake.lua
+++ b/packages/k/keystone/xmake.lua
@@ -17,7 +17,9 @@ package("keystone")
     end
 
     on_load(function (package)
-        if package:is_cross() or package:is_plat("mingw") or (package:is_plat("windows") and package:config("shared")) then
+        if package:is_cross() or package:is_plat("mingw") or 
+            (package:is_plat("windows") and package:config("shared")) or
+            (package:is_plat("windows") and package:has_tool("cc", "clang", "clang_cl")) then
             package:data_set("build_libs_only", true)
         end
         if not package:data("build_libs_only") then

--- a/packages/k/keystone/xmake.lua
+++ b/packages/k/keystone/xmake.lua
@@ -8,6 +8,8 @@ package("keystone")
 
     add_versions("0.9.2", "c9b3a343ed3e05ee168d29daf89820aff9effb2c74c6803c2d9e21d55b5b7c24")
 
+    add_patches("0.9.2", "patches/0.9.2/fix-gcc15.diff", "6b2140fdb0e446d746feb44e71d6f6cf1afcc733282de364be37f527ab7d039f")
+
     add_deps("cmake", "python 3.x", {kind = "binary"})
 
     if is_plat("windows", "mingw") then

--- a/packages/k/keystone/xmake.lua
+++ b/packages/k/keystone/xmake.lua
@@ -12,6 +12,12 @@ package("keystone")
 
     add_deps("cmake", "python 3.x", {kind = "binary"})
 
+    if is_subhost("windows") then
+        add_deps("pkgconf")
+    else
+        add_deps("pkg-config")
+    end
+
     if is_plat("windows", "mingw") then
         add_syslinks("shell32", "ole32", "uuid")
     end

--- a/packages/l/libmem/patches/5.0.5/fix-mingw.diff
+++ b/packages/l/libmem/patches/5.0.5/fix-mingw.diff
@@ -1,0 +1,84 @@
+diff --git a/src/win/memory.c b/src/win/memory.c
+index 07a4024..1f26ffb 100644
+--- a/src/win/memory.c
++++ b/src/win/memory.c
+@@ -50,8 +50,13 @@ LM_ReadMemoryEx(const lm_process_t *process,
+ 	if (!hproc)
+ 		return 0;
+ 
++	#if defined(__MINGW32__)
++	if (!ReadProcessMemory(hproc, (LPCVOID)source, dest, size, &bytes_read))
++		bytes_read = 0;
++	#else
+ 	if (!ReadProcessMemory(hproc, source, dest, size, &bytes_read))
+ 		bytes_read = 0;
++	#endif
+ 
+ 	close_handle(hproc);
+ 	return (lm_size_t)bytes_read;
+@@ -75,8 +80,13 @@ LM_WriteMemoryEx(const lm_process_t *process,
+ 	if (!hproc)
+ 		return 0;
+ 
++	#if defined(__MINGW32__)
++	if (!WriteProcessMemory(hproc, (LPVOID)dest, source, size, &bytes_written))
++		bytes_written = 0;
++	#else
+ 	if (!WriteProcessMemory(hproc, dest, source, size, &bytes_written))
+ 		bytes_written = 0;
++	#endif
+ 
+ 	close_handle(hproc);
+ 	return (lm_size_t)bytes_written;
+@@ -100,8 +110,13 @@ LM_ProtMemory(lm_address_t address,
+ 		size = get_page_size();
+ 
+ 	osprot = get_os_prot(prot);
++	#if defined(__MINGW32__)
++	if (!VirtualProtect((LPVOID)address, size, osprot, &old_osprot))
++		return LM_FALSE;
++	#else
+ 	if (!VirtualProtect(address, size, osprot, &old_osprot))
+ 		return LM_FALSE;
++	#endif
+ 
+ 	if (oldprot_out)
+ 		*oldprot_out = get_prot(old_osprot);
+@@ -134,8 +149,13 @@ LM_ProtMemoryEx(const lm_process_t *process,
+ 		return result;
+ 
+ 	osprot = get_os_prot(prot);
++	#if defined(__MINGW32__)
++	if (!VirtualProtectEx(hproc, (LPVOID)address, size, osprot, &old_osprot))
++		goto CLOSE_EXIT;
++	#else
+ 	if (!VirtualProtectEx(hproc, address, size, osprot, &old_osprot))
+ 		goto CLOSE_EXIT;
++	#endif
+ 
+ 	if (oldprot_out)
+ 		*oldprot_out = get_prot(old_osprot);
+@@ -212,7 +232,11 @@ LM_FreeMemory(lm_address_t alloc,
+ 	 */
+ 
+ 	size = 0;
++	#if defined(__MINGW32__)
++	return VirtualFree((LPVOID)alloc, size, MEM_RELEASE) ? LM_TRUE : LM_FALSE;
++	#else
+ 	return VirtualFree(alloc, size, MEM_RELEASE) ? LM_TRUE : LM_FALSE;
++	#endif
+ }
+ 
+ /********************************/
+@@ -233,7 +257,11 @@ LM_FreeMemoryEx(const lm_process_t *process,
+ 		return LM_FALSE;
+ 
+ 	size = 0;
++	#if defined(__MINGW32__)
++	ret = VirtualFreeEx(hproc, (LPVOID)alloc, size, MEM_RELEASE);
++	#else
+ 	ret = VirtualFreeEx(hproc, alloc, size, MEM_RELEASE);
++	#endif
+ 
+ 	close_handle(hproc);
+ 

--- a/packages/l/libmem/patches/5.0.5/fix-mingw.diff
+++ b/packages/l/libmem/patches/5.0.5/fix-mingw.diff
@@ -1,12 +1,12 @@
 diff --git a/src/win/memory.c b/src/win/memory.c
-index 07a4024..1f26ffb 100644
+index 07a4024..ab3868c 100644
 --- a/src/win/memory.c
 +++ b/src/win/memory.c
 @@ -50,8 +50,13 @@ LM_ReadMemoryEx(const lm_process_t *process,
  	if (!hproc)
  		return 0;
  
-+	#if defined(__MINGW32__)
++	#if defined(__MINGW32__) || defined(__clang__)
 +	if (!ReadProcessMemory(hproc, (LPCVOID)source, dest, size, &bytes_read))
 +		bytes_read = 0;
 +	#else
@@ -20,7 +20,7 @@ index 07a4024..1f26ffb 100644
  	if (!hproc)
  		return 0;
  
-+	#if defined(__MINGW32__)
++	#if defined(__MINGW32__) || defined(__clang__)
 +	if (!WriteProcessMemory(hproc, (LPVOID)dest, source, size, &bytes_written))
 +		bytes_written = 0;
 +	#else
@@ -34,7 +34,7 @@ index 07a4024..1f26ffb 100644
  		size = get_page_size();
  
  	osprot = get_os_prot(prot);
-+	#if defined(__MINGW32__)
++	#if defined(__MINGW32__) || defined(__clang__)
 +	if (!VirtualProtect((LPVOID)address, size, osprot, &old_osprot))
 +		return LM_FALSE;
 +	#else
@@ -48,7 +48,7 @@ index 07a4024..1f26ffb 100644
  		return result;
  
  	osprot = get_os_prot(prot);
-+	#if defined(__MINGW32__)
++	#if defined(__MINGW32__) || defined(__clang__)
 +	if (!VirtualProtectEx(hproc, (LPVOID)address, size, osprot, &old_osprot))
 +		goto CLOSE_EXIT;
 +	#else
@@ -62,7 +62,7 @@ index 07a4024..1f26ffb 100644
  	 */
  
  	size = 0;
-+	#if defined(__MINGW32__)
++	#if defined(__MINGW32__) || defined(__clang__)
 +	return VirtualFree((LPVOID)alloc, size, MEM_RELEASE) ? LM_TRUE : LM_FALSE;
 +	#else
  	return VirtualFree(alloc, size, MEM_RELEASE) ? LM_TRUE : LM_FALSE;
@@ -74,7 +74,7 @@ index 07a4024..1f26ffb 100644
  		return LM_FALSE;
  
  	size = 0;
-+	#if defined(__MINGW32__)
++	#if defined(__MINGW32__) || defined(__clang__)
 +	ret = VirtualFreeEx(hproc, (LPVOID)alloc, size, MEM_RELEASE);
 +	#else
  	ret = VirtualFreeEx(hproc, alloc, size, MEM_RELEASE);
@@ -83,14 +83,14 @@ index 07a4024..1f26ffb 100644
  	close_handle(hproc);
  
 diff --git a/src/win/module.c b/src/win/module.c
-index 013b03d..584222f 100644
+index 013b03d..07ba91b 100644
 --- a/src/win/module.c
 +++ b/src/win/module.c
 @@ -123,14 +123,23 @@ LM_LoadModuleEx(const lm_process_t *process,
  	if (modpath_addr == LM_ADDRESS_BAD)
  		return result;
  
-+	#if defined(__MINGW32__)
++	#if defined(__MINGW32__) || defined(__clang__)
 +	if (!LM_WriteMemoryEx(process, modpath_addr, (lm_bytearray_t)wpath, sizeof(wpath)))
 +		goto FREE_EXIT;
 +	#else
@@ -102,7 +102,7 @@ index 013b03d..584222f 100644
  	if (!hproc)
  		goto FREE_EXIT;
  
-+	#if defined(__MINGW32__)
++	#if defined(__MINGW32__) || defined(__clang__)
 +	hthread = (HANDLE)CreateRemoteThread(hproc, NULL, 0, (LPTHREAD_START_ROUTINE)LoadLibraryW, (LPVOID)modpath_addr, 0, NULL);
 +	#else
  	hthread = (HANDLE)CreateRemoteThread(hproc, NULL, 0, (LPTHREAD_START_ROUTINE)LoadLibraryW, modpath_addr, 0, NULL);
@@ -114,7 +114,7 @@ index 013b03d..584222f 100644
  	if (!hproc)
  		return LM_FALSE;
  
-+	#if defined(__MINGW32__)
++	#if defined(__MINGW32__) || defined(__clang__)
 +	hthread = (HANDLE)CreateRemoteThread(hproc, NULL, 0, (LPTHREAD_START_ROUTINE)FreeLibrary, (LPVOID)module->base, 0, NULL);
 +	#else
  	hthread = (HANDLE)CreateRemoteThread(hproc, NULL, 0, (LPTHREAD_START_ROUTINE)FreeLibrary, module->base, 0, NULL);
@@ -123,7 +123,7 @@ index 013b03d..584222f 100644
  	close_handle(&hproc);
  
 diff --git a/src/win/segment.c b/src/win/segment.c
-index bed38e0..6601e16 100644
+index bed38e0..fc9af97 100644
 --- a/src/win/segment.c
 +++ b/src/win/segment.c
 @@ -39,7 +39,11 @@ LM_EnumSegments(lm_bool_t (LM_CALL *callback)(lm_segment_t *segment,
@@ -131,7 +131,7 @@ index bed38e0..6601e16 100644
  
  	for (address = 0;
 -	     VirtualQuery(address, &meminfo, sizeof(meminfo)) > 0;
-+	     #if defined(__MINGW32__)
++	     #if defined(__MINGW32__) || defined(__clang__)
 +     	 VirtualQuery((LPCVOID)address, &meminfo, sizeof(meminfo)) > 0;
 +		 #else
 +     	 VirtualQuery(address, &meminfo, sizeof(meminfo)) > 0;
@@ -143,7 +143,7 @@ index bed38e0..6601e16 100644
  
  	/* TODO: Add fix for 32 bit processes enumerating 64 bit target processes (avoid address overflow) */
  	for (address = 0;
-+	     #if defined(__MINGW32__)
++	     #if defined(__MINGW32__) || defined(__clang__)
 +		 VirtualQueryEx(hproc, (LPCVOID)address, &meminfo, sizeof(meminfo)) > 0;
 +		 #else
  	     VirtualQueryEx(hproc, address, &meminfo, sizeof(meminfo)) > 0;

--- a/packages/l/libmem/patches/5.0.5/fix-mingw.diff
+++ b/packages/l/libmem/patches/5.0.5/fix-mingw.diff
@@ -82,3 +82,72 @@ index 07a4024..1f26ffb 100644
  
  	close_handle(hproc);
  
+diff --git a/src/win/module.c b/src/win/module.c
+index 013b03d..584222f 100644
+--- a/src/win/module.c
++++ b/src/win/module.c
+@@ -123,14 +123,23 @@ LM_LoadModuleEx(const lm_process_t *process,
+ 	if (modpath_addr == LM_ADDRESS_BAD)
+ 		return result;
+ 
++	#if defined(__MINGW32__)
++	if (!LM_WriteMemoryEx(process, modpath_addr, (lm_bytearray_t)wpath, sizeof(wpath)))
++		goto FREE_EXIT;
++	#else
+ 	if (!LM_WriteMemoryEx(process, modpath_addr, wpath, sizeof(wpath)))
+ 		goto FREE_EXIT;
++	#endif
+ 
+ 	hproc = open_process(process->pid, PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION | PROCESS_VM_OPERATION | PROCESS_VM_WRITE | PROCESS_VM_READ);
+ 	if (!hproc)
+ 		goto FREE_EXIT;
+ 
++	#if defined(__MINGW32__)
++	hthread = (HANDLE)CreateRemoteThread(hproc, NULL, 0, (LPTHREAD_START_ROUTINE)LoadLibraryW, (LPVOID)modpath_addr, 0, NULL);
++	#else
+ 	hthread = (HANDLE)CreateRemoteThread(hproc, NULL, 0, (LPTHREAD_START_ROUTINE)LoadLibraryW, modpath_addr, 0, NULL);
++	#endif
+ 
+ 	close_handle(&hproc);
+ 
+@@ -194,7 +203,11 @@ LM_UnloadModuleEx(const lm_process_t *process,
+ 	if (!hproc)
+ 		return LM_FALSE;
+ 
++	#if defined(__MINGW32__)
++	hthread = (HANDLE)CreateRemoteThread(hproc, NULL, 0, (LPTHREAD_START_ROUTINE)FreeLibrary, (LPVOID)module->base, 0, NULL);
++	#else
+ 	hthread = (HANDLE)CreateRemoteThread(hproc, NULL, 0, (LPTHREAD_START_ROUTINE)FreeLibrary, module->base, 0, NULL);
++	#endif
+ 
+ 	close_handle(&hproc);
+ 
+diff --git a/src/win/segment.c b/src/win/segment.c
+index bed38e0..6601e16 100644
+--- a/src/win/segment.c
++++ b/src/win/segment.c
+@@ -39,7 +39,11 @@ LM_EnumSegments(lm_bool_t (LM_CALL *callback)(lm_segment_t *segment,
+ 		return result;
+ 
+ 	for (address = 0;
+-	     VirtualQuery(address, &meminfo, sizeof(meminfo)) > 0;
++	     #if defined(__MINGW32__)
++     	 VirtualQuery((LPCVOID)address, &meminfo, sizeof(meminfo)) > 0;
++		 #else
++     	 VirtualQuery(address, &meminfo, sizeof(meminfo)) > 0;
++		 #endif
+ 	     address += meminfo.RegionSize) {
+ 		/* Skip unallocated regions */
+ 		if (meminfo.State == MEM_FREE)
+@@ -82,7 +86,11 @@ LM_EnumSegmentsEx(const lm_process_t *process,
+ 
+ 	/* TODO: Add fix for 32 bit processes enumerating 64 bit target processes (avoid address overflow) */
+ 	for (address = 0;
++	     #if defined(__MINGW32__)
++		 VirtualQueryEx(hproc, (LPCVOID)address, &meminfo, sizeof(meminfo)) > 0;
++		 #else
+ 	     VirtualQueryEx(hproc, address, &meminfo, sizeof(meminfo)) > 0;
++		 #endif
+ 	     address += meminfo.RegionSize) {
+ 		/* Skip unallocated regions */
+ 		if (meminfo.State == MEM_FREE)

--- a/packages/l/libmem/xmake.lua
+++ b/packages/l/libmem/xmake.lua
@@ -4,13 +4,13 @@ package("libmem")
     set_license("AGPL-3.0")
 
     add_urls("https://github.com/rdbo/libmem/archive/refs/tags/$(version).tar.gz",
-            "https://github.com/rdbo/libmem.git")
+             "https://github.com/rdbo/libmem.git", {submodules = false})
     add_versions("5.0.5", "9693d38b17b000b06cd9fbaff72f4e0873d3cf219a6e99a20bb90cf98a7b562d")
     add_versions("5.0.4", "32b968fb2bd1e33ae854db3bd3fc9ce4374bd9e61ff420f365c52d5f7bbd85dd")
     add_versions("5.0.3", "75a190d1195c641c7d5d2c37ac79d8d1b5f18e43268d023454765a566d6f0d88")
     add_versions("5.0.2", "99adea3e86bd3b83985dce9076adda16968646ebd9d9316c9f57e6854aeeab9c")
 
-    add_patches("5.0.5", "patches/5.0.5/fix-mingw.diff", "8f0ab37c35c4968fce10c321cfdd40685418eaac7f066d3337c6229e9c55cee7")
+    add_patches("5.0.5", "patches/5.0.5/fix-mingw.diff", "6cc818cc5443bd45f1f168a1b8d20ca50538e75929c119569fd36d13f5f9fa63")
 
     add_deps("capstone", "keystone")
 
@@ -31,7 +31,7 @@ package("libmem")
         end
     end)
 
-    on_install("windows", "linux|!arm64", "bsd", "mingw", function (package)
+    on_install("windows", "linux|!arm64", "bsd", "mingw", "msys", function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         import("package.tools.xmake").install(package)
     end)

--- a/packages/l/libmem/xmake.lua
+++ b/packages/l/libmem/xmake.lua
@@ -5,6 +5,7 @@ package("libmem")
 
     add_urls("https://github.com/rdbo/libmem/archive/refs/tags/$(version).tar.gz",
             "https://github.com/rdbo/libmem.git")
+    add_versions("5.0.5", "9693d38b17b000b06cd9fbaff72f4e0873d3cf219a6e99a20bb90cf98a7b562d")
     add_versions("5.0.4", "32b968fb2bd1e33ae854db3bd3fc9ce4374bd9e61ff420f365c52d5f7bbd85dd")
     add_versions("5.0.3", "75a190d1195c641c7d5d2c37ac79d8d1b5f18e43268d023454765a566d6f0d88")
     add_versions("5.0.2", "99adea3e86bd3b83985dce9076adda16968646ebd9d9316c9f57e6854aeeab9c")
@@ -28,7 +29,7 @@ package("libmem")
         end
     end)
 
-    on_install("windows", "linux", "bsd", function (package)
+    on_install("windows", "linux", "bsd", "mingw", function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         import("package.tools.xmake").install(package)
     end)

--- a/packages/l/libmem/xmake.lua
+++ b/packages/l/libmem/xmake.lua
@@ -10,6 +10,8 @@ package("libmem")
     add_versions("5.0.3", "75a190d1195c641c7d5d2c37ac79d8d1b5f18e43268d023454765a566d6f0d88")
     add_versions("5.0.2", "99adea3e86bd3b83985dce9076adda16968646ebd9d9316c9f57e6854aeeab9c")
 
+    add_patches("5.0.5", "patches/5.0.5/fix-mingw.diff", "8f0ab37c35c4968fce10c321cfdd40685418eaac7f066d3337c6229e9c55cee7")
+
     add_deps("capstone", "keystone")
 
     if is_plat("windows", "mingw") then
@@ -29,7 +31,7 @@ package("libmem")
         end
     end)
 
-    on_install("windows", "linux", "bsd", "mingw", function (package)
+    on_install("windows", "linux|!arm64", "bsd", "mingw", function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         import("package.tools.xmake").install(package)
     end)

--- a/packages/l/libmem/xmake.lua
+++ b/packages/l/libmem/xmake.lua
@@ -10,7 +10,7 @@ package("libmem")
     add_versions("5.0.3", "75a190d1195c641c7d5d2c37ac79d8d1b5f18e43268d023454765a566d6f0d88")
     add_versions("5.0.2", "99adea3e86bd3b83985dce9076adda16968646ebd9d9316c9f57e6854aeeab9c")
 
-    add_patches("5.0.5", "patches/5.0.5/fix-mingw.diff", "6cc818cc5443bd45f1f168a1b8d20ca50538e75929c119569fd36d13f5f9fa63")
+    add_patches("5.0.5", "patches/5.0.5/fix-mingw.diff", "7239f459204975ce2efcf63529dcb09273028c4dc166d7cbacb5f5f0e70f93a9")
 
     add_deps("capstone", "keystone")
 


### PR DESCRIPTION
Just test, I assume keystone is broken for GCC15.

- [x] Limit Linux arm64 for libmem - not supported
- [x] Fix GCC15 build for keystone
- [x] Fix and add support for MinGW for libmem
- [x] Fix clang-cl build for Windows (`xmake l scripts/test.lua --toolchain=clang-cl -vD -k shared --shallow libmem` for MSVC-ish clang provided by Developer Command Prompt 2022 Preview)
- [x] Gift pkgconf to Windows users just in case they miss it during keystone build. (If pkgconf not found on build machine it would result failed build -> windows users usually do not have pkgconf at all.)

------

TODO: clang-cl build succeeds. (`C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\Llvm\bin\clang-cl.exe`)