### PR TITLE
Auto-update eabase to 2.09.06

### DIFF
--- a/packages/e/eabase/xmake.lua
+++ b/packages/e/eabase/xmake.lua
@@ -7,6 +7,7 @@ package("eabase")
     add_urls("https://github.com/electronicarts/EABase/archive/refs/tags/$(version).tar.gz",
              "https://github.com/electronicarts/EABase.git")
 
+    add_versions("2.09.06", "981f922441617152b841585c0fc0bd205bd898c758016fa4985599a63c5a6e16")
     add_versions("2.09.05", "f85b98c96f1976aa013c8d6016c5e37a409633ac3fce843cd4ec0b89c67e6b7a")
     add_patches("2.09.05", "patches/2.09.05/add-arm64-windows.patch", "c140e4587fdb1fc93b16df639da93aac5d331420b86f68363482be31f4bd2bfd")
 


### PR DESCRIPTION
New version of eabase detected (package version: 2.09.05, last github version: 2.09.06)