### PR TITLE
Auto-update functionalplus to v0.2.26

### DIFF
--- a/packages/f/functionalplus/xmake.lua
+++ b/packages/f/functionalplus/xmake.lua
@@ -7,6 +7,7 @@ package("functionalplus")
     add_urls("https://github.com/Dobiasd/FunctionalPlus/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Dobiasd/FunctionalPlus.git")
 
+    add_versions("v0.2.26", "119894b4ab521d22e7dbd4692c364dc911cf206fca011071575658d4053e61f2")
     add_versions("v0.2.25", "9b5e24bbc92f43b977dc83efbc173bcf07dbe07f8718fc2670093655b56fcee3")
     add_versions("v0.2.24", "446c63ac3f2045e7587f694501882a3d7c7b962b70bcc08deacf5777bdaaff8c")
     add_versions("v0.2.23", "5c2d28d2ba7d0cdeab9e31bbf2e7f8a9d6f2ff6111a54bfc11d1b05422096f19")


### PR DESCRIPTION
New version of functionalplus detected (package version: v0.2.25, last github version: v0.2.26)