### PR TITLE
OpenAL Soft Fix: Disable GCC Protected Visibility Test to Resolve Build Failures on NixOS and Similar Systems

### DIFF
--- a/packages/o/openal-soft/xmake.lua
+++ b/packages/o/openal-soft/xmake.lua
@@ -50,10 +50,8 @@ package("openal-soft")
     end)
 
     on_install("windows", "linux", "mingw", "macosx", "android", "iphoneos", "cross", "bsd" , function (package)
-        if (package:is_plat("linux") and linuxos.name() == "fedora") or package:is_plat("bsd") then
-            -- https://github.com/kcat/openal-soft/issues/864
-            io.replace("CMakeLists.txt", "if(HAVE_GCC_PROTECTED_VISIBILITY)", "if(0)", {plain = true})
-        end
+        -- https://github.com/kcat/openal-soft/issues/864
+        io.replace("CMakeLists.txt", "if(HAVE_GCC_PROTECTED_VISIBILITY)", "if(0)", { plain = true })
         local configs = {"-DALSOFT_EXAMPLES=OFF", "-DALSOFT_UTILS=OFF"}
         if package:config("shared") then
             table.insert(configs, "-DBUILD_SHARED_LIBS=ON")


### PR DESCRIPTION
OpenAL Soft's CMake configuration attempts to detect GCC's support for protected visibility using the HAVE_GCC_PROTECTED_VISIBILITY check. This detection fails on systems like NixOS and Fedora, leading to build errors. 

Solution:

This commit unconditionally disables the HAVE_GCC_PROTECTED_VISIBILITY check in the CMakeLists.txt file by replacing the conditional block with a fixed if(0) statement. This ensures that the build process proceeds without being affected by the faulty visibility detection, thereby resolving the build issues.

This issue has been previously reported and discussed in the OpenAL Soft issue tracker: [Issue #864](https://github.com/kcat/openal-soft/issues/864).
