### PR TITLE
Auto-update json-schema-validator to 2.4.0

### DIFF
--- a/packages/j/json-schema-validator/xmake.lua
+++ b/packages/j/json-schema-validator/xmake.lua
@@ -4,6 +4,7 @@ package("json-schema-validator")
 
     add_urls("https://github.com/pboettch/json-schema-validator/archive/refs/tags/$(version).tar.gz",
              "https://github.com/pboettch/json-schema-validator.git")
+    add_versions("2.4.0", "24cbb114609cc9b43d4018b8d03e082ff5d2f26f5dce8bd36538097267b63af9")
     add_versions("2.1.0", "83f61d8112f485e0d3f1e72d51610ba3924b179926a8376aef3c038770faf202")
     add_versions("2.3.0", "2c00b50023c7d557cdaa71c0777f5bcff996c4efd7a539e58beaa4219fa2a5e1")
 


### PR DESCRIPTION
New version of json-schema-validator detected (package version: 2.3.0, last github version: 2.4.0)