### PR TITLE
Auto-update c-blosc2 to v2.21.0

### DIFF
--- a/packages/c/c-blosc2/xmake.lua
+++ b/packages/c/c-blosc2/xmake.lua
@@ -6,6 +6,7 @@ package("c-blosc2")
     add_urls("https://github.com/Blosc/c-blosc2/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Blosc/c-blosc2.git")
 
+    add_versions("v2.21.0", "de69eedd87a8301cdb665f3dab61e7c2b7e4b326a496f9ec88213fc8788d54d5")
     add_versions("v2.19.1", "cb645982acfeccc8676bc4f29859130593ec05f7f9acf62ebd4f1a004421fa28")
     add_versions("v2.18.0", "9fce013de33a3f325937b6c29fd64342c1e71de38df6bb9eda09519583d8aabe")
     add_versions("v2.17.1", "53c6ed1167683502f5db69d212106e782180548ca5495745eb580e796b7f7505")


### PR DESCRIPTION
New version of c-blosc2 detected (package version: v2.19.1, last github version: v2.21.0)