### PR TITLE
Auto-update simdutf to v7.4.0

### DIFF
--- a/packages/s/simdutf/xmake.lua
+++ b/packages/s/simdutf/xmake.lua
@@ -5,6 +5,7 @@ package("simdutf")
 
     add_urls("https://github.com/simdutf/simdutf/archive/refs/tags/$(version).tar.gz",
              "https://github.com/simdutf/simdutf.git")
+    add_versions("v7.4.0", "8fd729ebfd5ec56cb0395bcc176c4801e1f8a0ea834d166d52279d7b9e801283")
     add_versions("v7.3.6", "c08f3dce1cbb7a8bead9eb53bcbda778e8a1c69b7d3a0690682f1b09fbb85c31")
     add_versions("v7.3.4", "c42ed66ceff7bc3e5f4981453864d1b7f656032843909b3807a632be46a1f5d4")
     add_versions("v7.3.3", "6d720ecdd2e524790c0204561f559b755952d8a836a237b2b533f716ab6fdfbb")


### PR DESCRIPTION
New version of simdutf detected (package version: v7.3.6, last github version: v7.4.0)