### PR TITLE
standardlib: update to 2024.03.25

### DIFF
--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -30,5 +30,5 @@ package("standardlib")
                 const char *suffix = "text";
                 printf("Does the string end with \"%s\"? %s\n", suffix, ends_with(text, suffix) ? "Yes" : "No");
             }
-        ]]}, {configs = {languages = "c17"}}))
+        ]]}, {configs = {languages = "c20"}}))
     end)

--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -4,7 +4,7 @@ package("standardlib")
     set_description("A complete standardlib for c for once")
     set_license("Public Domain")
 
-    add_urls("https://github.com/gregoryc/standardlib.git", {includes = {"foundationallib.h"}})
+    add_urls("https://github.com/gregoryc/standardlib.git")
     add_versions("2024.03.25", "d27a1293ccfe7ef04a961806754c5d1272614b72")
 
     if is_plat("linux", "bsd") then
@@ -12,17 +12,17 @@ package("standardlib")
     end
 
     on_load(function (package)
-        if not package:is_plat("linux", "bsd", "cross") then
+        if not package:has_cxxincludes("threads.h", {configs = {languages = "c11"}}) then
             package:add("defines", "FOUNDATIONAL_LIB_THREAD_FUNCTIONS_ENABLED=0")
         end
     end)
 
-    on_install(function (package)
+    on_install("linux", "bsd", "cross", "mingw", function (package)
         os.cp("foundationallib.h", package:installdir("include"))
     end)
 
     on_test(function (package)
-        assert(package:check_cxxsnippets({test = [[
+        assert(package:check_csnippets({test = [[
             #include <foundationallib.h>
             #include <stdio.h>
             void test() {
@@ -30,5 +30,5 @@ package("standardlib")
                 const char *suffix = "text";
                 printf("Does the string end with \"%s\"? %s\n", suffix, ends_with(text, suffix) ? "Yes" : "No");
             }
-        ]]}, {configs = {languages = "c++17"}}))
+        ]]}, {configs = {languages = "c11"}}))
     end)

--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -11,11 +11,10 @@ package("standardlib")
         if not package:has_cincludes("threads.h", {configs = {languages = "c11"}}) then
             package:add("defines", "FOUNDATIONAL_LIB_THREAD_FUNCTIONS_ENABLED=0")
         end
-
         package:add("defines", "_DEFAULT_SOURCE", "_POSIX_C_SOURCE=200809L")
     end)
 
-    on_install("linux", "bsd", "cross", "mingw", function (package)
+    on_install("linux", "cross", "mingw", function (package)
         os.cp("foundationallib.h", package:installdir("include"))
     end)
 

--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -4,7 +4,7 @@ package("standardlib")
     set_description("A complete standardlib for c for once")
     set_license("Public Domain")
 
-    add_urls("https://github.com/gregoryc/standardlib.git")
+    add_urls("https://github.com/gregoryc/standardlib.git", {includes = {"foundationallib.h"}})
     add_versions("2024.03.25", "d27a1293ccfe7ef04a961806754c5d1272614b72")
 
     if is_plat("linux", "bsd") then

--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -1,13 +1,13 @@
 package("standardlib")
-
-    set_kind("library", {headeronly = true})
+    set_kind("library", {headeronly = true})    
     set_homepage("https://github.com/gregoryc/standardlib")
-    set_description("an actually usable and maximally efficient C standard library to make C as easy (or easier) than other languages")
+    set_description("A complete standardlib for c for once")
 
     add_urls("https://github.com/gregoryc/standardlib.git")
+    add_versions("2024.03.25", "d27a1293ccfe7ef04a961806754c5d1272614b72")
     add_versions("2023.12.5", "4fb308a5716927e5622a0488d7aa104660c96841")
 
-    on_install("linux", function (package)
+    on_install(function (package)
         os.cp("standardlib.h", package:installdir("include"))
     end)
 

--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -30,5 +30,5 @@ package("standardlib")
                 const char *suffix = "text";
                 printf("Does the string end with \"%s\"? %s\n", suffix, ends_with(text, suffix) ? "Yes" : "No");
             }
-        ]]}))
+        ]]}, {configs = {languages = "c++17"}}))
     end)

--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -12,7 +12,7 @@ package("standardlib")
     end
 
     on_load(function (package)
-        if not package:has_cxxincludes("threads.h", {configs = {languages = "c11"}}) then
+        if not package:has_cincludes("threads.h", {configs = {languages = "c11"}}) then
             package:add("defines", "FOUNDATIONAL_LIB_THREAD_FUNCTIONS_ENABLED=0")
         end
     end)

--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -12,7 +12,7 @@ package("standardlib")
             package:add("defines", "FOUNDATIONAL_LIB_THREAD_FUNCTIONS_ENABLED=0")
         end
 
-        package:add("defines", "_POSIX_C_SOURCE=200809L")
+        package:add("defines", "_DEFAULT_SOURCE", "_POSIX_C_SOURCE=200809L")
     end)
 
     on_install("linux", "bsd", "cross", "mingw", function (package)

--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -5,15 +5,24 @@ package("standardlib")
 
     add_urls("https://github.com/gregoryc/standardlib.git")
     add_versions("2024.03.25", "d27a1293ccfe7ef04a961806754c5d1272614b72")
-    add_versions("2023.12.5", "4fb308a5716927e5622a0488d7aa104660c96841")
+
+    if is_plat("linux", "bsd") then
+        add_syslinks("pthread")
+    end
+
+    -- on_load(function (package)
+        -- if not package:is_plat("linux", "bsd") then
+        --     package:add("defines", "FOUNDATIONAL_LIB_THREAD_FUNCTIONS_ENABLED=0")
+        -- end
+    -- end)
 
     on_install(function (package)
-        os.cp("standardlib.h", package:installdir("include"))
+        os.cp("foundationallib.h", package:installdir("include"))
     end)
 
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
-            #include "standardlib.h"
+            #include <foundationallib.h>
             #include <stdio.h>
             void test() {
                 const char *text = "This is a sample text";

--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -30,5 +30,5 @@ package("standardlib")
                 const char *suffix = "text";
                 printf("Does the string end with \"%s\"? %s\n", suffix, ends_with(text, suffix) ? "Yes" : "No");
             }
-        ]]}, {configs = {languages = "c11"}}))
+        ]]}, {configs = {languages = "c99"}}))
     end)

--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -30,5 +30,5 @@ package("standardlib")
                 const char *suffix = "text";
                 printf("Does the string end with \"%s\"? %s\n", suffix, ends_with(text, suffix) ? "Yes" : "No");
             }
-        ]]}, {configs = {languages = "c99"}}))
+        ]]}, {configs = {languages = "c17"}}))
     end)

--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -2,6 +2,7 @@ package("standardlib")
     set_kind("library", {headeronly = true})    
     set_homepage("https://github.com/gregoryc/standardlib")
     set_description("A complete standardlib for c for once")
+    set_license("Public Domain")
 
     add_urls("https://github.com/gregoryc/standardlib.git")
     add_versions("2024.03.25", "d27a1293ccfe7ef04a961806754c5d1272614b72")
@@ -10,11 +11,11 @@ package("standardlib")
         add_syslinks("pthread")
     end
 
-    -- on_load(function (package)
-        -- if not package:is_plat("linux", "bsd") then
-        --     package:add("defines", "FOUNDATIONAL_LIB_THREAD_FUNCTIONS_ENABLED=0")
-        -- end
-    -- end)
+    on_load(function (package)
+        if not package:is_plat("linux", "bsd", "cross") then
+            package:add("defines", "FOUNDATIONAL_LIB_THREAD_FUNCTIONS_ENABLED=0")
+        end
+    end)
 
     on_install(function (package)
         os.cp("foundationallib.h", package:installdir("include"))

--- a/packages/s/standardlib/xmake.lua
+++ b/packages/s/standardlib/xmake.lua
@@ -7,14 +7,12 @@ package("standardlib")
     add_urls("https://github.com/gregoryc/standardlib.git")
     add_versions("2024.03.25", "d27a1293ccfe7ef04a961806754c5d1272614b72")
 
-    if is_plat("linux", "bsd") then
-        add_syslinks("pthread")
-    end
-
     on_load(function (package)
         if not package:has_cincludes("threads.h", {configs = {languages = "c11"}}) then
             package:add("defines", "FOUNDATIONAL_LIB_THREAD_FUNCTIONS_ENABLED=0")
         end
+
+        package:add("defines", "_POSIX_C_SOURCE=200809L")
     end)
 
     on_install("linux", "bsd", "cross", "mingw", function (package)
@@ -30,5 +28,5 @@ package("standardlib")
                 const char *suffix = "text";
                 printf("Does the string end with \"%s\"? %s\n", suffix, ends_with(text, suffix) ? "Yes" : "No");
             }
-        ]]}, {configs = {languages = "c20"}}))
+        ]]}, {configs = {languages = "c11"}}))
     end)


### PR DESCRIPTION
It looks like releases and commit history was cleaned by upstream, and it is now just mirror of his so called *foundationallib*.

