### PR TITLE
Auto-update libbpf to v1.6.1

### DIFF
--- a/packages/l/libbpf/xmake.lua
+++ b/packages/l/libbpf/xmake.lua
@@ -5,6 +5,7 @@ package("libbpf")
 
     add_urls("https://github.com/libbpf/libbpf/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libbpf/libbpf.git")
+    add_versions("v1.6.1", "f6fa65c86f20d6d2d5d958f8bb8203a580a1c7496173714582300b724e37e338")
     add_versions("v0.3", "c168d84a75b541f753ceb49015d9eb886e3fb5cca87cdd9aabce7e10ad3a1efc")
 
     add_deps("libelf", "zlib")


### PR DESCRIPTION
New version of libbpf detected (package version: v0.3, last github version: v1.6.1)