### PR TITLE
Auto-update aws-c-event-stream to v0.5.5

### DIFF
--- a/packages/a/aws-c-event-stream/xmake.lua
+++ b/packages/a/aws-c-event-stream/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-event-stream")
     add_urls("https://github.com/awslabs/aws-c-event-stream/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-event-stream.git")
 
+    add_versions("v0.5.5", "f6e55c8fd6afd7f904e08d36c3210e199ece5dc838f0f8457b43b72ec4d818e9")
     add_versions("v0.5.4", "cef8b78e362836d15514110fb43a0a0c7a86b0a210d5fe25fd248a82027a7272")
     add_versions("v0.5.1", "22ce7a695b82debe118c9ecc641ea8bc7e59c9843f92d5acf8401fc86cac847a")
     add_versions("v0.5.0", "3a53a9d05f9e2fd06036a12854a8b4f05a0c4858bb5b8df8a30edba9de8532b5")


### PR DESCRIPTION
New version of aws-c-event-stream detected (package version: v0.5.4, last github version: v0.5.5)