### PR TITLE
Update imguitextselect to 1.3.0

### DIFF
--- a/packages/i/imguitextselect/port/xmake.lua
+++ b/packages/i/imguitextselect/port/xmake.lua
@@ -1,0 +1,26 @@
+add_rules("mode.debug", "mode.release")
+add_rules("utils.install.cmake_importfiles")
+set_languages("c++20")
+
+option("utfcpp", {default = false})
+
+add_requires("imgui")
+add_rules("mode.release", "mode.debug")
+
+if has_config("utfcpp") then
+    add_requires("utfcpp")
+end
+
+target("imguitextselect")
+    set_kind("$(kind)")
+    add_files("textselect.cpp")
+    add_headerfiles("textselect.hpp")
+    add_packages("imgui")
+
+    if has_config("utfcpp") then
+        add_packages("utfcpp")
+    end
+
+    if is_plat("windows") and is_kind("shared") then
+        add_rules("utils.symbols.export_all", {export_classes = true})
+    end

--- a/packages/i/imguitextselect/xmake.lua
+++ b/packages/i/imguitextselect/xmake.lua
@@ -6,6 +6,7 @@ package("imguitextselect")
     add_urls("https://github.com/AidanSun05/ImGuiTextSelect/archive/v$(version).tar.gz",
              "https://github.com/AidanSun05/ImGuiTextSelect.git")
 
+    add_versions("1.3.0", "529cf6bf5dc80d7540083395f93dd2a075e9c71450eb140104944021156a8dfa")
     add_versions("1.2.0", "63af906b955c8160b350aff426f7f89e6a250a7b784933338d1fc9504ac3a9ac")
     add_versions("1.1.6", "41ebb4323697bd2e1bedd3bb52a5abd222e941b9e145896d25741143b31ecec7")
     add_versions("1.1.5", "43636bc5a52c0ed92414d34976a839fcb69f76246e9c729c9d9e0da2c53d57b2")
@@ -16,23 +17,23 @@ package("imguitextselect")
     add_versions("1.1.0", "9464f5cdd118a77ecd64c21cad713ed4a729bae742750feb980d7c36e787d317")
     add_versions("1.0.0", "198184dc562a868e748606e1b88c708491f04762413ddcb2d2a251a1cba38a43")
 
-    add_deps("imgui", "utfcpp")
+    add_deps("imgui")
+
+    on_load(function (package)
+        local version = package:version()
+        if version and version:lt("1.3.0") then
+            package:add("deps", "utfcpp")
+        end
+    end)
 
     on_install("windows", "linux", "macosx", "mingw", "android", "iphoneos", function (package)
-        io.writefile("xmake.lua", [[
-            add_requires("imgui", "utfcpp")
-            add_rules("mode.release", "mode.debug")
-            target("imguitextselect")
-                set_kind("$(kind)")
-                set_languages("c++20")
-                add_files("textselect.cpp")
-                add_headerfiles("textselect.hpp")
-                add_packages("imgui", "utfcpp")
-                if is_plat("windows") and is_kind("shared") then
-                    add_rules("utils.symbols.export_all", {export_classes = true})
-                end
-        ]])
-        import("package.tools.xmake").install(package)
+        local version = package:version()
+        local configs = {
+            utfcpp = version and version:lt("1.3.0")
+        }
+
+        os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
+        import("package.tools.xmake").install(package, configs)
     end)
 
     on_test(function (package)


### PR DESCRIPTION
The new version drops the dependency on utfcpp so additional changes are made to handle this while maintaining backwards compatibility.