### PR TITLE
Auto-update fast-cdr to v2.3.4

### DIFF
--- a/packages/f/fast-cdr/xmake.lua
+++ b/packages/f/fast-cdr/xmake.lua
@@ -6,6 +6,7 @@ package("fast-cdr")
     add_urls("https://github.com/eProsima/Fast-CDR/archive/refs/tags/$(version).tar.gz",
              "https://github.com/eProsima/Fast-CDR.git")
 
+    add_versions("v2.3.4", "5b96e85680bd105138202eb734e02545b3e0a06bff8eb55f1f06b692087ed9ef")
     add_versions("v2.3.3", "d48c33aca3ed805383f9a1c6210b6141a5e8044f260c831c1ca03be3a801fdb8")
     add_versions("v2.3.1", "a8703fa3209c7e33dcb6950447a5269dfd4f36d59d74e857bbbfffcdafd97d3f")
     add_versions("v2.3.0", "d85ee9e24e105581b49de3e2b6b2585335a8dc98c4cabd288232fffc4b9b6a24")


### PR DESCRIPTION
New version of fast-cdr detected (package version: v2.3.3, last github version: v2.3.4)