### PR TITLE
Auto-update redis-plus-plus to 1.3.15

### DIFF
--- a/packages/r/redis-plus-plus/xmake.lua
+++ b/packages/r/redis-plus-plus/xmake.lua
@@ -4,6 +4,7 @@ package("redis-plus-plus")
 
     add_urls("https://github.com/sewenew/redis-plus-plus/archive/refs/tags/$(version).tar.gz",
              "https://github.com/sewenew/redis-plus-plus.git")
+    add_versions("1.3.15", "e9288fda74f1501c62dd9ab7d6a8dc67de51aa4d5b7c71770baa51987a945941")
     add_versions("1.3.14", "a7a15b51a857339cc73f444ea93e042a8c911a0e7858cecc394200c47b76fb3f")
     add_versions("1.3.13", "678a61898ed72f0c692102c7ce103a1bcae1e6ff85a4ad03e6002c1ba8fe1e08")
     add_versions("1.3.12", "26c1e45cdbafe1af4d2cf756957b2268baab6f802b53bcdd435864620e2c03c7")


### PR DESCRIPTION
New version of redis-plus-plus detected (package version: 1.3.14, last github version: 1.3.15)