### PR TITLE
Auto-update pybind11 to v3.0.1

### DIFF
--- a/packages/p/pybind11/xmake.lua
+++ b/packages/p/pybind11/xmake.lua
@@ -7,6 +7,7 @@ package("pybind11")
     add_urls("https://github.com/pybind/pybind11/archive/refs/tags/$(version).zip",
              "https://github.com/pybind/pybind11.git")
 
+    add_versions("v3.0.1", "20fb420fe163d0657a262a8decb619b7c3101ea91db35f1a7227e67c426d4c7e")
     add_versions("v3.0.0", "dfe152af2f454a9d8cd771206c014aecb8c3977822b5756123f29fd488648334")
     add_versions("v2.13.6", "d0a116e91f64a4a2d8fb7590c34242df92258a61ec644b79127951e821b47be6")
     add_versions("v2.13.5", "0b4f2d6a0187171c6d41e20cbac2b0413a66e10e014932c14fae36e64f23c565")


### PR DESCRIPTION
New version of pybind11 detected (package version: v3.0.0, last github version: v3.0.1)