### PR TITLE
Allow linux-arm64 builds for libavif

### DIFF
--- a/packages/l/libavif/xmake.lua
+++ b/packages/l/libavif/xmake.lua
@@ -33,11 +33,6 @@ package("libavif")
             local ndk = package:toolchain("ndk"):config("ndkver")
             assert(ndk and tonumber(ndk) > 22, "package(libavif): library deps libyuv need ndk version > 22")
         end)
-        on_check("linux", function (package)
-            if package:is_arch("arm64") then
-                raise("package(libavif): library deps libyuv unsupport compile flags -march=armv9-a+sme")
-            end
-        end)
     end
 
     on_load(function (package)


### PR DESCRIPTION
Mitigations have been deployed on libyuv's xmake file in #7677.

