### PR TITLE
Auto-update catch2 to v3.10.0

### DIFF
--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -5,6 +5,7 @@ package("catch2")
 
     add_urls("https://github.com/catchorg/Catch2/archive/refs/tags/$(version).zip",
              "https://github.com/catchorg/Catch2.git")
+    add_versions("v3.10.0", "e128e267ac17a7af61f57f65c31923a7b494cfe443aa7493e61033677cb7a0d3")
     add_versions("v3.9.0", "44d0c52a218d21da40800dc2d4e77f79ee6f8165ce9274fce52fa00608083912")
     add_versions("v3.8.1", "11e422a9d5a0a1732b3845ebb374c2d17e9d04337f3e717b21210be4ec2ec45b")
     add_versions("v3.8.0", "bffd2c45a84e5a4b0c17e695798e8d2f65931cbaf5c7556d40388d1d8d04eb83")


### PR DESCRIPTION
New version of catch2 detected (package version: v3.9.0, last github version: v3.10.0)