### PR TITLE
update vulkan packages to 1.4.321

### DIFF
--- a/packages/g/glslang/xmake.lua
+++ b/packages/g/glslang/xmake.lua
@@ -22,6 +22,7 @@ package("glslang")
     add_versions("1.3.283+0", "e8dd0b6903b34f1879520b444634c75ea2deedf5")
     add_versions("1.3.290+0", "fa9c3deb49e035a8abcabe366f26aac010f6cbfb")
     add_versions("1.4.309+0", "7200bc12a8979d13b22cd52de80ffb7d41939615")
+    add_versions("1.4.321+0", "vulkan-sdk-1.4.321.0")
 
     add_patches("1.3.246+1", "https://github.com/KhronosGroup/glslang/commit/1e4955adbcd9b3f5eaf2129e918ca057baed6520.patch", "47893def550f1684304ef7c49da38f0a8fe35c190a3452d3bf58370b3ee7165d")
 

--- a/packages/s/spirv-headers/xmake.lua
+++ b/packages/s/spirv-headers/xmake.lua
@@ -28,6 +28,7 @@ package("spirv-headers")
     add_versions("1.3.283+0", "a68a25996268841073c01514df7bab8f64e2db1945944b45087e5c40eed12cb9")
     add_versions("1.3.290+0", "1b9ff8a33e07814671dee61fe246c67ccbcfc9be6581f229e251784499700e24")
     add_versions("1.4.309+0", "a96f8b4f2dfb18f7432e5c523e220ab0075372a9509e0c25fbff21c76af0de7c")
+    add_versions("1.4.321+0", "5bbea925663d4cd2bab23efad53874f2718248a73dcaf9dd21dff8cb48e602fc")
 
     add_patches("1.3.261+1", "https://github.com/KhronosGroup/SPIRV-Headers/commit/c43effd54686240d8b13762279d5392058d10e27.patch", "b97a05c35c00620519a5f3638a974fc2a01f062bf6e86b74b49a234f82cc55ce")
 

--- a/packages/s/spirv-reflect/xmake.lua
+++ b/packages/s/spirv-reflect/xmake.lua
@@ -18,6 +18,7 @@ package("spirv-reflect")
     add_versions("1.3.283+0", "ee5b57fba6a986381f998567761bbc064428e645")
     add_versions("1.3.290+0", "b4dc70d8e6ac30c719a2d05b8ad05e1d277c92b4")
     add_versions("1.4.309+0", "c637858562fbce1b6f5dc7ca48d4e8a5bd117b70")
+    add_versions("1.4.321+0", "vulkan-sdk-1.4.321.0")
 
     add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
 

--- a/packages/s/spirv-tools/xmake.lua
+++ b/packages/s/spirv-tools/xmake.lua
@@ -21,6 +21,7 @@ package("spirv-tools")
     add_versions("1.3.283+0", "vulkan-sdk-1.3.283.0")
     add_versions("1.3.290+0", "vulkan-sdk-1.3.290.0")
     add_versions("1.4.309+0", "vulkan-sdk-1.4.309.0")
+    add_versions("1.4.321+0", "vulkan-sdk-1.4.321.0")
 
     add_deps("cmake >=3.17.2")
     add_deps("python 3.x", {kind = "binary"})

--- a/packages/v/volk/xmake.lua
+++ b/packages/v/volk/xmake.lua
@@ -15,6 +15,7 @@ package("volk")
     add_urls("https://github.com/zeux/volk.git", {alias = "git"})
 
     -- when adding a new sdk version, please ensure vulkan-headers, vulkan-hpp, vulkan-loader, vulkan-tools, vulkan-validationlayers, vulkan-utility-libraries, spirv-headers, spirv-reflect, spirv-tools, glslang and volk packages are updated simultaneously
+    add_versions("archive:1.4.321+0", "021ed905eea6f3e2cc8a60a21459ee7b43f98f32052ca30f27a3be390b7a4862")
     add_versions("archive:1.4.309+0", "1724924d8e3dccf0c508887edb79d56d9dd11b0738eab5a44e2fa95b8a9ebe1c")
     add_versions("archive:1.3.290+0", "bb6a6d616c0f2bbd5d180da982a6d92a0948581cec937de69f17883980c6ca06")
     add_versions("archive:1.3.283+0", "872035f1f26c53b218632a3a8dbccbd276710aaabafb9bb1bc1a6c0633ee6aab")
@@ -25,6 +26,7 @@ package("volk")
     add_versions("archive:1.3.250+1", "673241c6561fb4965f873d7fcdece17d950b24c77d6cf41466e47bdc2af67b81")
     add_versions("archive:1.3.231+1", "fac8d3d295e88bcc6bfb2b729d2c4babb2ea04ccb39fd918a3471b2d756789b9")
 
+    add_versions("git:1.4.321+0", "vulkan-sdk-1.4.321.0")
     add_versions("git:1.4.309+0", "vulkan-sdk-1.4.309.0")
     add_versions("git:1.3.290+0", "vulkan-sdk-1.3.290.0")
     add_versions("git:1.3.283+0", "vulkan-sdk-1.3.283.0")

--- a/packages/v/vulkan-headers/xmake.lua
+++ b/packages/v/vulkan-headers/xmake.lua
@@ -16,6 +16,7 @@ package("vulkan-headers")
     add_configs("modules", {description = "Build with C++20 modules support.", default = false, type = "boolean"})
 
     -- when adding a new sdk version, please ensure vulkan-headers, vulkan-hpp, vulkan-loader, vulkan-tools, vulkan-validationlayers, vulkan-utility-libraries, spirv-headers, spirv-reflect, spirv-tools, glslang and volk packages are updated simultaneously
+    add_versions("1.4.321+0", "17f8ff30fd79fb7531efcb7c78c02c17a595208d482a150f06836b0ca97ef8f2")
     add_versions("1.4.309+0", "2bc1b4127950badc80212abf1edfa5c3b5032f3425edf37255863ba7592c1969")
     add_versions("1.3.290+0", "5b186e1492d97c44102fe858fb9f222b55524a8b6da940a8795c9e326ae6d722")
     add_versions("1.3.283+0", "cf54a812911b4e3e4ff15716c222a8fb9a87c2771c0b86060cb0ca2570ea55a9")

--- a/packages/v/vulkan-hpp/xmake.lua
+++ b/packages/v/vulkan-hpp/xmake.lua
@@ -8,6 +8,7 @@ package("vulkan-hpp")
     add_urls("https://github.com/KhronosGroup/Vulkan-Hpp.git")
 
     -- when adding a new sdk version, please ensure vulkan-headers, vulkan-hpp, vulkan-loader, vulkan-tools, vulkan-validationlayers, vulkan-utility-libraries, spirv-headers, spirv-reflect, spirv-tools, glslang and volk packages are updated simultaneously
+    add_versions("v1.4.321", "v1.4.321")
     add_versions("v1.4.309", "16da8bd29e5d0b921c92d406d194759c0df6a2b8")
     add_versions("v1.2.180", "bfa6d4765212505c8241a44b97dc5a9ce3aa2969")
     add_versions("v1.2.189", "58ff1da4c03f5f124eb835f41a9dd8fe3c2e8087")

--- a/packages/v/vulkan-loader/xmake.lua
+++ b/packages/v/vulkan-loader/xmake.lua
@@ -12,6 +12,7 @@ package("vulkan-loader")
     end})
 
     -- when adding a new sdk version, please ensure vulkan-headers, vulkan-hpp, vulkan-loader, vulkan-tools, vulkan-validationlayers, vulkan-utility-libraries, spirv-headers, spirv-reflect, spirv-tools, glslang and volk packages are updated simultaneously
+    add_versions("1.4.321+0", "9e0315bd13d8def7d130524d0b69d0bef3e967374327ac69dd9c54cd2b716e8f")
     add_versions("1.4.309+0", "ddfeca84a868899fbb2c7f28b7c8fd1006e34b2b13ce653a63bddfb65cbc8d13")
     add_versions("1.3.290+0", "0cd31fdb9b576e432a85ad4d555fac4f4e5ede22ca37ff534ab67c71cd172644")
     add_versions("1.3.283+0", "59151a3cdbf8dcfe9c2ce4b5bf33358255a197f48d8d0ee8a1d8642ed9ace80f")

--- a/packages/v/vulkan-tools/xmake.lua
+++ b/packages/v/vulkan-tools/xmake.lua
@@ -16,12 +16,14 @@ package("vulkan-tools")
     add_urls("https://github.com/KhronosGroup/Vulkan-Tools.git", {alias = "git"})
 
     -- when adding a new sdk version, please ensure vulkan-headers, vulkan-hpp, vulkan-loader, vulkan-tools, vulkan-validationlayers, vulkan-utility-libraries, spirv-headers, spirv-reflect, spirv-tools, glslang and volk packages are updated simultaneously
+    add_versions("archive:1.4.321+0", "f897f76b1fae6b85b567ee86d7bc1ba6f5b1a13d3bfa5fe0f07fdb81609f7b75")
     add_versions("archive:1.4.309+0", "d854ff4324b519ff4a1cf5d9e9c333e5244ea7870fad6eadd73efd7b04aedcb0")
     add_versions("archive:1.2.198+0", "06e174bca7834df73dc6ce3c2a72ab3bc34b63e16fdb9a486bf1315f02768032")
     add_versions("archive:1.2.189+1", "ef5db0934ff7192657bbfc675f6e3e1ee009f2ad34aab915d2bd9993a59add81")
     add_versions("archive:1.2.162+0", "8324a6dfd1bc20d4fad45c4ea56357d8354fc03e3e4529d0a4919f124d9e6106")
     add_versions("archive:1.2.154+0", "c7d66ec1f5fe5c0a13e487fe5c6eefd3a954522c0b05f06bd2ae41792aeea272")
 
+    add_versions("git:1.4.321+0", "vulkan-sdk-1.4.321.0")
     add_versions("git:1.4.309+0", "vulkan-sdk-1.4.309.0")
     add_versions("git:1.2.198+0", "sdk-1.2.198.0")
     add_versions("git:1.2.189+1", "sdk-1.2.189.1")

--- a/packages/v/vulkan-utility-libraries/xmake.lua
+++ b/packages/v/vulkan-utility-libraries/xmake.lua
@@ -15,12 +15,14 @@ package("vulkan-utility-libraries")
     add_urls("https://github.com/KhronosGroup/Vulkan-Utility-Libraries.git", {alias = "git"})
 
     -- when adding a new sdk version, please ensure vulkan-headers, vulkan-hpp, vulkan-loader, vulkan-tools, vulkan-validationlayers, vulkan-utility-libraries, spirv-headers, spirv-reflect, spirv-tools, glslang and volk packages are updated simultaneously
+    add_versions("archive:1.4.321+0", "0cb3c19bc1ce3877a69fe00955597684fa7bde569eea633ac735e36dd959768e")
     add_versions("archive:1.4.309+0", "92e3b842d61965ccab1de04f154eeedef23f895104330e8237055a9ee2feed62")
     add_versions("archive:1.3.283+0", "765a2bb9767e77cd168dfac870533d60b7e8e0031a0738bbe060ca0d4c4e7a03")
     add_versions("archive:1.3.280+0", "075e13f2fdeeca3bb6fb39155c8cc345cf216ab93661549b1a33368aa28a9dea")
     add_versions("archive:1.3.275+0", "37d6b0771e1e351916f4d642cc12c696a3afffea6c47f91c97372287974e2bd8")
     add_versions("archive:1.3.268+0", "0352a6a9a703a969a805e0d6498e013cba2dc7091cc2013b7c89b1a21f61e3f8")
 
+    add_versions("git:1.4.321+0", "vulkan-sdk-1.4.321.0")
     add_versions("git:1.4.309+0", "vulkan-sdk-1.4.309.0")
     add_versions("git:1.3.283+0", "vulkan-sdk-1.3.283.0")
     add_versions("git:1.3.280+0", "vulkan-sdk-1.3.280.0")

--- a/packages/v/vulkan-validationlayers/xmake.lua
+++ b/packages/v/vulkan-validationlayers/xmake.lua
@@ -19,6 +19,7 @@ package("vulkan-validationlayers")
             end
         end})
 
+    add_versions("1.4.321+0", "9c0615f25e13576f86ea68b5799578b849a858fda1ba242ef892bc9455b0a473")
         add_versions("1.4.309+0", "6483ee30edcba3bb05e0ab3569dee632fd4532c190fef780e9ff038391c2edec")
         add_versions("1.3.290+0", "eb26b4bf1f031e57d1624c53d489279076b893b0383fddccc79de7ee2caaa128")
         add_versions("1.3.275+0", "6e22fb13601c1e780c44a17497a3c999cc5207e52a09819e7c32ecd8439eff7a")
@@ -35,6 +36,7 @@ package("vulkan-validationlayers")
             return version:startswith("v") and version or prefix .. version:gsub("%+", ".")
         end})
 
+    add_versions("1.4.321+0", "80f929ac4e9a1810401064fcd3a789a98006c7916b73b215c235a5f538daa5e9")
         add_versions("1.4.309+0", "56eb7b70c0ebf3e6b7def7723617a71bd01ca1497ab8dec542e1e4eadf6e07d7")
         add_versions("1.3.290+0", "59be2c0a5bdbfdbdebdcda48bd65ffa3b219f681c73a90fc683cd4708c1b79de")
         add_versions("1.3.275+0", "acfd84039109220129624b0ecb69980bbc3a858978c62b556dbe16efd0f26755")


### PR DESCRIPTION
This an update of all vulkan packages to sdk version 1.4.231. This should fix #8058.

I used a shell script in order to automate this tedious task. I observed some differences in the packages:
- Some versions are organized with version ascending in the file and others with version descending. I did not modify the original order. I don't know if there is a convention.
- Some git repository are identified with a SHA id, others with tag names. I chose to use tag names everywhere. Again, I don't know if there is a convention.
