### PR TITLE
Auto-update sparse-map to v0.7.0

### DIFF
--- a/packages/s/sparse-map/xmake.lua
+++ b/packages/s/sparse-map/xmake.lua
@@ -8,6 +8,7 @@ package("sparse-map")
     add_urls("https://github.com/Tessil/sparse-map/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Tessil/sparse-map.git")
 
+    add_versions("v0.7.0", "b603a24f596f95a06ec1d437f4cb928c2647cf9bc73b751ac6fb82deb7863d98")
     add_versions("v0.6.2", "7020c21e8752e59d72e37456cd80000e18671c803890a3e55ae36b295eba99f6")
 
     on_install("windows|x86", "windows|x64", "linux", "macosx", "bsd", "mingw", "msys", "android", "iphoneos", "cross", function (package)


### PR DESCRIPTION
New version of sparse-map detected (package version: v0.6.2, last github version: v0.7.0)