### PR TITLE
Auto-update re-flex to v6.0.0

### DIFF
--- a/packages/r/re-flex/xmake.lua
+++ b/packages/r/re-flex/xmake.lua
@@ -14,6 +14,10 @@ package("re-flex")
     add_versions("v4.4.0", "3b34d0c88f91db6b5387355a64a84bfa6464d90fb182aab05c367605db28d2e8")
     add_versions("v4.3.0", "1658c1be9fa95bf948a657d75d2cef0df81b614bc6052284935774d4d8551d95")
 
+    if is_plat("windows", "mingw", "msys") then
+        add_syslinks("ws2_32")
+    end
+
     on_install(function (package)
         io.writefile("xmake.lua",[[
             add_rules("mode.debug", "mode.release")
@@ -27,6 +31,9 @@ package("re-flex")
                 add_headerfiles("include/(reflex/*.h)")
                 add_files("lib/*.cpp")
                 add_files("unicode/*.cpp")
+                if is_plat("windows", "mingw", "msys") then
+                    add_syslinks("ws2_32")
+                end
                 if is_plat("windows") and is_kind("shared") then
                     add_rules("utils.symbols.export_all", {export_classes = true})
                 end
@@ -36,7 +43,12 @@ package("re-flex")
                 add_files("src/*.cpp")
                 add_deps("re-flex")
         ]])
-        import("package.tools.xmake").install(package)
+
+        local configs
+        if package:version() and package:version():ge("6.0") and package:is_plat("mingw") then
+            configs = {"--cxflags=-D_WIN32 -D_UCRT"}
+        end
+        import("package.tools.xmake").install(package, configs)
         package:addenv("PATH", "bin")
     end)
 

--- a/packages/r/re-flex/xmake.lua
+++ b/packages/r/re-flex/xmake.lua
@@ -6,6 +6,7 @@ package("re-flex")
     add_urls("https://github.com/Genivia/RE-flex/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Genivia/RE-flex.git")
 
+    add_versions("v6.0.0", "488a778577429408a3390b6aeac796eccaaa1297bb7573feccf3b608b9ae9d95")
     add_versions("v5.3.0", "f886b2a6354bd5c5e27dce64f5c701a0a8fcb62eafc58d41f8aed9c0582be764")
     add_versions("v5.2.2", "be7f4adb3141dcb9079f5431f36f35ed553d972eb76565e3bb36da635d9aa126")
     add_versions("v5.0.1", "b74430fe63a6e3e665676d23601e332fcf12714efb798661bf307cb7a230ca4f")


### PR DESCRIPTION
New version of re-flex detected (package version: v5.3.0, last github version: v6.0.0)