### PR TITLE
Auto-update gsl-lite to v1.0.1

### DIFF
--- a/packages/g/gsl-lite/xmake.lua
+++ b/packages/g/gsl-lite/xmake.lua
@@ -7,6 +7,7 @@ package("gsl-lite")
     add_urls("https://github.com/gsl-lite/gsl-lite/archive/refs/tags/$(version).tar.gz",
              "https://github.com/gsl-lite/gsl-lite.git")
 
+    add_versions("v1.0.1", "063a0b4248a2afd8154b2b5fe9d64472868a166d3963682e823f81516194af79")
     add_versions("v0.43.0", "e48c3138648156d2b85905b1d280d661fad61524c5c0ca10d3857036ca3dd519")
     add_versions("v0.42.0", "54a1b6f9db72eab5d8dcaf06b36d32d4f5da3471d91dac71aba19fe15291a773")
     add_versions("v0.41.0", "4682d8a60260321b92555760be3b9caab60e2a71f95eddbdfb91e557ee93302a")


### PR DESCRIPTION
New version of gsl-lite detected (package version: v0.43.0, last github version: v1.0.1)