### PR TITLE
sdl2webgpu: add package

### DIFF
--- a/packages/s/sdl2webgpu/xmake.lua
+++ b/packages/s/sdl2webgpu/xmake.lua
@@ -1,0 +1,54 @@
+package("sdl2webgpu")
+    set_description("An extension for the SDL2 library for using WebGPU native.")
+    set_homepage("https://github.com/eliemichel/sdl2webgpu")
+    set_license("MIT")
+
+    -- Version 1.0.0 is too old for the current wgpu-native, we have to fetch a newer version from a more recent commit
+    add_urls("https://github.com/eliemichel/sdl2webgpu.git")
+    add_versions("2025.04.18", "eda8bedcb78a755f42c5efa00b732c62e89c23cb")
+
+    add_deps("wgpu-native", "libsdl2")
+
+    if is_plat("macosx", "iphoneos") then
+        add_frameworks("CoreVideo", "IOKit", "QuartzCore", is_plat("macosx") and "Cocoa" or "UIKit")
+    end
+
+    on_install("windows|x64", "windows|x86", "linux|x86_64", "macosx|x86_64", "macosx|arm64", function (package)
+        if package:is_plat("macosx", "iphoneos") then
+            os.mv("sdl2webgpu.c", "sdl2webgpu.m")
+        end
+
+        io.writefile("xmake.lua", [[
+            add_rules("mode.debug", "mode.release")
+
+            add_requires("wgpu-native", "libsdl2")
+
+            target("sdl2webgpu")
+                set_kind("$(kind)")
+                set_languages("c11")
+                add_headerfiles("sdl2webgpu.h")
+
+                add_mxflags("-fno-objc-arc")
+
+                add_packages("wgpu-native")
+                add_packages("libsdl2")
+
+                if is_plat("macosx", "iphoneos") then
+                    add_frameworks("CoreVideo", "IOKit", "QuartzCore", is_plat("macosx") and "Cocoa" or "UIKit")
+                    add_files("sdl2webgpu.m")
+                else
+                    add_files("sdl2webgpu.c")
+                end
+
+                if is_plat("windows") and is_kind("shared") then
+                    add_rules("utils.symbols.export_all")
+                end
+
+        ]])
+
+        import("package.tools.xmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("SDL_GetWGPUSurface", {includes = "sdl2webgpu.h"}))
+    end)

--- a/packages/s/sdl2webgpu/xmake.lua
+++ b/packages/s/sdl2webgpu/xmake.lua
@@ -50,5 +50,5 @@ package("sdl2webgpu")
     end)
 
     on_test(function (package)
-        assert(package:has_cfuncs("SDL_GetWGPUSurface", {includes = "sdl2webgpu.h"}))
+        assert(package:has_cfuncs("SDL_GetWGPUSurface", {includes = "sdl2webgpu.h", configs = {defines = "SDL_MAIN_HANDLED"}}))
     end)


### PR DESCRIPTION
## sdl2webgpu
### An extension for the SDL2 library for using WebGPU native.
https://github.com/eliemichel/sdl2webgpu

Based on the xmake.lua file for glfw3webgpu.

