### PR TITLE
Auto-update nanoflann to v1.8.0

### DIFF
--- a/packages/n/nanoflann/xmake.lua
+++ b/packages/n/nanoflann/xmake.lua
@@ -7,6 +7,7 @@ package("nanoflann")
 
     add_urls("https://github.com/jlblancoc/nanoflann/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jlblancoc/nanoflann.git")
+    add_versions("v1.8.0", "14e82a1de64a8b26486322d36817449a8bc2e63ea3b91bfee64f320155790a9c")
     add_versions("v1.7.1", "887e4e57e9c5fbf1c2937f9f5a9bc461c4786d54729b57a9c19547bdedb46986")
     add_versions("v1.7.0", "5e0b05a209aa61e0b0377bcad8b6978862b17f096f67dbab1630ec9593aa075d")
     add_versions("v1.6.2", "c1b8f2e4d32c040249dad14a89dd03c5106a8c56f3e9ca4e60a0836a59259c0c")


### PR DESCRIPTION
New version of nanoflann detected (package version: v1.7.1, last github version: v1.8.0)