### PR TITLE
Auto-update catch2 to v3.9.0

### DIFF
--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -5,6 +5,7 @@ package("catch2")
 
     add_urls("https://github.com/catchorg/Catch2/archive/refs/tags/$(version).zip",
              "https://github.com/catchorg/Catch2.git")
+    add_versions("v3.9.0", "44d0c52a218d21da40800dc2d4e77f79ee6f8165ce9274fce52fa00608083912")
     add_versions("v3.8.1", "11e422a9d5a0a1732b3845ebb374c2d17e9d04337f3e717b21210be4ec2ec45b")
     add_versions("v3.8.0", "bffd2c45a84e5a4b0c17e695798e8d2f65931cbaf5c7556d40388d1d8d04eb83")
     add_versions("v3.7.1", "7d771897398704ecb61eae534912e50c4d3ec6129c4d01c174a55c29657970d7")


### PR DESCRIPTION
New version of catch2 detected (package version: v3.8.1, last github version: v3.9.0)