### PR TITLE
Auto-update imgui-file-dialog to v0.6.8

### DIFF
--- a/packages/i/imgui-file-dialog/xmake.lua
+++ b/packages/i/imgui-file-dialog/xmake.lua
@@ -22,11 +22,11 @@ package("imgui-file-dialog")
 
     on_check("mingw|i386", function (package)
         if package:version() and package:version():ge("0.6.8") then
-            raise("package(imgui-file-dialog >0.6.8) does not support i386 mingw build")
+            raise("package(imgui-file-dialog >=0.6.8) does not support i386 mingw build")
         end
     end)
 
-    on_install(function (package)
+    on_install("!iphoneos", function (package)
         local configs = {}
         io.writefile("xmake.lua", [[
             add_requires("imgui")


### PR DESCRIPTION
New version of imgui-file-dialog detected (package version: v0.6.7, last github version: v0.6.8)