### PR TITLE
Fix Intel compiler flags for OpenMP

### DIFF
--- a/packages/o/openmp/xmake.lua
+++ b/packages/o/openmp/xmake.lua
@@ -50,7 +50,7 @@ package("openmp")
                     end
                 elseif package:has_tool(toolkind, "gcc", "gxx", "gfortran") then
                     result[flagname] = "-fopenmp"
-                elseif package:has_tool(toolkind, "icx", "icpx", "ifx") then
+                elseif package:has_tool(toolkind, "icc", "icpc", "ifort", "icx", "icpx", "ifx") then
                     result[flagname] = "-qopenmp"
                 elseif package:has_tool(toolkind, "icl") then
                     result[flagname] = "-Qopenmp"
@@ -66,7 +66,7 @@ package("openmp")
                     elseif package:has_tool(toolkind, "gcc", "gxx") then
                         result.ldflags = "-fopenmp"
                         result.shflags = "-fopenmp"
-                    elseif package:has_tool(toolkind, "icx", "icpx") then
+                    elseif package:has_tool(toolkind, "icc", "icpc", "icx", "icpx") then
                         result.ldflags = "-qopenmp"
                         result.shflags = "-qopenmp"
                     elseif package:has_tool(toolkind, "icl") then


### PR DESCRIPTION
The Intel C++ Compiler Classic (`icc`) is deprecated and was discontinued 2024. As an alternative, it is recommended that developers use the Intel OneAPI C++ compiler (`icx`). The same is true for the Intel Fortran compiler: `ifort` is deprecated in favour of `ifx`. See the [icc Release notes](https://www.intel.com/content/www/us/en/developer/articles/release-notes/oneapi-c-compiler-release-notes.html) for more details.

Following the name change, xmake failed to provide the correct compiler flags for OpenMP, a parallel computing library for multicore processors. See also xmake-io/xmake#6596 for more information.

This pull request involves making minor changes to the xmake configuration for OpenMP, essentially renaming 'icc' to 'icx' and 'ifort' to 'ifx', to ensure that the Intel compiler is correctly detected and that OpenMP receives the correct compiler flags.

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

