### PR TITLE
Auto-update clip to 1.10

### DIFF
--- a/packages/c/clip/xmake.lua
+++ b/packages/c/clip/xmake.lua
@@ -4,6 +4,7 @@ package("clip")
     set_license("MIT")
 
     set_urls("https://github.com/dacap/clip/archive/refs/tags/v$(version).zip")
+    add_versions("1.10", "8d394acbbf05c1525b2ca58f1715962c74d01114da4800d9ee0c80f70ee7d3bb")
     add_versions("1.9", "905615eb1ceef15e96468891ad85b7aa6836bcda690006d61fa061ca029b2060")
     add_versions("1.8", "9df8728c9ce7c3afcfc9a0c6718e064319f0cdffb927243ac1ca3be591578d00")
     add_versions("1.5", "4ed7f54184c27c79a8f2382ba747dce11aeb4552017abf5588587369a6caeb6b")


### PR DESCRIPTION
New version of clip detected (package version: 1.9, last github version: 1.10)