### PR TITLE
protobuf-cpp: update abseil dependency handling based on version

### DIFF
--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -98,7 +98,11 @@ package("protobuf-cpp")
             package:add("deps", "zlib")
         end
         if package:version():ge("22.0") then
-            package:add("deps", "abseil <=20250127.0")
+            if package:version():lt("30.0") then
+                package:add("deps", "abseil <=20250127.0")
+            else
+                package:add("deps", "abseil")
+            end
         end
 
         if package:is_plat("windows") and package:config("shared") then


### PR DESCRIPTION
Abseil versions newer than 20250127 are not supported when building protobuf-cpp libraries with versions lower than 30.0.