### PR TITLE
Auto-update librats to 0.3.0

### DIFF
--- a/packages/l/librats/xmake.lua
+++ b/packages/l/librats/xmake.lua
@@ -6,6 +6,7 @@ package("librats")
     set_urls("https://github.com/DEgITx/librats/archive/refs/tags/$(version).tar.gz",
              "https://github.com/DEgITx/librats.git")
 
+    add_versions("0.3.0", "01e7e323e75ef7ef3b93a3025c7c2f31e37a42ebe414ec707cd500e054754e4b")
     add_versions("0.2.1", "32cc19dde006a54efdf642f54053d3506cb78815ca5b2db5c4d2c30104d33fc8")
     add_versions("0.1.5", "6e026e66c8a339f383a15ad1243d48acea601d91e584e146b8472cfc17709946")
 


### PR DESCRIPTION
New version of librats detected (package version: 0.2.1, last github version: 0.3.0)