### PR TITLE
Auto-update libsigcplusplus to 3.8.0

### DIFF
--- a/packages/l/libsigcplusplus/xmake.lua
+++ b/packages/l/libsigcplusplus/xmake.lua
@@ -6,6 +6,7 @@ package("libsigcplusplus")
     add_urls("https://github.com/libsigcplusplus/libsigcplusplus/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libsigcplusplus/libsigcplusplus.git")
 
+    add_versions("3.8.0", "fb2356847434c2cef8fc6093b2fd571cf9de9ba795d3b8ffe4ab70d1b8553cd9")
     add_versions("3.6.0", "bbe81e4f6d8acb41a9795525a38c0782751dbc4af3d78a9339f4a282e8a16c38")
     add_versions("3.4.0", "445d889079041b41b368ee3b923b7c71ae10a54da03bc746f2d0723e28ba2291")
 


### PR DESCRIPTION
New version of libsigcplusplus detected (package version: 3.6.0, last github version: 3.8.0)