### PR TITLE
Auto-update zstr to v1.1.0

### DIFF
--- a/packages/z/zstr/xmake.lua
+++ b/packages/z/zstr/xmake.lua
@@ -7,6 +7,7 @@ package("zstr")
 
     add_urls("https://github.com/mateidavid/zstr/archive/refs/tags/$(version).tar.gz",
              "https://github.com/mateidavid/zstr.git")
+    add_versions("v1.1.0", "b77ef8b961233a100a34da588962a95a2f3b00c9b2dc0ea67100b36ec72128af")
     add_versions("v1.0.7", "8d2ddae68ff7bd0a6fce6150a8f52ad9ce1bed2c4056c8846f4dec4f2dc60819")
 
     add_patches("v1.0.7", "patches/fix-build-on-android-ndksdk-21.patch", "66468d9aab3443c488b7fadde7fb2547f1501c73d89e00c672834652ce61a047")


### PR DESCRIPTION
New version of zstr detected (package version: v1.0.7, last github version: v1.1.0)