### PR TITLE
Auto-update rendergraph to v2.0.0

### DIFF
--- a/packages/r/rendergraph/xmake.lua
+++ b/packages/r/rendergraph/xmake.lua
@@ -6,6 +6,7 @@ package("rendergraph")
 
     set_urls("https://github.com/DragonJoker/RenderGraph/archive/refs/tags/$(version).tar.gz",
          "https://github.com/DragonJoker/RenderGraph.git")
+    add_versions("v2.0.0", "9ab5bf4ef16fac2bec8633b1634843c97e3e244a556be62c942348e2462d0888")
     add_versions("v1.4.1", "7096a6384165f98ec3fab995deba10523b42a4f170f9ad9473107bc03eb50a3d")
     add_versions("v1.4.0", "0009eac85885231069f7ba644d22a801e71505cc")
     add_versions("v1.3.0", "b9c68b6949c7b60ffb49f9b9997432aac5baec69")


### PR DESCRIPTION
New version of rendergraph detected (package version: v1.4.1, last github version: v2.0.0)