### PR TITLE
soxr: Keep only .zip source, remove .tar.xz source to resolve MSYS2

### DIFF
--- a/packages/s/soxr/xmake.lua
+++ b/packages/s/soxr/xmake.lua
@@ -31,13 +31,15 @@ package("soxr")
         if package:is_plat("windows") and package:config("shared") then
             package:add("defines", "SOXR_DLL")
         end
-        if package:is_plat("mingw") and not package:config("shared") or
-        package:is_plat("linux") and not package:config("shared") and package:is_arch("arm64") then
+        if package:is_plat("mingw") and not package:config("shared") then
             package:add("defines", "SOXR_DLL")
             package:add("defines", "soxr_EXPORTS")
             if package:config("lsr") then
                 package:add("defines", "soxr_lsr_EXPORTS")
             end
+        end
+        if package:is_plat("linux") and not package:config("shared") and package:is_arch("arm64") then
+            package:add("defines", "SOXR_VISIBILITY")
         end
     end)
 

--- a/packages/s/soxr/xmake.lua
+++ b/packages/s/soxr/xmake.lua
@@ -31,7 +31,7 @@ package("soxr")
         if package:is_plat("windows") and package:config("shared") then
             package:add("defines", "SOXR_DLL")
         end
-        if package:is_plat("mingw") and not package:config("shared") then
+        if package:is_plat("mingw", "linux") and not package:config("shared") then
             package:add("defines", "SOXR_DLL")
             package:add("defines", "soxr_EXPORTS")
             if package:config("lsr") then

--- a/packages/s/soxr/xmake.lua
+++ b/packages/s/soxr/xmake.lua
@@ -31,7 +31,8 @@ package("soxr")
         if package:is_plat("windows") and package:config("shared") then
             package:add("defines", "SOXR_DLL")
         end
-        if package:is_plat("mingw", "linux") and not package:config("shared") then
+        if package:is_plat("mingw") and not package:config("shared") or
+        package:is_plat("linux") and not package:config("shared") and package:is_arch("arm64") then
             package:add("defines", "SOXR_DLL")
             package:add("defines", "soxr_EXPORTS")
             if package:config("lsr") then

--- a/packages/s/soxr/xmake.lua
+++ b/packages/s/soxr/xmake.lua
@@ -39,7 +39,7 @@ package("soxr")
             end
         end
         if package:is_plat("linux") and not package:config("shared") and package:is_arch("arm64") then
-            package:add("defines", "SOXR=__attribute__ ((visibility("default")))")
+            package:add("defines", [[SOXR=__attribute__ ((visibility("default")))]])
         end
     end)
 

--- a/packages/s/soxr/xmake.lua
+++ b/packages/s/soxr/xmake.lua
@@ -3,10 +3,6 @@ package("soxr")
     set_description("The SoX Resampler library libsoxr performs fast, high-quality one-dimensional sample rate conversion.")
     set_license("LGPL-2.1")
 
-    add_urls("https://downloads.sourceforge.net/project/soxr/soxr-$(version)-Source.tar.xz",
-             "https://deac-fra.dl.sourceforge.net/project/soxr/soxr-$(version)-Source.tar.xz",
-             "https://deac-riga.dl.sourceforge.net/project/soxr/soxr-$(version)-Source.tar.xz", {alias = "sourceforge"})
-
     add_urls("https://sourceforge.net/code-snapshots/git/s/so/soxr/code.git/soxr-code-$(version).zip", {alias = "snapshot", version = function (version)
         local versions = {
             ["0.1.3"] = "945b592b70470e29f917f4de89b4281fbbd540c0"
@@ -15,7 +11,6 @@ package("soxr")
     end})
 
     add_versions("snapshot:0.1.3", "b797a5d23078be234e520af1041b5e11b49864696d56f0d0b022a0349d1e8d1b")
-    add_versions("sourceforge:0.1.3", "b111c15fdc8c029989330ff559184198c161100a59312f5dc19ddeb9b5a15889")
 
     add_configs("openmp",   {description = "Include OpenMP threading.", default = false, type = "boolean"})
     add_configs("lsr",      {description = "Include a `libsamplerate'-like interface.", default = true, type = "boolean"})

--- a/packages/s/soxr/xmake.lua
+++ b/packages/s/soxr/xmake.lua
@@ -39,7 +39,7 @@ package("soxr")
             end
         end
         if package:is_plat("linux") and not package:config("shared") and package:is_arch("arm64") then
-            package:add("defines", "SOXR_VISIBILITY")
+            package:add("defines", "SOXR=__attribute__ ((visibility("default")))")
         end
     end)
 

--- a/packages/s/soxr/xmake.lua
+++ b/packages/s/soxr/xmake.lua
@@ -17,6 +17,9 @@ package("soxr")
     if is_plat("mingw") and is_subhost("macosx") then
         add_configs("shared", {description = "Build shared library.", default = true, type = "boolean", readonly = true})
     end
+    if is_plat("linux") and is_arch("arm64") then
+        add_configs("shared", {description = "Build shared library.", default = true, type = "boolean", readonly = true})
+    end
 
     add_deps("cmake")
 
@@ -37,9 +40,6 @@ package("soxr")
             if package:config("lsr") then
                 package:add("defines", "soxr_lsr_EXPORTS")
             end
-        end
-        if package:is_plat("linux") and not package:config("shared") and package:is_arch("arm64") then
-            package:add("defines", [[SOXR=__attribute__ ((visibility("default")))]])
         end
     end)
 


### PR DESCRIPTION
I am not very familiar with the MSYS2 but this is workaround.
```
D:\a\_temp\msys64\mingw64\bin\xz.exe -d -f D:\a\_temp\msys64\tmp\.xmake\250725\_FCCFCA27021F473081250F5B39A30850.tar\soxr-0.1.3-Source.tar.xz
D:\a\_temp\msys64\usr\bin\tar.exe --force-local -xf D:\a\_temp\msys64\tmp\.xmake\250725\_FCCFCA27021F473081250F5B39A30850.tar\soxr-0.1.3-Source.tar
/usr/bin/tar: soxr-0.1.3-Source/inst-check-soxr-lsr: Cannot create symlink to ‘inst-check-soxr’: No such file or directory
/usr/bin/tar: Exiting with failure status due to previous errors
error: ...modules\private\action\require\impl\actions\download.lua:257: @programdir\modules\utils\archive\extract.lua:458: cannot extract soxr-0.1.3-Source.tar.xz, @programdir\modules\utils\archive\extract.lua:458: cannot extract soxr-0.1.3-Source.tar, @programdir\core\sandbox\modules\os.lua:378: execv(D:\a\_temp\msys64\usr\bin\tar.exe --force-local -xf D:\a\_temp\msys64\tmp\.xmake\250725\_FCCFCA27021F473081250F5B39A30850.tar\soxr-0.1.3-Source.tar) failed(2)
```
TODO: resolve linux arm64 issue.
I decided to keep it shared only for linux arm64 case.
Part of pulseaudio PR.
https://github.com/xmake-io/xmake-repo/pull/7695

