### PR TITLE
opencv-mobile: improve build logic and add platforms

### DIFF
--- a/packages/o/opencv-mobile/xmake.lua
+++ b/packages/o/opencv-mobile/xmake.lua
@@ -95,7 +95,6 @@ package("opencv-mobile")
                 table.insert(configs, "-DANDROID_ARM_NEON=ON")
             end
         elseif package:is_plat("iphoneos") or (package:is_plat("linux") and package:is_arch("arm.*")) then
-            table.insert(configs, "-DCMAKE_C_FLAGS=-fno-rtti -fno-exceptions")
             table.insert(configs, "-DCMAKE_CXX_FLAGS=-fno-rtti -fno-exceptions")
         end
         local options = string.split(io.readfile("options.txt"), "\n", {plain = true})


### PR DESCRIPTION
## Main Changes

- **Android**:
  - Fix openmp linking issues (use ndk omp)
  - Add ndk version check (require r23+ for armeabi-v7a)
  - Fix build flags for arm64
- **ios**:
  - Add support for `iphoneos` platform
  - Remove openmp, but idk why it works qwq
- **Windows**:
  - Fix for arm64 directory (copied from opencv
- **Mingw**:
  - Improve support.
- **Others**:
  - Remove unnecessary dependency on `python`