### PR TITLE
`quantlib`: fix linking issue related with `/usr/lib/libboost_python313.so` on `Arch Linux` by adding python as deps.

### DIFF
--- a/packages/q/quantlib/xmake.lua
+++ b/packages/q/quantlib/xmake.lua
@@ -19,6 +19,7 @@ package("quantlib")
 
     add_deps("cmake")
     add_deps("boost", {configs = {math = true, serialization = true, regex = true, thread = true}})
+    add_deps("python")
 
     on_load(function (package)
         if package:config("openmp") then


### PR DESCRIPTION
`quantlib`: deps `boost` has linking issue on Arch Linux. Fixed it by adding a python deps so it can link against the python libs.