### PR TITLE
Auto-update spectra to v1.2.0

### DIFF
--- a/packages/s/spectra/xmake.lua
+++ b/packages/s/spectra/xmake.lua
@@ -7,6 +7,7 @@ package("spectra")
 
     add_urls("https://github.com/yixuan/spectra/archive/refs/tags/$(version).tar.gz",
              "https://github.com/yixuan/spectra.git")
+    add_versions("v1.2.0", "fdfccacba1c77d9b4ffefae7258c760c99e3c8a2823ca87ea5b11a50d297a73b")
     add_versions("v1.1.0", "d29671e3d1b8036728933cadfddb05668a3cd6133331e91fc4535a9b85bedc79")
     add_versions("v1.0.1", "919e3fbc8c539a321fd5a0766966922b7637cc52eb50a969241a997c733789f3")
 


### PR DESCRIPTION
New version of spectra detected (package version: v1.1.0, last github version: v1.2.0)