### PR TITLE
Auto-update tiny-optional to v1.5.2

### DIFF
--- a/packages/t/tiny-optional/xmake.lua
+++ b/packages/t/tiny-optional/xmake.lua
@@ -7,6 +7,7 @@ package("tiny-optional")
     add_urls("https://github.com/Sedeniono/tiny-optional/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Sedeniono/tiny-optional.git")
 
+    add_versions("v1.5.2", "df67c6311a03282d892aa0539131696b8c66eaccf080d68f96a030aa690ea334")
     add_versions("v1.4.0", "e09f164b7a73f96d1e925b8f450749885b192b54ccce4f27f43bdf88a0021e33")
     add_versions("v1.3.1", "ae82a5116970c1c541bfaf73c9c99a61aa61031916a64cb069f776b0e893ff84")
     add_versions("v1.2.1", "0305d31c43ef8365befd7d022c13c431b913036d4c10c0c5419e9765077c5122")


### PR DESCRIPTION
New version of tiny-optional detected (package version: v1.4.0, last github version: v1.5.2)