### PR TITLE
Auto-update hlslpp to 3.7

### DIFF
--- a/packages/h/hlslpp/xmake.lua
+++ b/packages/h/hlslpp/xmake.lua
@@ -7,6 +7,7 @@ package("hlslpp")
     add_urls("https://github.com/redorav/hlslpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/redorav/hlslpp.git")
 
+    add_versions("3.7", "819a3d20e5dcea27ee16903b6c96c309d1432c950f282791c06c8f27c2cb12f0")
     add_versions("3.6", "d23b51e631363e7337e89564014fd5a9b7b12498a0296caddcc8433fb23727b8")
     add_versions("3.5.3", "9be1b0edcd7877da49e5e85473c83eac792ef10dcccd3f1ff18297f2176ac251")
     add_versions("3.5.1", "5f0a89db4b2a8dcf8237463455d6c03e3f9a090117aed2ba07a7309b239bd88c")


### PR DESCRIPTION
New version of hlslpp detected (package version: 3.6, last github version: 3.7)