### PR TITLE
Auto-update simdjson to v4.0.6

### DIFF
--- a/packages/s/simdjson/xmake.lua
+++ b/packages/s/simdjson/xmake.lua
@@ -6,6 +6,7 @@ package("simdjson")
 
     add_urls("https://github.com/simdjson/simdjson/archive/refs/tags/$(version).tar.gz",
              "https://github.com/simdjson/simdjson.git")
+    add_versions("v4.0.6", "84b90eaff91c8a4ac40feff1fffa9d13d706f914413dd41351644038a14079b6")
     add_versions("v3.12.3", "d0af071f2f4187d8b26b556e83ef832b634bd5feb4e2f537b9dabbd334d4e334")
     add_versions("v3.12.2", "8ac7c97073d5079f54ad66d04381ec75e1169c2e20bfe9b6500bc81304da3faf")
     add_versions("v3.11.3", "eeb10661047e476aa3b535d14a32af95690691778d7afe0630a344654ff9759a")


### PR DESCRIPTION
New version of simdjson detected (package version: v3.12.3, last github version: v4.0.6)