### PR TITLE
Auto-update vcpkg to 2025.08.27

### DIFF
--- a/packages/v/vcpkg/xmake.lua
+++ b/packages/v/vcpkg/xmake.lua
@@ -5,6 +5,7 @@ package("vcpkg")
     set_license("MIT")
 
     add_urls("https://github.com/microsoft/vcpkg/archive/refs/tags/$(version).tar.gz")
+    add_versions("2025.08.27", "b7ca5a754e4fbaa0f1d36c5f19ceef4ed47c65312fed298bb3dcf73c276dbe9b")
     add_versions("2025.07.25", "dff617c636a6519d4f083e658d404970c9da7d940a974e1d17f855f26a334e2f")
     add_versions("2024.11.16", "ec932ad758fb2b3aefc0d712d4bde8d913cd97ad2a0067d52f23d05c31b42aa0")
     add_versions("2024.10.21", "879ff57284d0bdcab127315a994cf571de4c1c72a0f7a80b770c3e3714d1649b")


### PR DESCRIPTION
New version of vcpkg detected (package version: 2025.07.25, last github version: 2025.08.27)