### PR TITLE
pocketpy: update and fix

### DIFF
--- a/packages/p/pocketpy/xmake.lua
+++ b/packages/p/pocketpy/xmake.lua
@@ -5,16 +5,23 @@ package("pocketpy")
     set_license("MIT")
 
     add_urls("https://github.com/pocketpy/pocketpy/releases/download/$(version)/pocketpy.h")
-    add_resources("v2.1.1", "c", "https://github.com/pocketpy/pocketpy/releases/download/v2.1.1/pocketpy.c", "587a83977525e11616d1bae748ae80dc50960e567b8c000a9ca6610b20681623")
 
+    add_versions("v2.1.3", "fb2d1b594ddc46084d5e090e3e907da0d6769287152dba5d51288ac231ff7dfa")
     add_versions("v2.1.1", "d54aec6d75f7f7d03b862d4370e0014f9723715da901623bedc82ac72566caae")
+    add_versions("v2.0.8", "9d6dada0fa9b661a44bcaf581f56ad15c7fe9ee18e0c719438f3332ccb3ac76f")
     add_versions("v1.4.6", "fbbe335e55fabfd41146ba3287bd93c992135da057e2da09e47dd7dc77682a04")
     add_versions("v1.4.5", "144f63ed8a21fd2a65e252df53939f7af453d544eb35570603af319ce1af5a46")
     add_versions("v0.9.0", "0da63afb3ea4ebb8b686bfe33b4c7556c0a927cd98ccf3c7a3fb4aa216fbf30b")
 
+    add_resources("v2.1.3", "c", "https://github.com/pocketpy/pocketpy/releases/download/v2.1.3/pocketpy.c", "ab4cbf3edd50dbbc5ca5a7ec7e7f2d001169541d9912330596400e0d34980d6b")
+    add_resources("v2.1.1", "c", "https://github.com/pocketpy/pocketpy/releases/download/v2.1.1/pocketpy.c", "587a83977525e11616d1bae748ae80dc50960e567b8c000a9ca6610b20681623")
+    add_resources("v2.0.8", "c", "https://github.com/pocketpy/pocketpy/releases/download/v2.0.8/pocketpy.c", "497f926dc270bfe1f9289db24068e596499c563aa8c946f63763a114c5d2bf5d")
+
     on_install("windows|x64", "linux", "macosx", "android", function (package)
-        os.cp("../pocketpy-" .. package:version(), package:installdir("include") .. "/pocketpy.h")
-        os.cp("../resources/c/pocketpy.c", package:installdir("include"))
+        os.cp(package:originfile(), package:installdir("include") .. "/pocketpy.h")
+        if package:version() and package:version():ge("v2.0.0") then
+            os.cp(package:resourcefile("c"), package:installdir("include"))
+        end
     end)
 
     on_test("linux", "macosx", "android", function (package)


### PR DESCRIPTION
Currently, running `xrepo install -vD "pocketpy"` will fail:
```
/usr/bin/curl -SL -A "Xmake/3.0.4+dev.d4d2990 (Linux;6.6.87.2-microsoft-standard-WSL2) curl/8.5.0" https://github.com/pocketpy/pocketpy/releases/download/v2.1.1/pocketpy.h -o pocketpy-v2.1.1.h
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
100 41262  100 41262    0     0  18702      0  0:00:02  0:00:02 --:--:--  165k
  => download https://github.com/pocketpy/pocketpy/releases/download/v2.1.1/pocketpy.h .. ok
downloading resource(c: https://github.com/pocketpy/pocketpy/releases/download/v2.1.1/pocketpy.c) to pocketpy-v2.1.1 ..
/usr/bin/curl -SL -A "Xmake/3.0.4+dev.d4d2990 (Linux;6.6.87.2-microsoft-standard-WSL2) curl/8.5.0" https://github.com/pocketpy/pocketpy/releases/download/v2.1.1/pocketpy.c -o /home/willaaaaaaa/.xmake/cache/packages/2511/p/pocketpy/v2.1.1/resources/c/pocketpy.c
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
100  892k  100  892k    0     0   317k      0  0:00:02  0:00:02 --:--:--  814k
error: @programdir/core/sandbox/modules/os.lua:100: cannot copy file ../pocketpy-v2.1.1, file not found!
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:1093]:
    [@programdir/core/sandbox/modules/os.lua:100]: in function 'cp'
    [...ke/repositories/xmake-repo/packages/p/pocketpy/xmake.lua:16]: in function 'script'
    [...dir/modules/private/action/require/impl/utils/filter.lua:114]: in function 'call'
    [.../modules/private/action/require/impl/actions/install.lua:472]:

  => install pocketpy v2.1.1 .. failed
```

---

Resolves: #8546 
Resolves: #6882 
Closes: #5628 
Closes: #5915 
Closes: #5969 
Closes: #6016 
Closes: #6211 
Closes: #6583 