### PR TITLE
Auto-update aws-c-s3 to v0.9.2

### DIFF
--- a/packages/a/aws-c-s3/xmake.lua
+++ b/packages/a/aws-c-s3/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-s3")
     add_urls("https://github.com/awslabs/aws-c-s3/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-s3.git")
 
+    add_versions("v0.9.2", "70ddd1e69fed7788ff5499b03158f36fb8137d82bd7b1af7bcdf57facbdb1557")
     add_versions("v0.8.7", "bbe1159f089ac4e5ddcdf5ef96941489240a3f780c5e140f3c8462df45e787ac")
     add_versions("v0.8.6", "583fb207c20a2e68a8e2990d62668b96c9662cf864f7c13c87d9ede09d61f8e5")
     add_versions("v0.8.3", "c1c233317927091ee966bb297db2e6adbb596d6e5f981dbc724b0831b7e8f07d")


### PR DESCRIPTION
New version of aws-c-s3 detected (package version: v0.8.7, last github version: v0.9.2)