### PR TITLE
Auto-update aws-c-io to v0.20.1

### DIFF
--- a/packages/a/aws-c-io/xmake.lua
+++ b/packages/a/aws-c-io/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-io")
     add_urls("https://github.com/awslabs/aws-c-io/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-io.git")
 
+    add_versions("v0.20.1", "8e2abf56e20f87383c44af6818235a12f54051b40c98870f44b2d5d05be08641")
     add_versions("v0.19.1", "f2fea0c066924f7fe3c2b1c7b2fa9be640f5b16a6514854226330e63a1faacd0")
     add_versions("v0.18.1", "65d275bbde1a1d287cdcde62164dc015b9613a5525fe688e972111d8a3b568fb")
     add_versions("v0.18.0", "c65a9f059dfe3208dbc92b7fc11f6d846d15e1a14cd0dabf98041ce9627cadda")


### PR DESCRIPTION
New version of aws-c-io detected (package version: v0.19.1, last github version: v0.20.1)