### PR TITLE
Auto-update quill to v10.0.0

### DIFF
--- a/packages/q/quill/xmake.lua
+++ b/packages/q/quill/xmake.lua
@@ -6,6 +6,7 @@ package("quill")
     set_urls("https://github.com/odygrd/quill/archive/refs/tags/$(version).tar.gz",
              "https://github.com/odygrd/quill.git")
 
+    add_versions("v10.0.0", "a90128cedeae3ba63e9cdec180b99c440ba61b0e470a177e8127a6991f47f261")
     add_versions("v9.0.3", "209b9a3fed9b44f61a50acc34fdc9f5f22338c03644728466e2f4a4b83036476")
     add_versions("v9.0.2", "7f5c6fbcc779d7d47a473b209a18908aadd691b2e3c82c4264ea015f6fbe4859")
     add_versions("v8.2.0", "17381f3ff19af9b1fb4e8ba83f4f3c9e3e54c4aea58353282f4d3ac3e9002224")


### PR DESCRIPTION
New version of quill detected (package version: v9.0.3, last github version: v10.0.0)