### PR TITLE
Auto-update libfabric to 2.3.0

### DIFF
--- a/packages/l/libfabric/xmake.lua
+++ b/packages/l/libfabric/xmake.lua
@@ -5,6 +5,7 @@ package("libfabric")
     set_license("BSD-2-Clause")
 
     add_urls("https://github.com/ofiwg/libfabric/releases/download/v$(version)/libfabric-$(version).tar.bz2")
+    add_versions("2.3.0", "1d18fce868f8fef68b42fccd1f5df2555369739e8cb7c148532a0529a308eb09")
     add_versions("2.2.0", "ff6d05240b4a9753bb3d1eaf962f5a06205038df5142374a6ef40f931bb55ecc")
     add_versions("2.1.0", "97df312779e2d937246d2f46385b700e0958ed796d6fed7aae77e2d18923e19f")
     add_versions("2.0.0", "1a8e40f1f331d6ee2e9ace518c0088a78c8a838968f8601c2b77fd012a7bf0f5")


### PR DESCRIPTION
New version of libfabric detected (package version: 2.2.0, last github version: 2.3.0)