### PR TITLE
glaze: add ssl config

### DIFF
--- a/packages/g/glaze/xmake.lua
+++ b/packages/g/glaze/xmake.lua
@@ -49,7 +49,7 @@ package("glaze")
 
     on_load(function (package)
         if package:config("ssl") then
-            package:add("deps", "openssl")
+            package:add("deps", "openssl3")
             package:add("defines", "GLZ_ENABLE_SSL")
         end
     end)


### PR DESCRIPTION
I wanted to limit this config to version 5.5.0 and above, but for some reason if I use `package:add("configs", ...)` then testing shows the config doesn't get detected.