### PR TITLE
jsoncons: Update to v1.4.3

### DIFF
--- a/packages/j/jsoncons/xmake.lua
+++ b/packages/j/jsoncons/xmake.lua
@@ -7,6 +7,7 @@ package("jsoncons")
     set_urls("https://github.com/danielaparker/jsoncons/archive/refs/tags/$(version).tar.gz",
              "https://github.com/danielaparker/jsoncons.git")
 
+    add_versions("v1.4.3", "6cc79df3bf10f3ecd5fbdd0a64deaaad35beda2767f8697e261e1af11e1e3526")
     add_versions("v1.3.2", "f22fb163df1a12c2f9ee5f95cad9fc37c6cfbefe0ae6f30aba7440832ef70fbe")
     add_versions("v1.3.0", "7a485c2af0ff214b62bb00f5a1487e5a0c4997eadc6ee9155ce3e8c9d05b9d7a")
     add_versions("v1.2.0", "3bdc0c8ceba1943b5deb889559911ebe97377971453a11227ed0a51a05e5d5d8")
@@ -18,6 +19,14 @@ package("jsoncons")
     add_versions("v0.170.2", "0ff0cd407f6b27dea66a3202bc8bc2e043ec1614419e76840eda5b5f8045a43a")
 
     add_configs("cmake", {description = "Use cmake build system", default = true, type = "boolean"})
+
+    if on_check then
+        on_check("android", function (package)
+            local ndk = package:toolchain("ndk")
+            local ndk_sdkver = ndk:config("ndk_sdkver")
+            assert(ndk_sdkver and tonumber(ndk_sdkver) >= 28, "package(jsoncons): require ndk api level >= 28")
+        end)
+    end
 
     on_load(function (package)
         if package:config("cmake") then


### PR DESCRIPTION
Resolves: #8542 

Reference: https://android.googlesource.com/platform/bionic/+/bcfe3cf/libc/include/wchar.h#98

error message:
```
checkinfo: ...amdir/core/sandbox/modules/import/core/tool/compiler.lua:84: @programdir/modules/core/tools/gcc.lua:1047: /home/runner/.xmake/packages/j/jsoncons/v1.4.3/ff5b680837404209ad5e3882e5ad26ef/include/jsoncons/utility/read_number.hpp:842:15: error: use of undeclared identifier 'wcstod_l'; did you mean 'wcstold_l'?
        val = wcstod_l(s, &end, locale);
              ^
/home/runner/.xmake/packages/n/ndk/22.1/73bb5a0e065c4d8fa242705e2555420f/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/wchar.h:191:13: note: 'wcstold_l' declared here
long double wcstold_l(const wchar_t* __s, wchar_t** __end_ptr, locale_t __l) __INTRODUCED_IN(21);
            ^
1 error generated.
```