### PR TITLE
Auto-update hpx to v1.11.0

### DIFF
--- a/packages/h/hpx/xmake.lua
+++ b/packages/h/hpx/xmake.lua
@@ -6,6 +6,7 @@ package("hpx")
     add_urls("https://github.com/STEllAR-GROUP/hpx/archive/refs/tags/$(version).tar.gz",
              "https://github.com/STEllAR-GROUP/hpx.git")
 
+    add_versions("v1.11.0", "01ec47228a2253b41e318bb09c83325a75021eb6ef3262400fbda30ac7389279")
     add_versions("v1.10.0", "5720ed7d2460fa0b57bd8cb74fa4f70593fe8675463897678160340526ec3c19")
     add_versions("v1.9.1", "1adae9d408388a723277290ddb33c699aa9ea72defadf3f12d4acc913a0ff22d")
 


### PR DESCRIPTION
New version of hpx detected (package version: v1.10.0, last github version: v1.11.0)