### PR TITLE
joltphysics: Guard JPH_PROFILE_ENABLED behind option

### DIFF
--- a/packages/j/joltphysics/xmake.lua
+++ b/packages/j/joltphysics/xmake.lua
@@ -82,7 +82,7 @@ package("joltphysics")
             package:add("defines", "JPH_DOUBLE_PRECISION")
         end
         if package:config("profile") then
-           package:add("defines", "JPH_PROFILE_ENABLED")
+            package:add("defines", "JPH_PROFILE_ENABLED")
         end
         if package:config("shared") then
             package:add("defines", "JPH_SHARED_LIBRARY")


### PR DESCRIPTION
This previously always had JPH_PROFILE_ENABLED defined despite the option existing to conditionally enable it, which can cause subtle failures with differing definitions between library and usage code.

