### PR TITLE
hwloc: update to 2.12.1

### DIFF
--- a/packages/h/hwloc/patches/2.12.1/cmake-win-arm64.patch
+++ b/packages/h/hwloc/patches/2.12.1/cmake-win-arm64.patch
@@ -1,34 +1,38 @@
 diff --git a/contrib/windows-cmake/CMakeLists.txt b/contrib/windows-cmake/CMakeLists.txt
-index 8a7610fc7..958c36947 100644
+index 8a7610fc7..ea89b66b4 100644
 --- a/contrib/windows-cmake/CMakeLists.txt
 +++ b/contrib/windows-cmake/CMakeLists.txt
-@@ -47,18 +47,9 @@ endif()
- 
- set(SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
- # disable x86 entirely by default
--set(HWLOC_X86_32_ARCH)
--set(HWLOC_X86_64_ARCH)
--set(HWLOC_HAVE_X86_CPUID 1)
+@@ -50,15 +50,20 @@ set(SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
+ set(HWLOC_X86_32_ARCH)
+ set(HWLOC_X86_64_ARCH)
+ set(HWLOC_HAVE_X86_CPUID 1)
 -if (CMAKE_SYSTEM_PROCESSOR MATCHES "(^AMD64$|^x86_64$)")
 -    # "AMD64" on Windows, "x86_64" on Linux
--    set(HWLOC_X86_64_ARCH 1)
++if(CMAKE_C_COMPILER_ARCHITECTURE_ID MATCHES "^(x64|x86_64)$")
++    # "x64"    for Windows (MSVC)
++    # "x86_64" for Windows (MinGW), Linux, macOS
+     set(HWLOC_X86_64_ARCH 1)
 -elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "(^x86$|i.86)")
 -    # "x86" on Windows, "i.86" on Linux
--    set(HWLOC_X86_32_ARCH 1)
--else()
--    set(HWLOC_HAVE_X86_CPUID 0)
--endif()
-+set(HWLOC_X86_32_ARCH 0)
-+set(HWLOC_X86_64_ARCH 0)
-+set(HWLOC_HAVE_X86_CPUID 0)
++elseif(CMAKE_C_COMPILER_ARCHITECTURE_ID MATCHES "^(X86|i[3-6]86)$")
++    # "X86"      for Windows (MSVC)
++    # "i[3-6]86" for Windows (MinGW), Linux, macOS
+     set(HWLOC_X86_32_ARCH 1)
+ else()
++    # For "arm64", "aarch64", "ARM64"...
+     set(HWLOC_HAVE_X86_CPUID 0)
+ endif()
++message(STATUS "Target Arch ID = ${CMAKE_C_COMPILER_ARCHITECTURE_ID}")
++message(STATUS "HWLOC_HAVE_X86_CPUID = ${HWLOC_HAVE_X86_CPUID}")
  
  check_c_source_compiles("int main(void) {int cpuinfo[4]; __cpuidex(cpuinfo,0,0); return 0;}"
  HWLOC_HAVE_MSVC_CPUIDEX
-@@ -122,7 +113,6 @@ add_library(hwloc
+@@ -122,7 +127,7 @@ add_library(hwloc
      ${TOPDIR}/hwloc/topology-xml.c
      ${TOPDIR}/hwloc/topology-xml-nolibxml.c
      ${TOPDIR}/hwloc/topology-windows.c
 -    ${TOPDIR}/hwloc/topology-x86.c
++    $<$<BOOL:${HWLOC_HAVE_X86_CPUID}>:${TOPDIR}/hwloc/topology-x86.c>
      $<$<BOOL:${HWLOC_HAVE_LIBXML2}>:${TOPDIR}/hwloc/topology-xml-libxml.c>
      $<$<BOOL:${HWLOC_HAVE_OPENCL}>:${TOPDIR}/hwloc/topology-opencl.c>
      $<$<BOOL:${HAVE_CUDA}>:${TOPDIR}/hwloc/topology-cuda.c>

--- a/packages/h/hwloc/xmake.lua
+++ b/packages/h/hwloc/xmake.lua
@@ -27,7 +27,7 @@ package("hwloc")
     end
 
     if is_plat("windows") and is_arch("arm64") then
-        add_patches(">=2.7.1", "patches/2.12.1/cmake-win-arm64.patch", "eded5f3c5d8375d07c9b4812edcf131be033451fbe2428b0089faba43f6e3b82")
+        add_patches(">=2.7.1", "patches/2.12.1/cmake-win-arm64.patch", "2f261838409ed286be114fad061cb7ba8335046c9b33dfd35fd9ca7a61da2a1b")
     end
 
     add_configs("libxml2", {description = "Use libxml2 instead of minimal XML.", default = false, type = "boolean"})


### PR DESCRIPTION
#7705 needs `hwloc`. It should be fixed.