### PR TITLE
libbpf: add back android support

### DIFF
--- a/packages/l/libbpf/xmake.lua
+++ b/packages/l/libbpf/xmake.lua
@@ -16,7 +16,11 @@ package("libbpf")
             local ndk_sdkver = ndk:config("ndk_sdkver")
             local ndkver = ndk:config("ndkver")
             assert(ndkver and tonumber(ndkver) < 26, "package(libbpf): need ndk version < 26 for android")
-            assert(ndk_sdkver and tonumber(ndk_sdkver) == 23, "package(libbpf): need ndk api level == 23 for android")
+            if package:version() and package:version():lt("0.5") then
+                assert(ndk_sdkver and tonumber(ndk_sdkver) >= 23, "package(libbpf) dep(libelf): need ndk api level >= 23 for android")
+            else
+                assert(ndk_sdkver and tonumber(ndk_sdkver) == 23, "package(libbpf) dep(elfutils): need ndk api level == 23 for android")
+            end
         end)
     end
 

--- a/packages/l/libbpf/xmake.lua
+++ b/packages/l/libbpf/xmake.lua
@@ -1,31 +1,48 @@
 package("libbpf")
-
     set_homepage("https://github.com/libbpf/libbpf")
     set_description("Automated upstream mirror for libbpf stand-alone build.")
+    set_license("BSD-2-Clause")
 
     add_urls("https://github.com/libbpf/libbpf/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libbpf/libbpf.git")
+    add_versions("v1.6.2", "16f31349c70764cba8e0fad3725cc9f52f6cf952554326aa0229daaa21ef4fbd")
     add_versions("v0.3", "c168d84a75b541f753ceb49015d9eb886e3fb5cca87cdd9aabce7e10ad3a1efc")
 
-    add_deps("libelf", "zlib")
+    add_deps("zlib")
+
+    if on_check then
+        on_check("android", function (package)
+            local ndk = package:toolchain("ndk"):config("ndkver")
+            assert(package:version():ge("0.5") and ndk and tonumber(ndk) > 22, "package(libbpf) >= v0.5 require ndk api version > 22")
+        end)
+    end
+
+    on_load(function (package)
+        if package:version() and package:version():lt("0.5") then
+            package:add("deps", "libelf")
+        else
+            package:add("deps", "elfutils")
+        end
+    end)
 
     add_includedirs("include", "include/uapi")
 
     on_install("linux", "android", function (package)
-        io.writefile("xmake.lua", [[
+        local libelfname = package:version():lt("0.5") and "libelf" or "elfutils"
+        io.writefile("xmake.lua", format([[
             add_rules("mode.debug", "mode.release")
-            add_requires("libelf", "zlib")
+            add_requires("%s", "zlib")
             target("bpf")
                 set_kind("$(kind)")
                 add_files("src/*.c")
                 add_includedirs("include", "include/uapi")
-                add_packages("libelf", "zlib")
+                add_packages("%s", "zlib")
                 add_headerfiles("src/(*.h)", {prefixdir = "bpf"})
                 add_headerfiles("include/(uapi/**.h)")
                 if is_plat("android") then
                     add_defines("__user=", "__force=", "__poll_t=uint32_t")
                 end
-        ]])
+        ]], libelfname, libelfname))
         local configs = {}
         import("package.tools.xmake").install(package, configs)
     end)

--- a/packages/l/libbpf/xmake.lua
+++ b/packages/l/libbpf/xmake.lua
@@ -12,8 +12,11 @@ package("libbpf")
 
     if on_check then
         on_check("android", function (package)
-            local ndk = package:toolchain("ndk"):config("ndkver")
-            assert(package:version():ge("0.5") and ndk and tonumber(ndk) > 22, "package(libbpf) >= v0.5 require ndk api version > 22")
+            local ndk = package:toolchain("ndk")
+            local ndk_sdkver = ndk:config("ndk_sdkver")
+            local ndkver = ndk:config("ndkver")
+            assert(ndkver and tonumber(ndkver) < 26, "package(libbpf): need ndk version < 26 for android")
+            assert(ndk_sdkver and tonumber(ndk_sdkver) == 23, "package(libbpf): need ndk api level == 23 for android")
         end)
     end
 


### PR DESCRIPTION
Based on #7975, but added Android support back.

Android needs NDK SDK version >= 23.
