### PR TITLE
Superlu: update to v7.0.1

### DIFF
--- a/.github/workflows/macos_arm64.yml
+++ b/.github/workflows/macos_arm64.yml
@@ -31,8 +31,6 @@ jobs:
           wget https://curl.haxx.se/ca/cacert.pem -O /tmp/cacert.pem
           export CURL_CA_BUNDLE=/tmp/cacert.pem
           sudo ln -s /opt/homebrew/bin/gfortran-14 /opt/homebrew/bin/gfortran
-          sudo mkdir /opt/homebrew/gfortran
-          sudo ln -s /opt/homebrew/Cellar/gcc@14/14.3.0/lib/gcc/14 /opt/homebrew/gfortran/lib
           export PATH="$PATH:/opt/homebrew/Cellar/gcc@14/14.3.0/libexec/gcc/aarch64-apple-darwin23/14/"
           export LIBRARY_PATH="$LIBRARY_PATH:/opt/homebrew/Cellar/gcc@14/14.3.0/lib/gcc/14/"
           export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/homebrew/Cellar/gcc@14/14.3.0/lib/gcc/14/"

--- a/.github/workflows/macos_arm64.yml
+++ b/.github/workflows/macos_arm64.yml
@@ -30,8 +30,10 @@ jobs:
         run: |
           wget https://curl.haxx.se/ca/cacert.pem -O /tmp/cacert.pem
           export CURL_CA_BUNDLE=/tmp/cacert.pem
-          sudo ln /opt/homebrew/bin/gfortran-14 /opt/homebrew/bin/gfortran
-          export PATH="$PATH:/opt/homebrew/Cellar/gcc/14.2.0/libexec/gcc/aarch64-apple-darwin23/14/"
-          export LIBRARY_PATH="$LIBRARY_PATH:/opt/homebrew/Cellar/gcc/14.2.0/lib/gcc/14/"
-          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/homebrew/Cellar/gcc/14.2.0/lib/gcc/14/"
+          sudo ln -s /opt/homebrew/bin/gfortran-14 /opt/homebrew/bin/gfortran
+          sudo mkdir /opt/homebrew/gfortran
+          sudo ln -s /opt/homebrew/Cellar/gcc@14/14.3.0/lib/gcc/14 /opt/homebrew/gfortran/lib
+          export PATH="$PATH:/opt/homebrew/Cellar/gcc@14/14.3.0/libexec/gcc/aarch64-apple-darwin23/14/"
+          export LIBRARY_PATH="$LIBRARY_PATH:/opt/homebrew/Cellar/gcc@14/14.3.0/lib/gcc/14/"
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/homebrew/Cellar/gcc@14/14.3.0/lib/gcc/14/"
           xmake l ./scripts/test.lua -D -a ${{ matrix.arch }} -k ${{ matrix.kind }}

--- a/.github/workflows/macos_arm64.yml
+++ b/.github/workflows/macos_arm64.yml
@@ -31,7 +31,6 @@ jobs:
           wget https://curl.haxx.se/ca/cacert.pem -O /tmp/cacert.pem
           export CURL_CA_BUNDLE=/tmp/cacert.pem
           sudo ln -s /opt/homebrew/bin/gfortran-14 /opt/homebrew/bin/gfortran
-          export PATH="$PATH:/opt/homebrew/Cellar/gcc@14/14.3.0/libexec/gcc/aarch64-apple-darwin23/14/"
-          export LIBRARY_PATH="$LIBRARY_PATH:/opt/homebrew/Cellar/gcc@14/14.3.0/lib/gcc/14/"
-          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/homebrew/Cellar/gcc@14/14.3.0/lib/gcc/14/"
+          export LIBRARY_PATH="$LIBRARY_PATH:/opt/homebrew/lib/gcc/14/"
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/homebrew/lib/gcc/14/"
           xmake l ./scripts/test.lua -D -a ${{ matrix.arch }} -k ${{ matrix.kind }}

--- a/.github/workflows/macos_x86_64.yml
+++ b/.github/workflows/macos_x86_64.yml
@@ -30,8 +30,10 @@ jobs:
         run: |
           wget https://curl.haxx.se/ca/cacert.pem -O /tmp/cacert.pem
           export CURL_CA_BUNDLE=/tmp/cacert.pem
-          sudo ln /usr/local/bin/gfortran-14 /usr/local/bin/gfortran
-          export PATH="$PATH:/usr/local/Cellar/gcc/14.2.0/libexec/gcc/x86_64-apple-darwin21/14/"
-          export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/Cellar/gcc/14.2.0/lib/gcc/14/"
-          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/Cellar/gcc/14.2.0/lib/gcc/14/"
+          sudo ln -s /usr/local/bin/gfortran-14 /usr/local/bin/gfortran
+          sudo mkdir /usr/local/gfortran
+          sudo ln -s /usr/local/Cellar/gcc@14/14.3.0/lib/gcc/14 /usr/local/gfortran/lib
+          export PATH="$PATH:/usr/local/Cellar/gcc@14/14.3.0/libexec/gcc/x86_64-apple-darwin21/14/"
+          export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/Cellar/gcc@14/14.3.0/lib/gcc/14/"
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/Cellar/gcc@14/14.3.0/lib/gcc/14/"
           xmake l ./scripts/test.lua -D -a ${{ matrix.arch }} -k ${{ matrix.kind }}

--- a/.github/workflows/macos_x86_64.yml
+++ b/.github/workflows/macos_x86_64.yml
@@ -31,8 +31,6 @@ jobs:
           wget https://curl.haxx.se/ca/cacert.pem -O /tmp/cacert.pem
           export CURL_CA_BUNDLE=/tmp/cacert.pem
           sudo ln -s /usr/local/bin/gfortran-14 /usr/local/bin/gfortran
-          sudo mkdir /usr/local/gfortran
-          sudo ln -s /usr/local/Cellar/gcc@14/14.3.0/lib/gcc/14 /usr/local/gfortran/lib
           export PATH="$PATH:/usr/local/Cellar/gcc@14/14.3.0/libexec/gcc/x86_64-apple-darwin21/14/"
           export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/Cellar/gcc@14/14.3.0/lib/gcc/14/"
           export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/Cellar/gcc@14/14.3.0/lib/gcc/14/"

--- a/.github/workflows/macos_x86_64.yml
+++ b/.github/workflows/macos_x86_64.yml
@@ -31,7 +31,6 @@ jobs:
           wget https://curl.haxx.se/ca/cacert.pem -O /tmp/cacert.pem
           export CURL_CA_BUNDLE=/tmp/cacert.pem
           sudo ln -s /usr/local/bin/gfortran-14 /usr/local/bin/gfortran
-          export PATH="$PATH:/usr/local/Cellar/gcc@14/14.3.0/libexec/gcc/x86_64-apple-darwin21/14/"
-          export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/Cellar/gcc@14/14.3.0/lib/gcc/14/"
-          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/Cellar/gcc@14/14.3.0/lib/gcc/14/"
+          export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/lib/gcc/14/"
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/gcc/14/"
           xmake l ./scripts/test.lua -D -a ${{ matrix.arch }} -k ${{ matrix.kind }}

--- a/packages/s/superlu/xmake.lua
+++ b/packages/s/superlu/xmake.lua
@@ -14,7 +14,12 @@ package("superlu")
     add_configs("blas", {description = "Choose BLAS library to use.", default = "openblas", type = "string", values = {"mkl", "openblas"}})
 
     on_load("windows|!arm64", "linux", "macosx", function (package)
-        package:add("deps", package:config("blas"))
+        local blas_lib = package:config("blas")
+        if blas_lib == "openblas" and is_plat("macosx") then
+                package:add("deps", "openblas", {configs = {fortran = true}})
+        else
+            package:add("deps", blas_lib)
+        end
     end)
 
     on_install("windows|!arm64", "linux", "macosx", function (package)

--- a/packages/s/superlu/xmake.lua
+++ b/packages/s/superlu/xmake.lua
@@ -14,12 +14,7 @@ package("superlu")
     add_configs("blas", {description = "Choose BLAS library to use.", default = "openblas", type = "string", values = {"mkl", "openblas"}})
 
     on_load("windows|!arm64", "linux", "macosx", function (package)
-        local blas_lib = package:config("blas")
-        if blas_lib == "openblas" and is_plat("macosx") then
-                package:add("deps", "openblas", {configs = {fortran = true}})
-        else
-            package:add("deps", blas_lib)
-        end
+        package:add("deps", package:config("blas"))
     end)
 
     on_install("windows|!arm64", "linux", "macosx", function (package)


### PR DESCRIPTION
#7464 
From v7.0.1, `superlu` no longer provides a **static** `superlu_config.h` file. This `.h` file must be dynamically generated from the `superlu_config.h.in` template through CMake macros. The old `xmake.lua` completely bypassed CMake, resulting in `superlu_config.h` never being created in v7.0.1, which in turn caused a "file not found" error when executing `io.replace`.

Solution:
Use `io.writefile` to overwrite.