### PR TITLE
Auto-update winreg to v6.4.0

### DIFF
--- a/packages/w/winreg/xmake.lua
+++ b/packages/w/winreg/xmake.lua
@@ -7,6 +7,7 @@ package("winreg")
     add_urls("https://github.com/GiovanniDicanio/WinReg/archive/refs/tags/$(version).tar.gz",
              "https://github.com/GiovanniDicanio/WinReg.git")
 
+    add_versions("v6.4.0", "a983d129b31cda357e118469d80e60bea2e8fa33010c6b40669ccd8f5f9896c2")
     add_versions("v6.3.2", "644adca91229d714efaeebf0c010cc795f888f6a1015bb7d42c2f0a45fe52f8b")
     add_versions("v6.3.1", "b92842cc37d3fe1a4d103929480045a40c39ba2efc15d7656f62e189d10d0bc4")
     add_versions("v6.3.0", "5a8b47c19ce705172cb1107451acbbb9fa7d8aa1e8f5356a2e682c16cf5532e9")


### PR DESCRIPTION
New version of winreg detected (package version: v6.3.2, last github version: v6.4.0)