### PR TITLE
quantlib: update to 1.40

### DIFF
--- a/packages/q/quantlib/xmake.lua
+++ b/packages/q/quantlib/xmake.lua
@@ -11,17 +11,27 @@ package("quantlib")
     add_versions("1.34", "eb87aa8ced76550361771e167eba26aace018074ec370f7af49a01aa56b2fe50")
     add_versions("1.33", "4810d789261eb36423c7d277266a6ee3b28a3c05af1ee0d45544ca2e0e8312bd")
 
+    add_configs("openmp", {description = "Enable OpenMP.", default = false, type = "boolean"})
+    add_configs("ms", {description = "Enable date resolution down to microseconds", default = false, type = "boolean"})
     if is_plat("windows") then
         add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
     end
 
     add_deps("cmake")
-    add_deps("boost", {configs = {math = true, container = true, serialization = true, regex = true, thread = true}})
+    add_deps("boost", {configs = {math = true, serialization = true, regex = true, thread = true}})
+
+    on_load(function (package)
+        if package:config("openmp") then
+            package:add("deps", "openmp")
+        end
+    end)
 
     on_install("windows", "linux", "macosx", "bsd", "mingw", "msys", "cross", function (package)
         local configs = {"-DQL_BUILD_BENCHMARK=OFF", "-DQL_BUILD_EXAMPLES=OFF", "-DQL_BUILD_TEST_SUITE=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        table.insert(configs, "-DQL_ENABLE_OPENMP=" .. (package:config("openmp") and "ON" or "OFF"))
+        table.insert(configs, "-DQL_HIGH_RESOLUTION_DATE=" .. (package:config("ms") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)
     end)
 


### PR DESCRIPTION
Currently, `xrepo install quantlib` will **fail** due to missinng `boost` headers.
This PR added necessary components of the boost library.
related prs: #5553 #6217 #7142 #7811 #8395 