### PR TITLE
Auto-update portmidi to v2.0.6

### DIFF
--- a/packages/p/portmidi/xmake.lua
+++ b/packages/p/portmidi/xmake.lua
@@ -5,6 +5,7 @@ package("portmidi")
     add_urls("https://github.com/PortMidi/portmidi/archive/refs/tags/$(version).tar.gz",
              "https://github.com/PortMidi/portmidi.git")
 
+    add_versions("v2.0.6", "81d22b34051621cd56c8d5ef12908ef2a59764c9cdfba6dae47aabddb71ac914")
     add_versions("v2.0.4", "64893e823ae146cabd3ad7f9a9a9c5332746abe7847c557b99b2577afa8a607c")
 
     if is_plat("linux", "bsd") then


### PR DESCRIPTION
New version of portmidi detected (package version: v2.0.4, last github version: v2.0.6)