### PR TITLE
libvorbis: add CMP flag to fix NDK build

### DIFF
--- a/packages/l/libvorbis/xmake.lua
+++ b/packages/l/libvorbis/xmake.lua
@@ -1,5 +1,4 @@
 package("libvorbis")
-
     set_homepage("https://xiph.org/vorbis")
     set_description("Reference implementation of the Ogg Vorbis audio format.")
     set_license("BSD-3")

--- a/packages/l/libvorbis/xmake.lua
+++ b/packages/l/libvorbis/xmake.lua
@@ -73,7 +73,7 @@ package("libvorbis")
     on_install("windows", "linux", "macosx", "iphoneos", "mingw", "android", "wasm", function (package)
         local configs = {}
         table.insert(configs, "-DBUILD_TESTING=OFF")
-        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         if not package:config("vorbisenc") then
             io.replace("CMakeLists.txt", "${CMAKE_CURRENT_BINARY_DIR}/vorbisenc.pc", "", {plain = true})

--- a/packages/l/libvorbis/xmake.lua
+++ b/packages/l/libvorbis/xmake.lua
@@ -71,7 +71,7 @@ package("libvorbis")
     end)
 
     on_install("windows", "linux", "macosx", "iphoneos", "mingw", "android", "wasm", function (package)
-        local configs = {}
+        local configs = {"-DCMAKE_POLICY_DEFAULT_CMP0057=NEW"}
         table.insert(configs, "-DBUILD_TESTING=OFF")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))


### PR DESCRIPTION
Part of pulseaudio PR.
https://github.com/xmake-io/xmake-repo/pull/7695
```xmake
local configs = {"-DCMAKE_POLICY_DEFAULT_CMP0057=NEW"}
```