### PR TITLE
Auto-update ufbx to v0.21.2

### DIFF
--- a/packages/u/ufbx/xmake.lua
+++ b/packages/u/ufbx/xmake.lua
@@ -6,6 +6,7 @@ package("ufbx")
     set_urls("https://github.com/ufbx/ufbx/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ufbx/ufbx.git")
 
+    add_versions("v0.21.2", "41488cde8a7dd43e361d04a7d4003123be9af8eaa2cc26d48e1834b44d120606")
     add_versions("v0.20.1", "1e45f7040ee38e8a6b564a5becb6b64335af89505f7077a0cc7bce092e188fca")
     add_versions("v0.20.0", "108fde070dc7c1471ad5a08890804cf92c84de7415cbb12d21f4ceaaa13a14cc")
     add_versions("v0.18.2", "9161239e9aade9fc3e432420450687fa538893566002ffc016aa0cba4d1c36a6")


### PR DESCRIPTION
New version of ufbx detected (package version: v0.20.1, last github version: v0.21.2)