### PR TITLE
Auto-update nodeeditor to 3.0.12

### DIFF
--- a/packages/n/nodeeditor/xmake.lua
+++ b/packages/n/nodeeditor/xmake.lua
@@ -5,6 +5,7 @@ package("nodeeditor")
 
     set_urls("https://github.com/paceholder/nodeeditor/archive/refs/tags/$(version).tar.gz",
              "https://github.com/paceholder/nodeeditor.git")
+    add_versions("3.0.12", "67268eccdd389732447f4dfcf04ba3345d91a8728d38582642eab84017208522")
     add_versions("2.1.3", "4e3194a04ac4a2a2bf4bc8eb6cc27d5cc154923143c1ecf579ce7f0115a90585")
     add_versions("2.2.2", "010ebcf9b68f676c81ea13ea4a541f7ba441ec3dc3b6508315c36f6466c13536")
     add_patches("2.1.3", path.join(os.scriptdir(), "patches", "2.1.3", "fix_qt.patch"), "11b6e765f8c8b0002f84ef0c3eb7dde23076b0564679760b7f4c8ba7c7e46887")


### PR DESCRIPTION
New version of nodeeditor detected (package version: 2.2.2, last github version: 3.0.12)