### PR TITLE
Auto-update ktx to v4.4.2

### DIFF
--- a/packages/k/ktx/patches/4.4.2/dep-unbundle.patch
+++ b/packages/k/ktx/patches/4.4.2/dep-unbundle.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5712cf8a..c2fcb133 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1274,21 +1274,13 @@ set(ASTCENC_DECOMPRESSOR OFF CACHE INTERNAL "")
+ set(ASTCENC_CLI OFF) # Only build as library not the CLI astcencoder
+ # Force static build for astc-encoder
+ set(BUILD_SHARED_LIBS OFF)
+-add_subdirectory(external/astc-encoder)
++include(FindPkgConfig)
++pkg_search_module(astc-encoder REQUIRED IMPORTED_TARGET astc-encoder)
++set(ASTCENC_LIB_TARGET PkgConfig::astc-encoder)
+ set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_RESET})
+-set_property(TARGET ${ASTCENC_LIB_TARGET} PROPERTY POSITION_INDEPENDENT_CODE ON)
+-target_compile_definitions(
+-    ${ASTCENC_LIB_TARGET}
+-PRIVATE
+-    # ASTC encoder uses std::mutex. For more info. see comment about
+-    # same setting in libktx starting about line 633. To be eventually
+-    # removed as noted in that comment.
+-    $<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.40.33811>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
+-    $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,17.0.3>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
+-)
+ 
+ macro(set_astc_dependencies target)
+-    if(NOT BUILD_SHARED_LIBS AND APPLE)
++    if(0)
+         # Make a single static library to simplify linking.
+         add_dependencies(${target} ${ASTCENC_LIB_TARGET})
+         add_custom_command( TARGET ${target}
+@@ -1338,7 +1330,7 @@ endif()
+ 
+ set(KTX_INSTALL_TARGETS ktx)
+ if(NOT BUILD_SHARED_LIBS AND NOT APPLE)
+-    list(APPEND KTX_INSTALL_TARGETS ${ASTCENC_LIB_TARGET})
++    
+ endif()
+ 
+ # Install

--- a/packages/k/ktx/xmake.lua
+++ b/packages/k/ktx/xmake.lua
@@ -9,6 +9,7 @@ package("ktx")
     add_versions("v4.4.2", "9412cb45045a503005acd47d98f9e8b47154634a50b4df21e17a1dfa8971d323")
     add_versions("v4.4.0", "3585d76edcdcbe3a671479686f8c81c1c10339f419e4b02a9a6f19cc6e4e0612")
 
+    add_patches("4.4.2", "patches/4.4.2/dep-unbundle.patch", "8dbccc8fc21256da166ef6c3c952bd3ae099414910cb8a6575635a6e60810ab2")
     add_patches("4.4.0", "patches/4.4.0/dep-unbundle.patch", "2b883bcbfc19f80d72b812d68b606b6e2a4234d913ad92c45d8030bd94207a59")
 
     add_configs("tools", {description = "Create KTX tools", default = false, type = "boolean"})


### PR DESCRIPTION
New version of ktx detected (package version: v4.4.0, last github version: v4.4.2)