### PR TITLE
fix(doctest): Copy headers to the include directory

### DIFF
--- a/packages/d/doctest/xmake.lua
+++ b/packages/d/doctest/xmake.lua
@@ -1,5 +1,4 @@
 package("doctest")
-
     set_kind("library", {headeronly = true})
     set_homepage("http://bit.ly/doctest-docs")
     set_description("The fastest feature-rich C++11/14/17/20 single-header testing framework for unit tests and TDD")
@@ -18,11 +17,31 @@ package("doctest")
     add_versions("2.3.6", "f63c3c01021ba3fb35a0702127abfaa6fc44aaefd309e2c246e62a083deffa1f")
     add_versions("2.3.1", "b3d3c6133874e3a8c8e319cab33167156b6b1d2ed1ddde08c2655193cdeb58a0")
 
+    add_configs("cmake", {description = "Use cmake build system", default = true, type = "boolean"})
+    add_configs("std", {description = "Use std headers", default = false, type = "boolean"})
+
     -- some packages like `FakeIt` use <doctest.h>, so we need to prepend include dir
     add_includedirs("include", "include/doctest")
 
+    on_load(function (package)
+        if package:config("cmake") then
+            package:add("deps", "cmake")
+        end
+        if package:config("std") then
+            package:add("defines", "DOCTEST_CONFIG_USE_STD_HEADERS")
+        end
+    end)
+
     on_install(function (package)
-        os.cp("doctest", package:installdir("include"))
+        if package:config("cmake") then
+            local configs = {"-DDOCTEST_WITH_TESTS=OFF"}
+            table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
+            table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+            table.insert(configs, "-DDOCTEST_USE_STD_HEADERS=" .. (package:config("std") and "ON" or "OFF"))
+            import("package.tools.cmake").install(package, configs)
+        else
+            os.cp("doctest", package:installdir("include"))
+        end
     end)
 
     on_test(function (package)


### PR DESCRIPTION
1. Some packages like `FakeIt` use <doctest.h>, so we need a copy of header files in the include dir

Hear is an example in [FakeIt](https://github.com/eranpeer/FakeIt/blob/1d172eb87929b8bd5a8dd9a981fc0e43b9245475/single_header/doctest/fakeit.hpp#L1164) package. It use `<doctest.h>` directly, but the doctest package install `<doctest.h>` in the `include/doctest` directory, so a copy of `<doctest.h>` in `include` directory is nedded.

