### PR TITLE
fixed: update the patch checksum for utf8proc version 2.10.0

### DIFF
--- a/packages/u/utf8proc/xmake.lua
+++ b/packages/u/utf8proc/xmake.lua
@@ -11,7 +11,7 @@ package("utf8proc")
     add_versions("v2.7.0", "4bb121e297293c0fd55f08f83afab6d35d48f0af4ecc07523ad8ec99aa2b12a1")
     add_versions("v2.8.0", "a0a60a79fe6f6d54e7d411facbfcc867a6e198608f2cd992490e46f04b1bcecc")
 
-    add_patches("v2.10.0", "https://github.com/JuliaStrings/utf8proc/commit/24e2a191247290f46701c5cb723a575442356656.diff", "743578657d1ef89231da7f67d7189b31f0f10a0cb779ffeed6c9007a58db90d8")
+    add_patches("v2.10.0", "https://github.com/JuliaStrings/utf8proc/commit/24e2a191247290f46701c5cb723a575442356656.diff", "16b63b4091093c4cf42935fc0ee273555dd0562394f55a4a4c8ae33c2147b462")
 
     add_deps("cmake")
     on_load(function (package)


### PR DESCRIPTION
update the patch checksum for utf8proc version 2.10.0. 

old checksum error!
<img width="2536" height="510" alt="图片" src="https://github.com/user-attachments/assets/f9870cf7-463f-4583-9c1d-48313af899fc" />


