### PR TITLE
Auto-update lzav to 4.23

### DIFF
--- a/packages/l/lzav/xmake.lua
+++ b/packages/l/lzav/xmake.lua
@@ -7,6 +7,7 @@ package("lzav")
     add_urls("https://github.com/avaneev/lzav/archive/refs/tags/$(version).tar.gz",
              "https://github.com/avaneev/lzav.git")
 
+    add_versions("4.23", "f3ea9cfbbc99da786ff6c336ea43cc629502638d457b07e64c182d4ab98c5c09")
     add_versions("4.19", "e19e093f465b69906aec109ab78f5a38c00fee1d21c61c013d7b185da33911dc")
     add_versions("4.9", "460aaed16cce0ce1d6af03cf20db1dd9566adef7e1cbc8529ce1b8653ede0412")
     add_versions("4.7", "bb888588ec0edce238ce900806ff9cd1722b6109374cb7766587ad8375cd1517")


### PR DESCRIPTION
New version of lzav detected (package version: 4.19, last github version: 4.23)