### PR TITLE
Auto-update libzip to v1.11.4

### DIFF
--- a/packages/l/libzip/xmake.lua
+++ b/packages/l/libzip/xmake.lua
@@ -9,6 +9,7 @@ package("libzip")
          end})
     add_urls("https://github.com/nih-at/libzip.git")
 
+    add_versions("v1.11.4", "82e9f2f2421f9d7c2466bbc3173cd09595a88ea37db0d559a9d0a2dc60dc722e")
     add_versions("v1.11.3", "76653f135dde3036036c500e11861648ffbf9e1fc5b233ff473c60897d9db0ea")
     add_versions("v1.11.2", "6b2a43837005e1c23fdfee532b78f806863e412d2089b9c42b49ab08cbcd7665")
     add_versions("v1.11.1", "c0e6fa52a62ba11efd30262290dc6970947aef32e0cc294ee50e9005ceac092a")


### PR DESCRIPTION
New version of libzip detected (package version: v1.11.3, last github version: v1.11.4)