### PR TITLE
Auto-update google-cloud-cpp to v2.39.0

### DIFF
--- a/packages/g/google-cloud-cpp/xmake.lua
+++ b/packages/g/google-cloud-cpp/xmake.lua
@@ -6,6 +6,7 @@ package("google-cloud-cpp")
     add_urls("https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/googleapis/google-cloud-cpp.git")
 
+    add_versions("v2.39.0", "629cbfcc5bd581d38277ba8fa94a5b6591af1e0f6af0dab6d1d9ed796bf48b61")
     add_versions("v2.38.0", "f1493b2dce9b379714342f2be7ccb483d70d13aac09d4a90ae3b4756693b72fc")
     add_versions("v2.37.0", "10867580483cb338e7d50920c2383698f3572cc6b4c7d072e38d5f43755cbd80")
     add_versions("v2.36.0", "9a6e182fd658ba114512cf21bd9f274a315830638f62f0b831113df9e674bea0")


### PR DESCRIPTION
New version of google-cloud-cpp detected (package version: v2.38.0, last github version: v2.39.0)