### PR TITLE
Auto-update mlpack to 4.6.2

### DIFF
--- a/packages/m/mlpack/xmake.lua
+++ b/packages/m/mlpack/xmake.lua
@@ -7,6 +7,7 @@ package("mlpack")
     add_urls("https://github.com/mlpack/mlpack/archive/refs/tags/$(version).tar.gz",
              "https://github.com/mlpack/mlpack.git")
 
+    add_versions("4.6.2", "2fe772da383a935645ced07a07b51942ca178d38129df3bf685890bc3c1752cf")
     add_versions("4.3.0", "08cd54f711fde66fc3b6c9db89dc26776f9abf1a6256c77cfa3556e2a56f1a3d")
 
     if is_plat("linux") then


### PR DESCRIPTION
New version of mlpack detected (package version: 4.3.0, last github version: 4.6.2)