### PR TITLE
Auto-update tracy to v0.12.2

### DIFF
--- a/packages/t/tracy/xmake.lua
+++ b/packages/t/tracy/xmake.lua
@@ -5,6 +5,7 @@ package("tracy")
     add_urls("https://github.com/wolfpld/tracy/archive/refs/tags/$(version).tar.gz",
              "https://github.com/wolfpld/tracy.git")
 
+    add_versions("v0.12.2", "09617765ba5ff1aa6da128d9ba3c608166c5ef05ac28e2bb77f791269d444952")
     add_versions("v0.12.1", "03580b01df3c435f74eec165193d6557cdbf3a84d39582ca30969ef5354560aa")
     add_versions("v0.12.0", "ce2fb5b89aeb6db8401d7efe1bfe8393b7a81ca551273e8c6dd46ed37c02a040")
     add_versions("v0.11.1", "2c11ca816f2b756be2730f86b0092920419f3dabc7a7173829ffd897d91888a1")


### PR DESCRIPTION
New version of tracy detected (package version: v0.12.1, last github version: v0.12.2)