### PR TITLE
Auto-update rocksdb to v10.7.5

### DIFF
--- a/packages/r/rocksdb/xmake.lua
+++ b/packages/r/rocksdb/xmake.lua
@@ -6,6 +6,7 @@ package("rocksdb")
     add_urls("https://github.com/facebook/rocksdb/archive/refs/tags/$(version).tar.gz",
              "https://github.com/facebook/rocksdb.git")
 
+    add_versions("v10.7.5", "a9948bf5f00dd1e656fc40c4b0bf39001c3773ad22c56959bdb1c940d10e3d8d")
     add_versions("v10.5.1", "7ec942baab802b2845188d02bc5d4e42c29236e61bcbc08f5b3a6bdd92290c22")
     add_versions("v10.4.2", "afccfab496556904900afacf7d99887f1d50cb893e5d2288bd502db233adacac")
     add_versions("v10.0.1", "3fdc9ca996971c4c039959866382c4a3a6c8ade4abf888f3b2ff77153e07bf28")


### PR DESCRIPTION
New version of rocksdb detected (package version: v10.5.1, last github version: v10.7.5)