### PR TITLE
Auto-update drogon to v1.9.11

### DIFF
--- a/packages/d/drogon/xmake.lua
+++ b/packages/d/drogon/xmake.lua
@@ -6,6 +6,7 @@ package("drogon")
     add_urls("https://github.com/an-tao/drogon/archive/refs/tags/$(version).tar.gz",
              "https://github.com/an-tao/drogon.git", {submodules = false})
 
+    add_versions("v1.9.11", "f50098bb21bd0013f8da16b796313816bf79b0ecb1d74bfe33216d5400ab2002")
     add_versions("v1.9.10", "5de93fe16682388f363bb4b26ab00b0253d39108d8e7f53d5637c1b7da59a48f")
     add_versions("v1.9.9", "4155f78196902ef2f9d06b708897c9e8acaa1536cc4a8c8da9726ceb8ada2aaf")
     add_versions("v1.9.8", "62332a4882cc7db1c7cf04391b65c91ddf6fcbb49af129fc37eb0130809e0449")


### PR DESCRIPTION
New version of drogon detected (package version: v1.9.10, last github version: v1.9.11)