### PR TITLE
Auto-update xtensor to 0.27.1

### DIFF
--- a/packages/x/xtensor/xmake.lua
+++ b/packages/x/xtensor/xmake.lua
@@ -7,6 +7,7 @@ package("xtensor")
     add_urls("https://github.com/xtensor-stack/xtensor/archive/refs/tags/$(version).tar.gz",
              "https://github.com/xtensor-stack/xtensor.git")
 
+    add_versions("0.27.1", "117c192ae3b7c37c0156dedaa88038e0599a6b264666c3c6c2553154b500fe23")
     add_versions("0.27.0", "9ca1743048492edfcc841bbe01f58520ff9c595ec587c0e7dc2fc39deeef3e04")
     add_versions("0.26.0", "f5f42267d850f781d71097b50567a480a82cd6875a5ec3e6238555e0ef987dc6")
     add_versions("0.25.0", "32d5d9fd23998c57e746c375a544edf544b74f0a18ad6bc3c38cbba968d5e6c7")


### PR DESCRIPTION
New version of xtensor detected (package version: 0.27.0, last github version: 0.27.1)