### PR TITLE
freetype: fix cmake

### DIFF
--- a/packages/f/freetype/xmake.lua
+++ b/packages/f/freetype/xmake.lua
@@ -70,6 +70,7 @@ package("freetype")
     end)
 
     on_install(function (package)
+        io.replace("CMakeLists.txt", "cmake_minimum_required(VERSION 3.12", "cmake_minimum_required(VERSION 3.25", {plain = true})
         local configs = {"-DCMAKE_INSTALL_LIBDIR=lib"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))


### PR DESCRIPTION
~~Before CMake 3.25, the FindZLIB module had a bug:~~
~~in module mode, it would set `ZLIB_LIBRARY` to `zlib.lib;zlib.dll`.~~
误会cmake了