### PR TITLE
Auto-update tree-sitter to v0.25.8

### DIFF
--- a/packages/t/tree-sitter/xmake.lua
+++ b/packages/t/tree-sitter/xmake.lua
@@ -6,6 +6,7 @@ package("tree-sitter")
     add_urls("https://github.com/tree-sitter/tree-sitter/archive/refs/tags/$(version).zip",
              "https://github.com/tree-sitter/tree-sitter.git")
 
+    add_versions("v0.25.8", "baae36c8f3e34ee588424135ef7a910cefca0f0e54da2281a7297ebcc25784e1")
     add_versions("v0.25.6", "1bfd4db2b3a6a4b81058c6a6cfa7fd339e71508c44355c7c8a5034e9b2ad56f1")
     add_versions("v0.25.5", "67690cf9f5d3a79a1eaaee565545f7b094aaaf4aabbaee786f33458becd30d7d")
     add_versions("v0.25.3", "cae078014ebdb5a470116b814da9def5fb180653e0e47f9dc9b3a0308fd5786e")


### PR DESCRIPTION
New version of tree-sitter detected (package version: v0.25.6, last github version: v0.25.8)