### PR TITLE
zig: add mirrors & update to v0.15.2

### DIFF
--- a/packages/z/zig/xmake.lua
+++ b/packages/z/zig/xmake.lua
@@ -6,6 +6,8 @@ package("zig")
 
     if is_host("macosx") then
         if os.arch() == "arm64" then
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-macos-aarch64-$(version).tar.xz")
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-aarch64-macos-$(version).tar.xz")
             add_urls("https://ziglang.org/download/$(version)/zig-macos-aarch64-$(version).tar.xz")
             add_urls("https://ziglang.org/download/$(version)/zig-aarch64-macos-$(version).tar.xz")
             add_versions("0.10.1", "b9b00477ec5fa1f1b89f35a7d2a58688e019910ab80a65eac2a7417162737656")
@@ -14,7 +16,10 @@ package("zig")
             add_versions("0.13.0", "46fae219656545dfaf4dce12fb4e8685cec5b51d721beee9389ab4194d43394c")
             add_versions("0.14.0", "b71e4b7c4b4be9953657877f7f9e6f7ee89114c716da7c070f4a238220e95d7e")
             add_versions("0.15.1", "c4bd624d901c1268f2deb9d8eb2d86a2f8b97bafa3f118025344242da2c54d7b")
+            add_versions("0.15.2", "3cc2bab367e185cdfb27501c4b30b1b0653c28d9f73df8dc91488e66ece5fa6b")
         else
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-macos-x86_64-$(version).tar.xz")
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-x86_64-macos-$(version).tar.xz")
             add_urls("https://ziglang.org/download/$(version)/zig-macos-x86_64-$(version).tar.xz")
             add_urls("https://ziglang.org/download/$(version)/zig-x86_64-macos-$(version).tar.xz")
             add_versions("0.10.1", "02483550b89d2a3070c2ed003357fd6e6a3059707b8ee3fbc0c67f83ca898437")
@@ -23,9 +28,12 @@ package("zig")
             add_versions("0.13.0", "8b06ed1091b2269b700b3b07f8e3be3b833000841bae5aa6a09b1a8b4773effd")
             add_versions("0.14.0", "685816166f21f0b8d6fc7aa6a36e91396dcd82ca6556dfbe3e329deffc01fec3")
             add_versions("0.15.1", "9919392e0287cccc106dfbcbb46c7c1c3fa05d919567bb58d7eb16bca4116184")
+            add_versions("0.15.2", "375b6909fc1495d16fc2c7db9538f707456bfc3373b14ee83fdd3e22b3d43f7f")
         end
     elseif is_host("windows") then
         if os.arch() == "arm64" then
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-windows-aarch64-$(version).zip")
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-aarch64-windows-$(version).zip")
             add_urls("https://ziglang.org/download/$(version)/zig-windows-aarch64-$(version).zip")
             add_urls("https://ziglang.org/download/$(version)/zig-aarch64-windows-$(version).zip")
             add_versions("0.10.1", "ece93b0d77b2ab03c40db99ef7ccbc63e0b6bd658af12b97898960f621305428")
@@ -34,7 +42,10 @@ package("zig")
             add_versions("0.13.0", "95ff88427af7ba2b4f312f45d2377ce7a033e5e3c620c8caaa396a9aba20efda")
             add_versions("0.14.0", "03e984383ebb8f85293557cfa9f48ee8698e7c400239570c9ff1aef3bffaf046")
             add_versions("0.15.1", "1f1bf16228b0ffcc882b713dc5e11a6db4219cb30997e13c72e8e723c2104ec6")
+            add_versions("0.15.2", "b926465f8872bf983422257cd9ec248bb2b270996fbe8d57872cca13b56fc370")
         else
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-windows-x86_64-$(version).zip")
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-x86_64-windows-$(version).zip")
             add_urls("https://ziglang.org/download/$(version)/zig-windows-x86_64-$(version).zip")
             add_urls("https://ziglang.org/download/$(version)/zig-x86_64-windows-$(version).zip")
             add_versions("0.10.1", "5768004e5e274c7969c3892e891596e51c5df2b422d798865471e05049988125")
@@ -43,9 +54,12 @@ package("zig")
             add_versions("0.13.0", "d859994725ef9402381e557c60bb57497215682e355204d754ee3df75ee3c158")
             add_versions("0.14.0", "f53e5f9011ba20bbc3e0e6d0a9441b31eb227a97bac0e7d24172f1b8b27b4371")
             add_versions("0.15.1", "91e69e887ca8c943ce9a515df3af013d95a66a190a3df3f89221277ebad29e34")
+            add_versions("0.15.2", "3a0ed1e8799a2f8ce2a6e6290a9ff22e6906f8227865911fb7ddedc3cc14cb0c")
         end
     elseif is_host("linux") then
         if os.arch() == "i386" then
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-linux-x86-$(version).tar.xz")
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-x86-linux-$(version).tar.xz")
             add_urls("https://ziglang.org/download/$(version)/zig-linux-x86-$(version).tar.xz")
             add_urls("https://ziglang.org/download/$(version)/zig-x86-linux-$(version).tar.xz")
             add_versions("0.11.0", "7b0dc3e0e070ae0e0d2240b1892af6a1f9faac3516cae24e57f7a0e7b04662a8")
@@ -53,7 +67,10 @@ package("zig")
             add_versions("0.13.0", "876159cc1e15efb571e61843b39a2327f8925951d48b9a7a03048c36f72180f7")
             add_versions("0.14.0", "55d1ba21de5109686ffa675b9cc1dd66930093c202995a637ce3e397816e4c08")
             add_versions("0.15.1", "dff166f25fdd06e8341d831a71211b5ba7411463a6b264bdefa8868438690b6a")
+            add_versions("0.15.2", "4c6e23f39daa305e274197bfdff0d56ffd1750fc1de226ae10505c0eff52d7a5")
         elseif os.arch() == "arm64" then
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-linux-aarch64-$(version).tar.xz")
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-aarch64-linux-$(version).tar.xz")
             add_urls("https://ziglang.org/download/$(version)/zig-linux-aarch64-$(version).tar.xz")
             add_urls("https://ziglang.org/download/$(version)/zig-aarch64-linux-$(version).tar.xz")
             add_versions("0.10.1", "db0761664f5f22aa5bbd7442a1617dd696c076d5717ddefcc9d8b95278f71f5d")
@@ -62,7 +79,10 @@ package("zig")
             add_versions("0.13.0", "041ac42323837eb5624068acd8b00cd5777dac4cf91179e8dad7a7e90dd0c556")
             add_versions("0.14.0", "ab64e3ea277f6fc5f3d723dcd95d9ce1ab282c8ed0f431b4de880d30df891e4f")
             add_versions("0.15.1", "bb4a8d2ad735e7fba764c497ddf4243cb129fece4148da3222a7046d3f1f19fe")
+            add_versions("0.15.2", "958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f")
         else
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-linux-x86_64-$(version).tar.xz")
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-x86_64-linux-$(version).tar.xz")
             add_urls("https://ziglang.org/download/$(version)/zig-linux-x86_64-$(version).tar.xz")
             add_urls("https://ziglang.org/download/$(version)/zig-x86_64-linux-$(version).tar.xz")
             add_versions("0.10.1", "6699f0e7293081b42428f32c9d9c983854094bd15fee5489f12c4cf4518cc380")
@@ -71,14 +91,18 @@ package("zig")
             add_versions("0.13.0", "d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea")
             add_versions("0.14.0", "473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982")
             add_versions("0.15.1", "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05")
+            add_versions("0.15.2", "02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239")
         end
     elseif is_host("bsd") then
         if os.arch() == "x86_64" then
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-freebsd-x86_64-$(version).tar.xz")
+            add_urls("https://pkg.machengine.org/zig/$(version)/zig-x86_64-freebsd-$(version).tar.xz")
             add_urls("https://ziglang.org/download/$(version)/zig-freebsd-x86_64-$(version).tar.xz")
             add_urls("https://ziglang.org/download/$(version)/zig-x86_64-freebsd-$(version).tar.xz")
             add_versions("0.11.0", "ea430327f9178377b79264a1d492868dcff056cd76d43a6fb00719203749e958")
             add_versions("0.13.0", "adc1ffc9be56533b2f1c7191f9e435ad55db00414ff2829d951ef63d95aaad8c")
             add_versions("0.15.1", "9714f8ac3d3dc908b1599837c6167f857c1efaa930f0cfa840699458de7c3cd0")
+            add_versions("0.15.2", "5509ff57cd3f219165caed0da10221739af82742b9edfcda3f7bfaf4da7212dd")
         end
     end
 


### PR DESCRIPTION
Follow the suggestion, preferring to use mirror sites for downloads:

<img width="990" height="476" alt="image" src="https://github.com/user-attachments/assets/9af16901-3bd2-49b7-baf5-4b45b8f2e12d" />


