### PR TITLE
Auto-update hyprwayland-scanner to v0.4.5

### DIFF
--- a/packages/h/hyprwayland-scanner/xmake.lua
+++ b/packages/h/hyprwayland-scanner/xmake.lua
@@ -7,6 +7,7 @@ package("hyprwayland-scanner")
     add_urls("https://github.com/hyprwm/hyprwayland-scanner/archive/refs/tags/$(version).tar.gz",
              "https://github.com/hyprwm/hyprwayland-scanner.git")
 
+    add_versions("v0.4.5", "2125d279eea106e3e6c8dc9fa15181c75d67467b5352d24e2a07903b10abad62")
     add_versions("v0.4.4", "ac73f626019f8d819ff79a5fca06ce4768ce8a3bded6f48c404445f3afaa25ac")
 
     if is_plat("linux") then


### PR DESCRIPTION
New version of hyprwayland-scanner detected (package version: v0.4.4, last github version: v0.4.5)