### PR TITLE
Auto-update simsimd to v6.5.0

### DIFF
--- a/packages/s/simsimd/xmake.lua
+++ b/packages/s/simsimd/xmake.lua
@@ -7,6 +7,7 @@ package("simsimd")
     add_urls("https://github.com/ashvardanian/SimSIMD/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ashvardanian/SimSIMD.git")
 
+    add_versions("v6.5.0", "c9afe4fe80c233d43473a8438af063e01c0ca7bc55b744fde53f301e420ae8c9")
     add_versions("v6.4.3", "1125551b98d41839d59cdaa9f00630b4391002567889d64aefd50c8fa3212549")
     add_versions("v6.4.1", "dab384a1fc310687f7ae5d43bc13f814089835d60a3b83a8cb01659e5f3cb1ab")
     add_versions("v6.4.0", "ec5221abd6d91d6e89016ec408ca756a5a73cf354c2f3c962c949fbc8c39fab9")


### PR DESCRIPTION
New version of simsimd detected (package version: v6.4.3, last github version: v6.5.0)