### PR TITLE
krb5: fix build & upgrade to 1.22.1

### DIFF
--- a/packages/k/krb5/xmake.lua
+++ b/packages/k/krb5/xmake.lua
@@ -6,7 +6,7 @@ package("krb5")
     add_urls("https://kerberos.org/dist/krb5/$(version).tar.gz", {version = function (version)
         return format("%d.%d/krb5-%s", version:major(), version:minor(), version)
     end})
-    add_versions("1.19.2", "10453fee4e3a8f8ce6129059e5c050b8a65dab1c257df68b99b3112eaa0cdf6a")
+    add_versions("1.22.1", "1a8832b8cad923ebbf1394f67e2efcf41e3a49f460285a66e35adec8fa0053af")
 
     add_configs("tls", {description = "Enable TLS/OpenSSL support.", default = false, type = "boolean"})
     add_configs("shared", {description = "Build shared library.", default = true, type = "boolean", readonly = true})


### PR DESCRIPTION
#8114 

 - upgrade to 1.22.1
 - 1.19.2 seems to use gnu89, which is currently difficult to use with libraries using newer standards (such as openssl), so I dropped it.