### PR TITLE
rocksdb: fix build

### DIFF
--- a/packages/r/rocksdb/xmake.lua
+++ b/packages/r/rocksdb/xmake.lua
@@ -6,6 +6,7 @@ package("rocksdb")
     add_urls("https://github.com/facebook/rocksdb/archive/refs/tags/$(version).tar.gz",
              "https://github.com/facebook/rocksdb.git")
 
+    add_versions("v10.7.5", "a9948bf5f00dd1e656fc40c4b0bf39001c3773ad22c56959bdb1c940d10e3d8d")
     add_versions("v10.5.1", "7ec942baab802b2845188d02bc5d4e42c29236e61bcbc08f5b3a6bdd92290c22")
     add_versions("v10.4.2", "afccfab496556904900afacf7d99887f1d50cb893e5d2288bd502db233adacac")
     add_versions("v10.0.1", "3fdc9ca996971c4c039959866382c4a3a6c8ade4abf888f3b2ff77153e07bf28")
@@ -100,5 +101,5 @@ package("rocksdb")
                 options.create_if_missing = true;
                 rocksdb::Status status = rocksdb::DB::Open(options, "./test", &db);
             }
-        ]]}, {configs = {languages = "c++17"}, includes = "rocksdb/db.h"}))
+        ]]}, {configs = {languages = package:version():ge("10.7.0") and "c++20" or "c++17"}, includes = "rocksdb/db.h"}))
     end)


### PR DESCRIPTION
RocksDB now requires a C++20 compatible compiler (GCC >= 11, Clang >= 10, Visual Studio >= 2019), including for any code using RocksDB headers.

<img width="814" height="747" alt="image" src="https://github.com/user-attachments/assets/a9072248-54b1-4edb-b2ee-a1864455f615" />

Fixes #8608 

