### PR TITLE
Auto-update onednn to v3.10.1

### DIFF
--- a/packages/o/onednn/xmake.lua
+++ b/packages/o/onednn/xmake.lua
@@ -6,6 +6,7 @@ package("onednn")
 
     add_urls("https://github.com/oneapi-src/oneDNN/archive/refs/tags/$(version).tar.gz",
              "https://github.com/oneapi-src/oneDNN.git")
+    add_versions("v3.10.1", "d89998bfae2f33c209e216e3d3a8d280ed6eb65a57971dfb4dcfa56beac9571b")
     add_versions("v3.10", "ba5834a1fdbb6d1c1b1c065dfd789438e7aa42c03fc52d92c02af85d78d1c75c")
     add_versions("v3.9.1", "fa44702f5979ed5ab927f7ccc1d2947adb4e6d0e58c433149465c5fc71e3bd45")
     add_versions("v3.9", "806ec963b8a89cc7555c43afbb6f5369dc9010c8cf435b85aaf708acd1a2d837")


### PR DESCRIPTION
New version of onednn detected (package version: v3.10, last github version: v3.10.1)