### PR TITLE
skia: fix build for MDd on Windows

### DIFF
--- a/packages/s/skia/xmake.lua
+++ b/packages/s/skia/xmake.lua
@@ -46,7 +46,7 @@ package("skia")
         end)
     end
 
-    on_install("macosx", "linux", "windows", function (package)
+    on_install("macosx", "linux|!arm64", "windows|!arm64", function (package)
         local args = {is_official_build = false,
                       is_component_build = false,
                       is_debug = package:debug(),

--- a/packages/s/skia/xmake.lua
+++ b/packages/s/skia/xmake.lua
@@ -81,7 +81,7 @@ package("skia")
             args.cc            = package:build_getenv("cc")
             args.cxx           = package:build_getenv("cxx")
         else
-            args.extra_cflags  = {(package:config("vs_runtime"):startswith("MT") and "/MT" or "/MD")}
+            args.extra_cflags  = {(package:config("vs_runtime"):startswith("MT") and "/MT" or "/" .. package:config("vs_runtime"))}
         end
         if package:is_plat("macosx") then
             args.extra_ldflags = {"-lstdc++"}

--- a/packages/s/skia/xmake.lua
+++ b/packages/s/skia/xmake.lua
@@ -49,7 +49,7 @@ package("skia")
     on_install("macosx", "linux|!arm64", "windows|!arm64", function (package)
         local args = {is_official_build = false,
                       is_component_build = false,
-                      is_debug = package:debug(),
+                      is_debug = package:is_debug(),
                       is_shared_library = package:config("shared"),
                       skia_enable_tools = false,
                       skia_use_icu = false,

--- a/packages/s/skia/xmake.lua
+++ b/packages/s/skia/xmake.lua
@@ -81,7 +81,9 @@ package("skia")
             args.cc            = package:build_getenv("cc")
             args.cxx           = package:build_getenv("cxx")
         else
-            args.extra_cflags  = {(package:config("vs_runtime"):startswith("MT") and "/MT" or "/" .. package:config("vs_runtime"))}
+            args.extra_cflags  = {
+                "/" .. package:runtimes()
+            }
         end
         if package:is_plat("macosx") then
             args.extra_ldflags = {"-lstdc++"}


### PR DESCRIPTION
Cannot use `xmake project -k vsxmake` because the skia package does not compile with MDd in xmake 3.0

Error:
```
skia.lib(skia.SkPaint.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkPaint.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MDd_DynamicDebug' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkMemory_malloc.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkMemory_malloc.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MDd_DynamicDebug' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkColor.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkColor.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MDd_DynamicDebug' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkBlendModeBlender.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkBlendModeBlender.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MDd_DynamicDebug' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkColorFilter.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkColorFilter.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MDd_DynamicDebug' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkImageFilter.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkImageFilter.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MDd_DynamicDebug' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkStrokeRec.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkColorSpace.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MDd_DynamicDebug' in _A679C31107FE4E708DCAFD283F118DE0.o
skia.lib(skia.SkColorSpaceXformSteps.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in _A679C31107FE4E708DCAFD283F118DE0.o
```
