### PR TITLE
Auto-update clip to v1.13

### DIFF
--- a/packages/c/clip/xmake.lua
+++ b/packages/c/clip/xmake.lua
@@ -6,6 +6,7 @@ package("clip")
     add_urls("https://github.com/dacap/clip/archive/refs/tags/$(version).tar.gz",
              "https://github.com/dacap/clip.git")
 
+    add_versions("v1.13", "0d07f80bc48c16d049778501bfb4a58d4f5c4087fd99a53b0640d64dc3b86868")
     add_versions("v1.12", "54e96e04115c7ca1eeeecf432548db5cd3dddb08a91ededb118adc31b128e08c")
     add_versions("v1.11", "047d43f837adffcb3a26ce09fd321472615cf35a18e86418d789b70d742519dc")
 


### PR DESCRIPTION
New version of clip detected (package version: v1.12, last github version: v1.13)