### PR TITLE
Auto-update sentry-native to 0.12.0

### DIFF
--- a/packages/s/sentry-native/xmake.lua
+++ b/packages/s/sentry-native/xmake.lua
@@ -49,7 +49,7 @@ package("sentry-native")
         add_syslinks("dl", "log")
     elseif is_plat("macosx") then
         add_deps("libcurl")
-        add_frameworks("CoreText", "CoreGraphics", "SystemConfiguration", "CoreFoundation", "Foundation")
+        add_frameworks("CoreText", "CoreGraphics", "SystemConfiguration", "CoreFoundation", "Foundation", "IOKit")
         add_syslinks("bsm")
     end
 


### PR DESCRIPTION
New version of sentry-native detected (package version: 0.11.3, last github version: 0.12.0)