### PR TITLE
wayland: update to 1.24.0

### DIFF
--- a/packages/w/wayland/xmake.lua
+++ b/packages/w/wayland/xmake.lua
@@ -3,12 +3,13 @@ package("wayland")
     set_description("Wayland is a protocol for a compositor to talk to its clients as well as a C library implementation of that protocol.")
     set_license("MIT")
 
-    add_urls("https://gitlab.freedesktop.org/wayland/wayland/-/releases/$(version)/downloads/wayland-$(version).tar.xz",
-             "https://fossies.org/linux/misc/wayland-$(version).tar.xz")
+    add_urls("https://fossies.org/linux/misc/wayland-$(version).tar.xz",
+             "https://gitlab.freedesktop.org/wayland/wayland/-/releases/$(version)/downloads/wayland-$(version).tar.xz")
     add_versions("1.18.0", "4675a79f091020817a98fd0484e7208c8762242266967f55a67776936c2e294d")
     add_versions("1.19.0", "baccd902300d354581cd5ad3cc49daa4921d55fb416a5883e218750fef166d15")
     add_versions("1.23.0", "05b3e1574d3e67626b5974f862f36b5b427c7ceeb965cb36a4e6c2d342e45ab2")
     add_versions("1.23.1", "864fb2a8399e2d0ec39d56e9d9b753c093775beadc6022ce81f441929a81e5ed")
+    add_versions("1.24.0", "82892487a01ad67b334eca83b54317a7c86a03a89cfadacfef5211f11a5d0536")
 
     if is_plat("linux") then
         add_extsources("apt::libwayland-dev", "pacman::wayland")


### PR DESCRIPTION
Place fossies mirror first in list, since `https://gitlab.freedesktop.org` is protected by anubis anti-DDoS, which could filter our request with higher possibility rather mirror url.
