### PR TITLE
Auto-update libpqxx to 7.10.2

### DIFF
--- a/packages/l/libpqxx/xmake.lua
+++ b/packages/l/libpqxx/xmake.lua
@@ -5,6 +5,7 @@ package("libpqxx")
     add_urls("https://github.com/jtv/libpqxx/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jtv/libpqxx.git")
              
+    add_versions("7.10.2", "9e109ffe12daa7b689da41dac05509f41b803f8405e38b1687b54e09df19000f")
     add_versions("7.10.1", "9bfaf9cb5a73ac23f9b7a9dfd7ef069a6e2124fb")
     add_versions("7.7.0", "2d99de960aa3016915bc69326b369fcee04425e57fbe9dad48dd3fa6203879fb")
 


### PR DESCRIPTION
New version of libpqxx detected (package version: 7.10.1, last github version: 7.10.2)