### PR TITLE
Auto-update minizip to v1.3.1

### DIFF
--- a/packages/m/minizip/xmake.lua
+++ b/packages/m/minizip/xmake.lua
@@ -61,7 +61,7 @@ package("minizip")
             io.replace("CMakeLists.txt", "return()", "", {plain = true})
             io.replace("CMakeLists.txt", "find_package(ZLIB REQUIRED CONFIG)", "find_package(ZLIB REQUIRED)", {plain = true})
             io.replace("CMakeLists.txt", "ZLIB::ZLIBSTATIC", "ZLIB::ZLIB", {plain = true})
-            if package:version() and package:version():le("1.2.13") then
+            if package:version() and package:version():le("1.3.1") then
                 io.replace("CMakeLists.txt", "ints.h", "", {plain = true})
                 io.replace("CMakeLists.txt", "skipset.h", "", {plain = true})
             end


### PR DESCRIPTION
New version of minizip detected (package version: v1.2.13, last github version: v1.3.1)