### PR TITLE
Auto-update cli11 to v2.6.1

### DIFF
--- a/packages/c/cli11/xmake.lua
+++ b/packages/c/cli11/xmake.lua
@@ -6,6 +6,7 @@ package("cli11")
 
     add_urls("https://github.com/CLIUtils/CLI11/archive/refs/tags/$(version).tar.gz",
              "https://github.com/CLIUtils/CLI11.git")
+    add_versions("v2.6.1", "377691f3fac2b340f12a2f79f523c780564578ba3d6eaf5238e9f35895d5ba95")
     add_versions("v2.5.0", "17e02b4cddc2fa348e5dbdbb582c59a3486fa2b2433e70a0c3bacb871334fd55")
     add_versions("v2.4.2", "f2d893a65c3b1324c50d4e682c0cdc021dd0477ae2c048544f39eed6654b699a")
     add_versions("v2.4.1", "73b7ec52261ce8fe980a29df6b4ceb66243bb0b779451dbd3d014cfec9fdbb58")


### PR DESCRIPTION
New version of cli11 detected (package version: v2.5.0, last github version: v2.6.1)