### PR TITLE
Update CEF to 141.0.11

### DIFF
--- a/packages/c/cef/port/xmake.lua
+++ b/packages/c/cef/port/xmake.lua
@@ -4,7 +4,7 @@ target("cef_dll_wrapper")
     add_files("libcef_dll/**.cc|ctocpp/test/**.cc|cpptoc/test/**.cc")
     add_includedirs(".")
     add_headerfiles("include/(**.h)")
-    add_defines("WRAPPING_CEF_SHARED")
+    add_defines("WRAPPING_CEF_SHARED", "UNICODE", "_UNICODE")
     set_languages("c++17")
     if is_plat("windows") then
         -- fix std::max conflict with windows.h

--- a/packages/c/cef/xmake.lua
+++ b/packages/c/cef/xmake.lua
@@ -52,8 +52,6 @@ package("cef")
 
     -- TODO: add support for arm
     on_install("windows|x86", "windows|x64", function (package)
-        package:add("defines", "UNICODE", "_UNICODE")
-
         local distrib_type = package:debug() and "Debug" or "Release"
         os.cp(path.join(distrib_type, "*.lib"), package:installdir("lib"))
         os.cp(path.join(distrib_type, "*.dll"), package:installdir("bin"))


### PR DESCRIPTION
Changed `has_cxxfuncs` assert because `CefEnableHighDPISupport` is gone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Windows build/version 141.0.11 entries and platform-specific install targets for x86 and x64.
  * Defined UNICODE/_UNICODE for Windows builds.
  * Updated C++ language standard requirement to C++17.

* **Tests**
  * Updated test verification to reference the shutdown API during checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->