### PR TITLE
Disable gtest cmake option by default

### DIFF
--- a/packages/g/gtest/xmake.lua
+++ b/packages/g/gtest/xmake.lua
@@ -25,7 +25,7 @@ package("gtest")
 
     add_configs("main",  {description = "Link to the gtest_main entry point.", default = false, type = "boolean"})
     add_configs("gmock", {description = "Link to the googlemock library.", default = true, type = "boolean"})
-    add_configs("cmake", {description = "Use cmake build system", default = true, type = "boolean"})
+    add_configs("cmake", {description = "Use cmake build system", default = false, type = "boolean"})
 
     if is_plat("linux", "bsd") then
         add_syslinks("pthread")


### PR DESCRIPTION
* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

Work around for #8202, caused by #8157 . I am not familiar enough with the tooling to fix the underlying cause, just reverting 
the defaults to old working path.