### PR TITLE
diligentcore: don't install pdb on static targets

### DIFF
--- a/packages/d/diligentcore/patches/v2.5.6/fix-install-path.diff
+++ b/packages/d/diligentcore/patches/v2.5.6/fix-install-path.diff
@@ -1,8 +1,8 @@
 diff --git a/BuildTools/CMake/BuildUtils.cmake b/BuildTools/CMake/BuildUtils.cmake
-index e97b96b..bf9d26e 100644
+index ee394acab..da9d7b69e 100644
 --- a/BuildTools/CMake/BuildUtils.cmake
 +++ b/BuildTools/CMake/BuildUtils.cmake
-@@ -292,14 +292,22 @@ function(install_core_lib _TARGET)
+@@ -335,14 +335,19 @@ function(install_core_lib _TARGET)
      if(TARGET_TYPE STREQUAL STATIC_LIBRARY)
          list(APPEND DILIGENT_CORE_INSTALL_LIBS_LIST ${_TARGET})
          set(DILIGENT_CORE_INSTALL_LIBS_LIST ${DILIGENT_CORE_INSTALL_LIBS_LIST} CACHE INTERNAL "Core libraries installation list")
@@ -11,9 +11,6 @@ index e97b96b..bf9d26e 100644
 +                LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 +                RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 +        )
-+        if (DILIGENT_INSTALL_PDB)
-+            install(FILES $<TARGET_PDB_FILE:${_TARGET}> DESTINATION "${CMAKE_INSTALL_BINDIR}" OPTIONAL)
-+        endif()
      elseif(TARGET_TYPE STREQUAL SHARED_LIBRARY)
          install(TARGETS                 ${_TARGET}
 -                ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}/${DILIGENT_CORE_DIR}/$<CONFIG>"
@@ -30,10 +27,10 @@ index e97b96b..bf9d26e 100644
      endif()
  
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fc3c5d8..9edc6a4 100644
+index 37baf199b..caf3d0867 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -614,7 +614,6 @@ add_subdirectory(Primitives)
+@@ -595,7 +595,6 @@ add_subdirectory(Primitives)
  add_subdirectory(Platforms)
  add_subdirectory(Common)
  add_subdirectory(Graphics)
@@ -41,7 +38,7 @@ index fc3c5d8..9edc6a4 100644
  
  
  # Installation instructions
-@@ -625,7 +624,7 @@ if(DILIGENT_INSTALL_CORE)
+@@ -606,7 +605,7 @@ if(DILIGENT_INSTALL_CORE)
          "${DILIGENT_CORE_INSTALL_LIBS_LIST}"
          DiligentCore-static                     # Custom target name
          DiligentCore                            # Folder

--- a/packages/d/diligentcore/xmake.lua
+++ b/packages/d/diligentcore/xmake.lua
@@ -11,7 +11,7 @@ package("diligentcore")
     add_patches("v2.5.6", "patches/v2.5.6/debundle-thirdparty.diff", "3d276a78e9ae47516668229dcb644f328a3602d389a3d73784eeb52d8a53108d")
     add_patches("v2.5.6", "patches/v2.5.6/enforce-static-lib-type-for-platform-libraries.diff", "ee88a2a04348dcc9de7960a87ff5dc1fb1b534caf1f6224bb2d0c88d37a4bc53")
     add_patches("v2.5.6", "patches/v2.5.6/fix-build-deps-pkgconf.diff", "9998204546cf551a48301e972b582eeeaf002607a4f474086d7d80f4762451ee")
-    add_patches("v2.5.6", "patches/v2.5.6/fix-install-path.diff", "0fa50da9946dff8e57713edc4a224b8b54c548242e1c556d3dc11354eb69b2c1")
+    add_patches("v2.5.6", "patches/v2.5.6/fix-install-path.diff", "6be244cb16df0a5d84ae4fe97ebecd0cf0f2058f8fded78f5c0a28d84510afc9")
     add_patches("v2.5.6", "patches/v2.5.6/fix-spirv-cross-namespace.diff", "d5a866d4b5bce061a3597dcc026cb88c4b9f92af352ef4071750d355b8b924f0")
 
     add_includedirs("include", "include/DiligentCore")


### PR DESCRIPTION
Don't install pdb on static targets in `DiligentCore` (check #8283) 

The original cmake's function in `DiligentCore` doesnt install pdb to static libraries ([link](
https://github.com/DiligentGraphics/DiligentCore/blob/72eed01453e8d44f8b5cd4c9b531e87558bab16c/BuildTools/CMake/BuildUtils.cmake#L331-L354))
```cmake
function(install_core_lib _TARGET)
    ...
    if(TARGET_TYPE STREQUAL STATIC_LIBRARY)
        list(APPEND DILIGENT_CORE_INSTALL_LIBS_LIST ${_TARGET})
        set(DILIGENT_CORE_INSTALL_LIBS_LIST ${DILIGENT_CORE_INSTALL_LIBS_LIST} CACHE INTERNAL "Core libraries installation list")
    elseif(TARGET_TYPE STREQUAL SHARED_LIBRARY)
        ...
    endif()
    ...
endfunction()
```