### PR TITLE
Auto-update utf8proc to v2.11.1

### DIFF
--- a/packages/u/utf8proc/xmake.lua
+++ b/packages/u/utf8proc/xmake.lua
@@ -6,6 +6,7 @@ package("utf8proc")
 
     add_urls("https://github.com/JuliaStrings/utf8proc/archive/refs/tags/$(version).tar.gz",
              "https://github.com/JuliaStrings/utf8proc.git")
+    add_versions("v2.11.1", "dc146fd279eacbbf399d3f70932ce66f516aac2d13f8ec2d26a30f8ed70aa5b4")
     add_versions("v2.11.0", "c24379b5fa0a429a1f9a3fc23b44a75f2b141a34c09146a529a55d20a5808070")
     add_versions("v2.10.0", "6f4f1b639daa6dca9f80bc5db1233e9cbaa31a67790887106160b33ef743f136")
     add_versions("v2.9.0", "18c1626e9fc5a2e192311e36b3010bfc698078f692888940f1fa150547abb0c1")


### PR DESCRIPTION
New version of utf8proc detected (package version: v2.11.0, last github version: v2.11.1)