### PR TITLE
Upgrade `buildir` to `builddir` on `libzip`

### DIFF
--- a/packages/l/libzip/xmake.lua
+++ b/packages/l/libzip/xmake.lua
@@ -73,20 +73,7 @@ package("libzip")
         for config, dep in pairs(configdeps) do
             table.insert(configs, "-DENABLE_" .. config:upper() .. "=" .. (package:config(config) and "ON" or "OFF"))
         end
-
-        local builddir = package.builddir and package:builddir() or package:buildir() -- `buildir` backwards compatibility
-
-        if package:is_plat("windows") then
-            os.mkdir(path.join(builddir(), "src/pdb"))
-            os.mkdir(path.join(builddir(), "lib/pdb"))
-        end
         import("package.tools.cmake").install(package, configs)
-
-        if package:is_plat("windows") and package:is_debug() then
-            local dir = package:installdir(package:config("shared") and "bin" or "lib")
-            os.vcp(path.join(builddir(), "src/*.pdb"), dir)
-            os.vcp(path.join(builddir(), "lib/*.pdb"), dir)
-        end
     end)
 
     on_test(function (package)


### PR DESCRIPTION
Fixes warning:
> [!WARNING]
>  package:buildir() has been deprecated, please use package:builddir()
