### PR TITLE
Auto-update libsais to v2.10.4

### DIFF
--- a/packages/l/libsais/xmake.lua
+++ b/packages/l/libsais/xmake.lua
@@ -5,6 +5,7 @@ package("libsais")
 
     add_urls("https://github.com/IlyaGrebnov/libsais/archive/refs/tags/$(version).tar.gz",
              "https://github.com/IlyaGrebnov/libsais.git")
+    add_versions("v2.10.4", "94aa88f9e29f8812214ecfa6b55f5dca14c7d8a427409c062f734a61ca4c6931")
     add_versions("v2.10.3", "69cb3ce4982ac0f6228cab4f5b324dc2445f82bb260ad8c927aea8033c661d52")
     add_versions("v2.10.2", "e2fe778b69dcd9e4a1df57b8eefb577f803788336855b6a5f9fbf22683f3980e")
     add_versions("v2.10.1", "ecf4611c18fefd8d4377343e4dc3f257ae17a501301a13f7cb7585c836405d39")


### PR DESCRIPTION
New version of libsais detected (package version: v2.10.3, last github version: v2.10.4)