### PR TITLE
Auto-update etl to 20.42.1

### DIFF
--- a/packages/e/etl/xmake.lua
+++ b/packages/e/etl/xmake.lua
@@ -7,6 +7,7 @@ package("etl")
     add_urls("https://github.com/ETLCPP/etl/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ETLCPP/etl.git")
 
+    add_versions("20.42.1", "25b7ae3eba614b497ecf17e2f2d749f69ef7e7cd4215347e6cefa8f542712668")
     add_versions("20.42.0", "041321b0ff84baf816ce3572152f3203ba13a534ecbcdd8f14f63e35c5dae7f0")
     add_versions("20.41.7", "10a26f084fcd603bc2b2b8df98221c8896036a558f069acaa1fbaecce7974a39")
     add_versions("20.41.6", "c68a869a26397fe86bba8749132962c2e53104186eb3fc8a26a1713de8a70d1c")


### PR DESCRIPTION
New version of etl detected (package version: 20.42.0, last github version: 20.42.1)