### PR TITLE
Auto-update geos to 3.14.1

### DIFF
--- a/packages/g/geos/xmake.lua
+++ b/packages/g/geos/xmake.lua
@@ -6,6 +6,7 @@ package("geos")
     add_urls("https://github.com/libgeos/geos/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libgeos/geos.git")
 
+    add_versions("3.14.1", "512118b3be3ccefbca66b36b0f3e895576d08d6ff330ba1511a31a306abbb477")
     add_versions("3.14.0", "47dbfad4e90073c7593ae5cfd560bc961f049af2b6868882cc1e7a9b9885a22c")
     add_versions("3.13.1", "724788988fa32a59b3853b876b3d865595c11dfcda7883e4e6a78e44334ac8ce")
     add_versions("3.13.0", "351375d3697000d94a6b3d4041f08e12221f4eb065ed412c677960a869518631")


### PR DESCRIPTION
New version of geos detected (package version: 3.14.0, last github version: 3.14.1)