### PR TITLE
Auto-update kokkos to 4.6.02

### DIFF
--- a/packages/k/kokkos/xmake.lua
+++ b/packages/k/kokkos/xmake.lua
@@ -6,6 +6,7 @@ package("kokkos")
     add_urls("https://github.com/kokkos/kokkos/archive/refs/tags/$(version).tar.gz",
              "https://github.com/kokkos/kokkos.git")
 
+    add_versions("4.6.02", "a4e6a39f34a0ffec8de0b23959a9866721363b581adb60554263bcfc15a10734")
     add_versions("4.6.01", "43190b118d0cf108b39a28f985058eecdc73370be57082a1d961c1d978ede104")
     add_versions("4.6.00", "348b2d860046fc3ddef5ca3a128317be1a6f3fa35196f268338a180fcae52264")
     add_versions("4.4.00", "c638980cb62c34969b8c85b73e68327a2cb64f763dd33e5241f5fd437170205a")


### PR DESCRIPTION
New version of kokkos detected (package version: 4.6.01, last github version: 4.6.02)