### PR TITLE
Auto-update platformfolders to 4.3.0

### DIFF
--- a/packages/p/platformfolders/xmake.lua
+++ b/packages/p/platformfolders/xmake.lua
@@ -6,6 +6,7 @@ package("platformfolders")
     add_urls("https://github.com/sago007/PlatformFolders/archive/refs/tags/$(version).tar.gz",
              "https://github.com/sago007/PlatformFolders.git")
 
+    add_versions("4.3.0", "4d1c3139882c55f4f1206d89157a699224476e17fbeda68d891ddfb61f901ffd")
     add_versions("4.2.0", "31bb0f64a27315aec8994f226332aaafe9888d00bb69a2ff2dff9912e2f4ccf4")
 
     add_patches("4.2.0", "patches/4.2.0/cmake-install.patch", "a38850ff7e9b91034f226685af7633ff692de3aea4798cb3dddecc6b055a7601")


### PR DESCRIPTION
New version of platformfolders detected (package version: 4.2.0, last github version: 4.3.0)