### PR TITLE
Auto-update re2c to 4.3

### DIFF
--- a/packages/r/re2c/xmake.lua
+++ b/packages/r/re2c/xmake.lua
@@ -7,6 +7,7 @@ package("re2c")
     add_urls("https://github.com/skvadrik/re2c/archive/refs/tags/$(version).tar.gz",
              "https://github.com/skvadrik/re2c.git", {submodules = false})
 
+    add_versions("4.3", "39cd7048a817cf3d7d0c2e58a52fb3597d6e1bc86b1df32b8a3cd755c458adfd")
     add_versions("4.2", "01b56c67ca2d5054b1aafc41ef5c15c50fbb6a7e760b1b2346e6116ef039525e")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of re2c detected (package version: 4.2, last github version: 4.3)