### PR TITLE
Auto-update veil to v1.5.0

### DIFF
--- a/packages/v/veil/xmake.lua
+++ b/packages/v/veil/xmake.lua
@@ -7,6 +7,7 @@ package("veil")
     add_urls("https://github.com/MiroKaku/Musa.Veil/archive/refs/tags/$(version).tar.gz",
              "https://github.com/MiroKaku/Musa.Veil.git")
 
+    add_versions("v1.5.0", "13dfa9249c26926fc3a6b6995ff917f58bfd032c22274349c5837e1d482a3baa")
     add_versions("v1.4.1", "bf58b3d8162bb3df98d98f91ebd3b472288886e0e5e8fae058d21f85e6cc8ef3")
 
     add_syslinks("ntdll")


### PR DESCRIPTION
New version of veil detected (package version: v1.4.1, last github version: v1.5.0)