### PR TITLE
Auto-update lief to 0.17.0

### DIFF
--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -6,6 +6,7 @@ package("lief")
     set_urls("https://github.com/lief-project/LIEF/archive/refs/tags/$(version).tar.gz",
              "https://github.com/lief-project/LIEF.git")
 
+    add_versions("0.17.0", "bcc5f1e0dcfbf6de07d8a666bf742cda6467cd08d4b5a9679dfdbaafe08563e2")
     add_versions("0.16.6", "20bae0130c98d6b29a8a7853f6a0f270398b277f12c3673164b08563cbd18e0c")
     add_versions("0.16.5", "10ef46bc958d7936feb155040c874504ab0bd40dc59b4678f807691ccd0d138f")
     add_versions("0.16.4", "311fff5ea9ecbe57b8d02e68739b97673cb14763129ce53af3eac8fee6bf845e")


### PR DESCRIPTION
New version of lief detected (package version: 0.16.6, last github version: 0.17.0)