### PR TITLE
p11-kit: fix pkg-config and upgrade to 0.25.9

### DIFF
--- a/packages/p/p11-kit/xmake.lua
+++ b/packages/p/p11-kit/xmake.lua
@@ -36,7 +36,8 @@ package("p11-kit")
             "-Dbash_completion=disabled",
             "-Dman=false",
             "-Dnls=false",
-            "-Dtest=false"}
+            "-Dtest=false"
+        }
         table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
         import("package.tools.meson").install(package, configs)
     end)

--- a/packages/p/p11-kit/xmake.lua
+++ b/packages/p/p11-kit/xmake.lua
@@ -6,6 +6,7 @@ package("p11-kit")
     add_urls("https://github.com/p11-glue/p11-kit/releases/download/$(version)/p11-kit-$(version).tar.xz",
              "https://github.com/p11-glue/p11-kit.git")
 
+    add_versions("0.25.9", "98a96f6602a70206f8073deb5e894b1c8efd76ef53c629ab88815d58273f2561")
     add_versions("0.25.8", "2fd4073ee2a47edafaae2c8affa2bcca64e0697f8881f68f580801ef43cab0ce")
     add_versions("0.25.5", "04d0a86450cdb1be018f26af6699857171a188ac6d5b8c90786a60854e1198e5")
 
@@ -20,6 +21,7 @@ package("p11-kit")
     add_deps("meson", "ninja")
     add_deps("libffi", "libtasn1")
 
+    add_includedirs("include/p11-kit-1")
     on_load(function (package)
         if package:is_cross() then
             package:add("deps", "libtasn1~host", {host = true, private = true})
@@ -29,10 +31,14 @@ package("p11-kit")
     end)
 
     on_install("linux", "mingw", "macosx", "iphoneos", "bsd", "cross", function (package)
-        local configs = {"-Dsystemd=disabled", "-Dbash_completion=disabled", "-Dtest=false"}
+        local configs = {
+            "-Dsystemd=disabled", 
+            "-Dbash_completion=disabled",
+            "-Dman=false",
+            "-Dnls=false",
+            "-Dtest=false"}
         table.insert(configs, "-Ddefault_library=" .. (package:config("shared") and "shared" or "static"))
         import("package.tools.meson").install(package, configs)
-        os.trymv(package:installdir("include", "p11-kit-1", "*"), package:installdir("include"))
     end)
 
     on_test(function (package)


### PR DESCRIPTION
## about pkg-config fix
The original package moved the include files but didn't fix pkg-config, I restored the original includedir structure.