### PR TITLE
Auto-update nuklear to 4.12.8

### DIFF
--- a/packages/n/nuklear/xmake.lua
+++ b/packages/n/nuklear/xmake.lua
@@ -8,6 +8,7 @@ package("nuklear")
     add_urls("https://github.com/Immediate-Mode-UI/Nuklear/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Immediate-Mode-UI/Nuklear.git")
 
+    add_versions("4.12.8", "2b5d278547cf7f4232d2a48334b8756c3c4533608bf01b2ebc9a4de0063eef08")
     add_versions("4.12.7", "5809afbb2e1182894d283f56e586d5aec09ab5ae9c936be51d55033ec6ea77bf")
     add_versions("4.12.6", "60a62c3a15b0d11a4cc74e0007ea42787e08548db4caa642ca9fd2208f47d8ca")
     add_versions("4.12.5", "1067ae54a2bde8b94b8db262618b75f63c8a6f4df2085ec0970bd9b210fbec0b")


### PR DESCRIPTION
New version of nuklear detected (package version: 4.12.7, last github version: 4.12.8)