### PR TITLE
nzsl: fix compilation when asan is enabled

### DIFF
--- a/packages/n/nzsl/xmake.lua
+++ b/packages/n/nzsl/xmake.lua
@@ -46,6 +46,7 @@ package("nzsl")
 
     on_install(function (package)
         local configs = {}
+        configs.asan = package:config("asan")
         configs.cbinding = package:config("cbinding")
         configs.fs_watcher = package:config("fs_watcher") or false
         configs.erronwarn = false


### PR DESCRIPTION
asan policy is not passed to xmake tool, so we need to pass it ourselves