### PR TITLE
asio2: Fix build failure due to asio upgrade

### DIFF
--- a/packages/a/asio2/xmake.lua
+++ b/packages/a/asio2/xmake.lua
@@ -13,7 +13,7 @@ package("asio2")
 
     add_patches("2.9", "patches/2.9/remove-const.patch", "6326f333ab2d0484c23bb3cd9cfd5a565030b5525d083677565a693f5f8803b6")
 
-    add_deps("asio", "cereal")
+    add_deps("asio 1.29.0", "cereal")
     add_deps("spdlog", { configs = { header_only = false, fmt_external = true } })
 
     if is_plat("windows", "mingw") then


### PR DESCRIPTION
asio upgrade broke asio2 whose codebase specified a version.
**The last time this library updated is last year, so I think it's better to specify asio's version to 1.29.0**
https://github.com/zhllxt/asio2/blob/36ba0c3d5d3914c4caca2d0448775de5e44a0c6c/3rd/asio/version.hpp#L21