### PR TITLE
libkmod: fix pkg-config and upgrade to v33.

### DIFF
--- a/packages/l/libkmod/port/xmake.lua
+++ b/packages/l/libkmod/port/xmake.lua
@@ -1,5 +1,32 @@
 add_rules("mode.debug", "mode.release")
 
+option("zlib", {type = "boolean", default = false})
+option("zstd", {type = "boolean", default = false})
+option("xz",   {type = "boolean", default = false})
+option("ver",  {type = "number"})
+
+if has_config("zlib") then
+    add_requires("zlib")
+    add_packages("zlib")
+    add_defines("ENABLE_ZLIB")
+end
+if has_config("zstd") then
+    add_requires("zstd")
+    add_packages("zstd")
+    add_defines("ENABLE_ZSTD")
+end
+if has_config("xz") then
+    add_requires("xz")
+    add_packages("xz")
+    add_defines("ENABLE_XZ")
+end
+
+add_defines("ENABLE_DEBUG=" .. (is_mode("debug") and "1" or "0"))
+
+-- if is_config("ver", 34) then
+--     add_defines("ENABLE_ELFDBG=" .. (is_mode("debug") and "1" or "0"))
+-- end
+
 target("kmod")
     set_kind("$(kind)")
     set_languages("gnu99")
@@ -9,20 +36,25 @@ target("kmod")
     add_defines("PATH_MAX=4096")
     add_defines("ANOTHER_BRICK_IN_THE")
     add_defines("SYSCONFDIR=\"/tmp\"")
+    add_defines("DISTCONFDIR=\"/lib\"")
+    add_defines("MODULE_DIRECTORY=\"/lib/modules\"")
     add_defines("secure_getenv=getenv")
     add_cflags("-include config.h")
-    add_files(
-        "libkmod/libkmod.c",
-        "libkmod/libkmod-builtin.c",
-        "libkmod/libkmod-file.c",
-        "libkmod/libkmod-module.c",
-        "libkmod/libkmod-config.c",
-        "libkmod/libkmod-index.c",
-        "libkmod/libkmod-elf.c",
-        "libkmod/libkmod-list.c",
-        "libkmod/libkmod-signature.c",
-        "shared/array.c",
-        "shared/scratchbuf.c",
-        "shared/util.c",
-        "shared/hash.c",
-        "shared/strbuf.c")
+    add_files("libkmod/*.c", "shared/*.c")
+    add_options("zlib", "zstd", "xz", "ver")
+
+    if not has_config("zlib") then
+        remove_files("libkmod/libkmod-file-zlib.c")
+    end
+    if not has_config("zstd") then
+        remove_files("libkmod/libkmod-file-zstd.c")
+    end
+    if not has_config("xz") then
+        remove_files("libkmod/libkmod-file-xz.c")
+    end
+
+    on_config(function(target)
+        if target:has_cfuncs("basename", {includes = "string.h"}) then
+            target:add("defines", "HAVE_DECL_BASENAME")
+        end
+    end)

--- a/packages/l/libkmod/xmake.lua
+++ b/packages/l/libkmod/xmake.lua
@@ -3,19 +3,43 @@ package("libkmod")
     set_description("libkmod - Linux kernel module handling")
     set_license("LGPL-2.1")
 
-    add_urls("https://github.com/kmod-project/kmod/archive/refs/tags/$(version).tar.gz",
+    add_urls("https://github.com/kmod-project/kmod/archive/refs/tags/v$(version).tar.gz",
              "https://github.com/kmod-project/kmod.git")
 
-    add_versions("v31", "16c40aaa50fc953035b4811b29ce3182f220e95f3c9e5eacb4b07b1abf85f003")
-    add_versions("v30", "1fa3974abd80b992d61324bcc04fa65ea96cfe2e9e1150f48394833030c4b583")
+    add_versions("33", "c72120a2582ae240221671ddc1aa53ee522764806f50f8bf1522bbf055679985")
+    add_versions("32", "9477fa096acfcddaa56c74b988045ad94ee0bac22e0c1caa84ba1b7d408da76e")
+    add_versions("31", "16c40aaa50fc953035b4811b29ce3182f220e95f3c9e5eacb4b07b1abf85f003")
+    add_versions("30", "1fa3974abd80b992d61324bcc04fa65ea96cfe2e9e1150f48394833030c4b583")
 
-    add_patches("31", path.join(os.scriptdir(), "patches", "31", "basename.patch"), "83d07e169882cc91f3af162912ae97cd4b62ff48876ca83b0317c40a388773ad")
+    add_patches(">=30 <33", path.join(os.scriptdir(), "patches", "31", "basename.patch"), "83d07e169882cc91f3af162912ae97cd4b62ff48876ca83b0317c40a388773ad")
+
+    add_configs("zstd", {description = "Enable zstd support.", default = true, type = "boolean"})
+    add_configs("zlib", {description = "Enable zlib support.", default = true, type = "boolean"})
+    add_configs("xz", {description = "Enable xz support.", default = true, type = "boolean"})
+
+    add_includedirs("include", "include/libkmod")
+    on_load(function (package)
+        if package:config("zstd") then
+            package:add("deps", "zstd")
+        end
+        if package:config("zlib") then
+            package:add("deps", "zlib")
+        end
+        if package:config("xz") then
+            package:add("deps", "xz")
+        end
+    end)
 
     on_install("linux", "android", function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         os.cp(path.join(package:scriptdir(), "port", "config.h"), "config.h")
         os.cp(path.join(package:scriptdir(), "port", "endian-darwin.h"), "endian-darwin.h")
-        import("package.tools.xmake").install(package)
+        import("package.tools.xmake").install(package, {
+            zstd = package:config("zstd"),
+            zlib = package:config("zlib"),
+            xz = package:config("xz"),
+            ver = package:version_str()
+        })
     end)
 
     on_test(function (package)


### PR DESCRIPTION
## about pkg-config fix
The original package incorrectly uses `v31` as the version number (it should be `31`), which will cause other projects that use this package through pkg-config to be unable to correctly compare the version number.
