### PR TITLE
Auto-update dlpack to v1.2

### DIFF
--- a/packages/d/dlpack/xmake.lua
+++ b/packages/d/dlpack/xmake.lua
@@ -6,6 +6,7 @@ package("dlpack")
     add_urls("https://github.com/dmlc/dlpack/archive/refs/tags/$(version).tar.gz",
              "https://github.com/dmlc/dlpack.git")
 
+    add_versions("v1.2", "58284a3b004a48450c958a23b30274527ebaf35a061124bbd4193fffa45efbd6")
     add_versions("v1.1", "2e3b94b55825c240cc58e6721e15b449978cbae21a2a4caa23058b0157ee2fb3")
     add_versions("v1.0", "f8cfdcb634ff3cf0e3d9a3426e019e1c6469780a3b0020c9bc4ecc09cf9abcb1")
     add_versions("v0.8", "cf965c26a5430ba4cc53d61963f288edddcd77443aa4c85ce722aaf1e2f29513")


### PR DESCRIPTION
New version of dlpack detected (package version: v1.1, last github version: v1.2)