### PR TITLE
Auto-update luau to 0.691

### DIFF
--- a/packages/l/luau/xmake.lua
+++ b/packages/l/luau/xmake.lua
@@ -6,6 +6,7 @@ package("luau")
     add_urls("https://github.com/luau-lang/luau/archive/refs/tags/$(version).tar.gz",
              "https://github.com/luau-lang/luau.git")
     
+    add_versions("0.691", "ac4d630d475b352f96ddc511773640a69f146e30f465922e8ce406bd9294df4c")
     add_versions("0.689", "d03c79ee496b732c72f405283ffec07185050ed993347e45a0c4a1518c8cb886")
     add_versions("0.686", "34dd6a83e71a02f684707b7041674779c03961858a8ecefdd74cad36afc31177")
     add_versions("0.683", "a2c7aaf906d625e43ca468792acf8e47a9cbd1d4352623b5e62d2a4011faa15c")


### PR DESCRIPTION
New version of luau detected (package version: 0.689, last github version: 0.691)