### PR TITLE
Auto-update gdcm to v3.2.2

### DIFF
--- a/packages/g/gdcm/xmake.lua
+++ b/packages/g/gdcm/xmake.lua
@@ -5,6 +5,7 @@ package("gdcm")
 
     add_urls("https://github.com/malaterre/GDCM/archive/refs/tags/$(version).tar.gz",
              "https://github.com/malaterre/GDCM.git")
+    add_versions("v3.2.2", "133078bfff4fe850a1faaea44b0a907ba93579fd16f34c956f4d665b24b590e5")
     add_versions("v3.2.1", "63d4fbbb487d450bc8004542892a45349bdc9f4400f7010c07170c127ef0f9e3")
     add_versions("v3.0.24", "d88519a094797c645ca34797a24a14efc10965829c4c3352c8ef33782a556336")
     add_patches(">3.0", "patches/cmake.patch", "2583f0f0beb829f7c67bc2ee56f1d976245153aa006973f89e5bc42e659afea6")


### PR DESCRIPTION
New version of gdcm detected (package version: v3.2.1, last github version: v3.2.2)