### PR TITLE
Auto-update portmidi to v2.0.7

### DIFF
--- a/packages/p/portmidi/xmake.lua
+++ b/packages/p/portmidi/xmake.lua
@@ -5,6 +5,7 @@ package("portmidi")
     add_urls("https://github.com/PortMidi/portmidi/archive/refs/tags/$(version).tar.gz",
              "https://github.com/PortMidi/portmidi.git")
 
+    add_versions("v2.0.7", "43fa65b4ed7ebaa68b0028a538ba8b2ca4dc9b86a7e22ec48842070e010f823f")
     add_versions("v2.0.6", "81d22b34051621cd56c8d5ef12908ef2a59764c9cdfba6dae47aabddb71ac914")
     add_versions("v2.0.4", "64893e823ae146cabd3ad7f9a9a9c5332746abe7847c557b99b2577afa8a607c")
 


### PR DESCRIPTION
New version of portmidi detected (package version: v2.0.6, last github version: v2.0.7)