### PR TITLE
Auto-update freeglut to 3.8.0

### DIFF
--- a/packages/f/freeglut/xmake.lua
+++ b/packages/f/freeglut/xmake.lua
@@ -6,6 +6,7 @@ package("freeglut")
     add_urls("https://github.com/freeglut/freeglut/releases/download/v$(version)/freeglut-$(version).tar.gz",
              "https://github.com/freeglut/freeglut.git")
 
+    add_versions("3.8.0", "674dcaff25010e09e450aec458b8870d9e98c46f99538db457ab659b321d9989")
     add_versions("3.6.0", "9c3d4d6516fbfa0280edc93c77698fb7303e443c1aaaf37d269e3288a6c3ea52")
     add_versions("3.4.0", "3c0bcb915d9b180a97edaebd011b7a1de54583a838644dcd42bb0ea0c6f3eaec")
 


### PR DESCRIPTION
New version of freeglut detected (package version: 3.6.0, last github version: 3.8.0)