### PR TITLE
Auto-update libdwarf to 2.1.0

### DIFF
--- a/packages/l/libdwarf/xmake.lua
+++ b/packages/l/libdwarf/xmake.lua
@@ -6,6 +6,7 @@ package("libdwarf")
     add_urls("https://github.com/davea42/libdwarf-code/releases/download/v$(version)/libdwarf-$(version).tar.xz",
              "https://github.com/davea42/libdwarf-code.git")
 
+    add_versions("2.1.0", "461bd29cbb9a41c26a25b0e527c3736c772bb7a89f6260d1edb39ab105226e06")
     add_versions("2.0.0", "c3d1db72a979e14ee60b93010f0698d30fc1bca4eb1341006783d4e9c9ec7e72")
     add_versions("0.12.0", "444dc1c5176f04d3ebc50341552a8b2ea6c334f8f1868a023a740ace0e6eae9f")
     add_versions("0.11.1", "b5be211b1bd0c1ee41b871b543c73cbff5822f76994f6b160fc70d01d1b5a1bf")


### PR DESCRIPTION
New version of libdwarf detected (package version: 2.0.0, last github version: 2.1.0)