### PR TITLE
Auto-update hwdata to v0.398

### DIFF
--- a/packages/h/hwdata/xmake.lua
+++ b/packages/h/hwdata/xmake.lua
@@ -7,6 +7,7 @@ package("hwdata")
     add_urls("https://github.com/vcrhonek/hwdata/archive/refs/tags/$(version).tar.gz",
              "https://github.com/vcrhonek/hwdata.git")
 
+    add_versions("v0.398", "cd52f7eb5c0f438a3605d1799d9f345a2894ad0f269ab6e8441f55e27e80dd78")
     add_versions("v0.397", "09eee39e73a63ab27af651ab6afdd13d6e5c3485872f2cd406b35e4d80ffdb0b")
 
     if is_plat("bsd") then


### PR DESCRIPTION
New version of hwdata detected (package version: v0.397, last github version: v0.398)