### PR TITLE
ng-log: add package

### DIFF
--- a/packages/n/ng-log/xmake.lua
+++ b/packages/n/ng-log/xmake.lua
@@ -57,6 +57,10 @@ package("ng-log")
         for config, dep in pairs(configdeps) do
             table.insert(configs, "-DWITH_" .. config:upper() .. "=" .. (package:config(config) and "ON" or "OFF"))
         end
+        -- fix cmake try run
+        if package:is_plat("mingw") or (package:is_plat("windows") and package:is_arch("arm64")) then
+            table.insert(configs, "-DHAVE_SYMBOLIZE_EXITCODE=1")
+        end
         import("package.tools.cmake").install(package, configs)
     end)
 


### PR DESCRIPTION
google glog于2025年6月30日[存档](https://github.com/google/glog),并停止维护, 有两个可能的替代品:

abseil库 有日志功能, 它已经在仓库中

[ng-log](https://github.com/ng-log/ng-log) 是一个轻量级日志库, 与glog保持api兼容



