### PR TITLE
Auto-update libwebsockets to v4.4.1

### DIFF
--- a/packages/l/libwebsockets/xmake.lua
+++ b/packages/l/libwebsockets/xmake.lua
@@ -6,6 +6,7 @@ package("libwebsockets")
     set_urls("https://github.com/warmcat/libwebsockets/archive/refs/tags/$(version).tar.gz",
              "https://github.com/warmcat/libwebsockets.git")
 
+    add_versions("v4.4.1", "472e6cfa77b6f80ff2cc176bc59f6cb2856df7e30e8f31afcbd1fc94ffd2f828")
     add_versions("v4.3.5", "87f99ad32803ed325fceac5327aae1f5c1b417d54ee61ad36cffc8df5f5ab276")
     add_versions("v4.3.4", "896b36aa063b4d05865f9ffee4404b26d4c2d3e2ba17b0b69f021b615377845e")
     add_versions("v4.3.3", "6fd33527b410a37ebc91bb64ca51bdabab12b076bc99d153d7c5dd405e4bdf90")


### PR DESCRIPTION
New version of libwebsockets detected (package version: v4.3.5, last github version: v4.4.1)