### PR TITLE
Auto-update libfabric to 2.3.1

### DIFF
--- a/packages/l/libfabric/xmake.lua
+++ b/packages/l/libfabric/xmake.lua
@@ -5,6 +5,7 @@ package("libfabric")
     set_license("BSD-2-Clause")
 
     add_urls("https://github.com/ofiwg/libfabric/releases/download/v$(version)/libfabric-$(version).tar.bz2")
+    add_versions("2.3.1", "2e939f17ce4d30a999d0445f741d3055b19dfd894eff70450e23470fe774f35a")
     add_versions("2.3.0", "1d18fce868f8fef68b42fccd1f5df2555369739e8cb7c148532a0529a308eb09")
     add_versions("2.2.0", "ff6d05240b4a9753bb3d1eaf962f5a06205038df5142374a6ef40f931bb55ecc")
     add_versions("2.1.0", "97df312779e2d937246d2f46385b700e0958ed796d6fed7aae77e2d18923e19f")


### PR DESCRIPTION
New version of libfabric detected (package version: 2.3.0, last github version: 2.3.1)