### PR TITLE
Auto-update cpp-rotor to v0.35

### DIFF
--- a/packages/c/cpp-rotor/xmake.lua
+++ b/packages/c/cpp-rotor/xmake.lua
@@ -6,6 +6,7 @@ package("cpp-rotor")
     add_urls("https://github.com/basiliscos/cpp-rotor/archive/refs/tags/$(version).tar.gz",
              "https://github.com/basiliscos/cpp-rotor.git", {submodules = false})
 
+    add_versions("v0.35", "245fdda4374ed7a0af18b682b1d861df87d05162daeca263776259a31d1dd4b9")
     add_versions("v0.34", "8c59a36b3b2917c91650fb91e57f8e116e0dd7f88b70d95e2e92bde4f9395202")
     add_versions("v0.33", "0a57af1018e2ca89c9cd95ae134c4b2af2c8e803c81ebee5433495776830eea6")
     add_versions("v0.32", "b0b7a294704f1ab779b95ab433eb5f4a2859db3539108a0e08709fc97f6bccee")


### PR DESCRIPTION
New version of cpp-rotor detected (package version: v0.34, last github version: v0.35)