### PR TITLE
Auto-update alembic to 1.8.10

### DIFF
--- a/packages/a/alembic/xmake.lua
+++ b/packages/a/alembic/xmake.lua
@@ -6,6 +6,7 @@ package("alembic")
     add_urls("https://github.com/alembic/alembic/archive/refs/tags/$(version).tar.gz",
              "https://github.com/alembic/alembic.git")
 
+    add_versions("1.8.10", "06c9172faf29e9fdebb7be99621ca18b32b474f8e481238a159c87d16b298553")
     add_versions("1.8.9", "8c59c10813feee917d262c71af77d6fa3db1acaf7c5fecfd4104167077403955")
     add_versions("1.8.8", "ba1f34544608ef7d3f68cafea946ec9cc84792ddf9cda3e8d5590821df71f6c6")
     add_versions("1.8.7", "6de0b97cd14dcfb7b2d0d788c951b6da3c5b336c47322ea881d64f18575c33da")


### PR DESCRIPTION
New version of alembic detected (package version: 1.8.9, last github version: 1.8.10)