### PR TITLE
Auto-update nanobind to v2.9.2

### DIFF
--- a/packages/n/nanobind/xmake.lua
+++ b/packages/n/nanobind/xmake.lua
@@ -6,6 +6,7 @@ package("nanobind")
     set_urls("https://github.com/wjakob/nanobind/archive/refs/tags/$(version).tar.gz",
              "https://github.com/wjakob/nanobind.git", {submodules = false})
 
+    add_versions("v2.9.2", "8ce3667dce3e64fc06bfb9b778b6f48731482362fb89a43da156632266cd5a90")
     add_versions("v2.8.0", "17506f1ef5c92491183ab28242fa4f658d9625fe4f91ccd1d1358cb6e5f5acb6")
     add_versions("v2.7.0", "6c8c6bf0435b9d8da9312801686affcf34b6dbba142db60feec8d8e220830499")
     add_versions("v2.6.1", "519c6dd56581ad6db9aab814105c2666a0491096487cb384dd20216f80d1a291")


### PR DESCRIPTION
New version of nanobind detected (package version: v2.8.0, last github version: v2.9.2)