### PR TITLE
Auto-update aws-c-cal to v0.9.5

### DIFF
--- a/packages/a/aws-c-cal/xmake.lua
+++ b/packages/a/aws-c-cal/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-cal")
     add_urls("https://github.com/awslabs/aws-c-cal/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-cal.git")
 
+    add_versions("v0.9.5", "5cedd82d093960a09a91bf8d8c3540425e49972ed9b565763bf2a5b2ba1a2a7c")
     add_versions("v0.9.2", "f9f3bc6a069e2efe25fcdf73e4d2b16b5608c327d2eb57c8f7a8524e9e1fcad0")
     add_versions("v0.9.0", "516ff370a45bfc49fd6d34a9bd2b1b3e753221046a9e2fbd117341d6f9d39edc")
     add_versions("v0.8.7", "5882096093f6f39d9442f9b8a4e377155a6846277d4277334a58cd36b736674f")


### PR DESCRIPTION
New version of aws-c-cal detected (package version: v0.9.2, last github version: v0.9.5)