### PR TITLE
Auto-update libuv to v1.51.0

### DIFF
--- a/packages/l/libuv/xmake.lua
+++ b/packages/l/libuv/xmake.lua
@@ -6,6 +6,7 @@ package("libuv")
     set_urls("https://github.com/libuv/libuv/archive/refs/tags/$(version).zip",
              "https://github.com/libuv/libuv.git")
 
+    add_versions("v1.51.0", "54e1e108c54b2d1dcaee0d16721385404fc95cc2a2cd2deb51e3529c202d6455")
     add_versions("v1.50.0", "038f48e48b3d15c9341dfe1fa5099b83b52ac30f15c97a67269163f8f8ab99ac")
     add_versions("v1.49.2", "9050042ac6cbd85c644e38c23a67e9f8a9d32eafe71479bbea674b4125489141")
     add_versions("v1.49.1", "94312ede44c6cae544ae316557e2651aea65efce5da06f8d44685db08392ec5d")


### PR DESCRIPTION
New version of libuv detected (package version: v1.50.0, last github version: v1.51.0)