### PR TITLE
Auto-update igraph to 0.10.16

### DIFF
--- a/packages/i/igraph/xmake.lua
+++ b/packages/i/igraph/xmake.lua
@@ -6,6 +6,7 @@ package("igraph")
     add_urls("https://github.com/igraph/igraph/releases/download/$(version)/igraph-$(version).tar.gz",
              "https://github.com/igraph/igraph.git")
 
+    add_versions("0.10.16", "15a1540a8d270232c9aa99adeeffb7787bea96289d6bef6646ec9c91a9a93992")
     add_versions("0.10.15", "03ba01db0544c4e32e51ab66f2356a034394533f61b4e14d769b9bbf5ad5e52c")
 
     add_configs("glpk", {description = "Compile igraph with GLPK support", default = false, type = "boolean"})


### PR DESCRIPTION
New version of igraph detected (package version: 0.10.15, last github version: 0.10.16)