### PR TITLE
Auto-update quickjs-ng to v0.11.0

### DIFF
--- a/packages/q/quickjs-ng/xmake.lua
+++ b/packages/q/quickjs-ng/xmake.lua
@@ -31,8 +31,8 @@ package("quickjs-ng")
             end
         end)
         on_check("iphoneos", function (package)
-            if package:version() and package:version():gt("v0.11.0") then
-                raise("package(quickjs-ng >v0.11.0) supports ios")
+            if package:version() and package:version():le("v0.11.0") then
+                raise("package(quickjs-ng <=v0.11.0) unsupported ios platform")
             end
         end)
     end


### PR DESCRIPTION
New version of quickjs-ng detected (package version: v0.9.0, last github version: v0.11.0)