### PR TITLE
Auto-update watcher to 0.13.8

### DIFF
--- a/packages/w/watcher/xmake.lua
+++ b/packages/w/watcher/xmake.lua
@@ -7,6 +7,7 @@ package("watcher")
     set_urls("https://github.com/e-dant/watcher/archive/refs/tags/release/$(version).tar.gz",
              "https://github.com/e-dant/watcher.git")
 
+    add_versions("0.13.8", "ca415bb6e63012bb92543c2a0c76aec347fb36df48d6c1af8538018dd6584e06")
     add_versions("0.13.6", "b58b3a9f91d96d90080fd56cd998b1649633c43f92fc1bfe5562a000db472016")
     add_versions("0.13.5", "5bb0ea65b94d9444a6853eacff3a9b2121f0415d0ac895388d241f6f8be1e695")
     add_versions("0.13.2", "b037b4717a292892d61f619f9a2497ac0a49e8fd73d2c6bf4f9a6bef320718b2")


### PR DESCRIPTION
New version of watcher detected (package version: 0.13.6, last github version: 0.13.8)