### PR TITLE
Auto-update flecs to v4.1.2

### DIFF
--- a/packages/f/flecs/xmake.lua
+++ b/packages/f/flecs/xmake.lua
@@ -32,7 +32,7 @@ package("flecs")
     add_deps("cmake")
 
     if is_plat("windows", "mingw") then
-        add_syslinks("wsock32", "ws2_32")
+        add_syslinks("wsock32", "ws2_32", "Dbghelp")
     elseif is_plat("linux") then
         add_syslinks("pthread")
     elseif is_plat("bsd") then


### PR DESCRIPTION
New version of flecs detected (package version: v4.1.1, last github version: v4.1.2)