### PR TITLE
Auto-update dylib to v3.0.1

### DIFF
--- a/packages/d/dylib/xmake.lua
+++ b/packages/d/dylib/xmake.lua
@@ -12,7 +12,7 @@ package("dylib")
 
     add_deps("cmake")
 
-    on_install(function (package)
+    on_install("!android and !bsd", function (package)
         import("package.tools.cmake").install(package)
     end)
 

--- a/packages/d/dylib/xmake.lua
+++ b/packages/d/dylib/xmake.lua
@@ -7,6 +7,7 @@ package("dylib")
     add_urls("https://github.com/martin-olivier/dylib/archive/refs/tags/$(version).tar.gz",
              "https://github.com/martin-olivier/dylib.git")
 
+    add_versions("v3.0.1", "dfef3f0aeccf4ad847a5cd02f0b0bff086b4fac6e764e33abd82d3c85cfb578c")
     add_versions("v2.2.1", "6af0d2a91860743dc9f564ba0ab7f036a9b37c904395610288791571d4dbea5b")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of dylib detected (package version: v2.2.1, last github version: v3.0.1)