### PR TITLE
Auto-update git-crypt to 0.8.0

### DIFF
--- a/packages/g/git-crypt/xmake.lua
+++ b/packages/g/git-crypt/xmake.lua
@@ -6,6 +6,7 @@ package("git-crypt")
 
     add_urls("https://github.com/AGWA/git-crypt/archive/refs/tags/$(version).tar.gz",
              "https://github.com/AGWA/git-crypt.git")
+    add_versions("0.8.0", "786199c24f8b79a54d62b98c24b1113606c4ebd83125e642b228704686305e69")
     add_versions("0.7.0", "2210a89588169ae9a54988c7fdd9717333f0c6053ff704d335631a387bd3bcff")
 
     if is_plat("linux", "macosx", "mingw@macosx") then


### PR DESCRIPTION
New version of git-crypt detected (package version: 0.7.0, last github version: 0.8.0)