### PR TITLE
update cpptrace to 1.0.3

### DIFF
--- a/packages/c/cpptrace/xmake.lua
+++ b/packages/c/cpptrace/xmake.lua
@@ -6,6 +6,7 @@ package("cpptrace")
     add_urls("https://github.com/jeremy-rifkin/cpptrace/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jeremy-rifkin/cpptrace.git")
 
+    add_versions("v1.0.3", "d9145f3ca2b828a984477fbfb49616b1541aa249af945615f9c2abad573a71cc")
     add_versions("v1.0.2", "f92825b3c839c3af851204c79ea2a63871f9060f016e7c0411cfdc1727978feb")
     add_versions("v1.0.1", "bdc1d1ebc3f0e72c384aba6982cdfc08788d85f9ea2228e5621a6ff536df4900")
     add_versions("v1.0.0", "0e11aebb6b9b98ce9134a58532b63982365aadc76533a4fbb7f6fb6edb32de2e")


### PR DESCRIPTION
New version of cpptrace (package version: v1.0.2, lastest github version: v1.0.3)