### PR TITLE
Auto-update lsp-framework to 1.2.0

### DIFF
--- a/packages/l/lsp-framework/xmake.lua
+++ b/packages/l/lsp-framework/xmake.lua
@@ -6,6 +6,7 @@ package("lsp-framework")
     add_urls("https://github.com/leon-bckl/lsp-framework/archive/refs/tags/$(version).tar.gz",
              "https://github.com/leon-bckl/lsp-framework.git")
 
+    add_versions("1.2.0", "1bbd32b6a0014b8a3c28863d55c2fe90d29aad2bd485800abf540e5ef0f19841")
     add_versions("1.0.1", "07f924d851896a2d424d554d20820483f8458aa1ff907bb68657b0d2d0bd0d13")
 
     add_patches("1.0.1", "patches/1.0.1/fix-install.diff", "bb5e4436091ba1846144ffa80fb8afd4d0213760bce45dd6fd31662905cb4bc3")


### PR DESCRIPTION
New version of lsp-framework detected (package version: 1.0.1, last github version: 1.2.0)