### PR TITLE
opencv: fix build & cmake

### DIFF
--- a/packages/o/opencv/xmake.lua
+++ b/packages/o/opencv/xmake.lua
@@ -1,5 +1,4 @@
 package("opencv")
-
     set_homepage("https://opencv.org/")
     set_description("A open source computer vision library.")
     set_license("Apache-2.0")


### PR DESCRIPTION
cmake error: https://github.com/xmake-io/xmake-repo/pull/8484
```
CMake Error at /github/home/.xmake/packages/o/opencv/4.12.0/f64cc25c8ea945fd9fed9b60af1ed663/lib/cmake/opencv4/OpenCVModules.cmake:363 (set_target_properties):
  The link interface of target "opencv_wechat_qrcode" contains:

    Iconv::Iconv

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  /github/home/.xmake/packages/o/opencv/4.12.0/f64cc25c8ea945fd9fed9b60af1ed663/lib/cmake/opencv4/OpenCVConfig.cmake:128 (include)
  CMakeLists.txt:221 (FIND_PACKAGE)
```