### PR TITLE
Auto-update croaring to v4.3.6

### DIFF
--- a/packages/c/croaring/xmake.lua
+++ b/packages/c/croaring/xmake.lua
@@ -6,6 +6,7 @@ package("croaring")
     add_urls("https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/$(version).tar.gz",
              "https://github.com/RoaringBitmap/CRoaring.git")
 
+    add_versions("v4.3.6", "d9c63e6fa06630cd626be004a226bea15eb4acba6740a46f58c6b189fa5d49b3")
     add_versions("v4.3.5", "fd5afacb174322ce45bea333076440e615fb8cc2751b537c8051ac2d39f52b1e")
     add_versions("v4.1.7", "ea235796c074c3a8a8c3e5c84bb5f09619723b8e4913cf99cc349f626c193569")
     add_versions("v4.1.5", "7eafa9fd0dace499e80859867a6ba5a010816cf6e914dd9350ad1d44c0fc83eb")


### PR DESCRIPTION
New version of croaring detected (package version: v4.3.5, last github version: v4.3.6)