### PR TITLE
Auto-update cppzmq to v4.11.0

### DIFF
--- a/packages/c/cppzmq/xmake.lua
+++ b/packages/c/cppzmq/xmake.lua
@@ -7,6 +7,7 @@ package("cppzmq")
     add_urls("https://github.com/zeromq/cppzmq/archive/refs/tags/$(version).tar.gz",
              "https://github.com/zeromq/cppzmq.git")
 
+    add_versions("v4.11.0", "0fff4ff311a7c88fdb76fceefba0e180232d56984f577db371d505e4d4c91afd")
     add_versions("v4.8.1", "7a23639a45f3a0049e11a188e29aaedd10b2f4845f0000cf3e22d6774ebde0af")
     add_versions("v4.9.0", "3fdf5b100206953f674c94d40599bdb3ea255244dcc42fab0d75855ee3645581")
     add_versions("v4.10.0", "c81c81bba8a7644c84932225f018b5088743a22999c6d82a2b5f5cd1e6942b74")


### PR DESCRIPTION
New version of cppzmq detected (package version: v4.10.0, last github version: v4.11.0)