### PR TITLE
Auto-update ada to v3.3.0

### DIFF
--- a/packages/a/ada/xmake.lua
+++ b/packages/a/ada/xmake.lua
@@ -6,6 +6,7 @@ package("ada")
     set_urls("https://github.com/ada-url/ada/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ada-url/ada.git")
 
+    add_versions("v3.3.0", "75565e2d4cc8e3ce2dd7927f5c75cc5ebbd3b620468cb0226501dae68d8fe1cd")
     add_versions("v3.2.7", "91094beb8090875b03af74549f03b9ad3f21545d29c18e88dff0d8004d7c1417")
     add_versions("v3.2.6", "2e0b0c464ae9b5d97bc99fbec37878dde4a436fa0a34127f5755a0dfeb2c84a0")
     add_versions("v3.2.5", "cfda162be4b4e30f368e404e8df6704cdb18f0f26c901bb2f0290150c91e04b5")


### PR DESCRIPTION
New version of ada detected (package version: v3.2.7, last github version: v3.3.0)