### PR TITLE
Auto-update fakeit to 2.5.0

### DIFF
--- a/packages/f/fakeit/xmake.lua
+++ b/packages/f/fakeit/xmake.lua
@@ -7,6 +7,7 @@ package("fakeit")
     add_urls("https://github.com/eranpeer/FakeIt/archive/refs/tags/$(version).tar.gz",
              "https://github.com/eranpeer/FakeIt.git")
 
+    add_versions("2.5.0", "57adedf802271513d88a1d9342d829cfb34988c3d835e07346f8129047200c53")
     add_versions("2.4.1", "f5234a36d42363cb7ccd2cf99c8a754c832d9092035d984ad40aafa5371d0e95")
     add_versions("2.4.0", "eb79459ad6a97a5c985e3301b0d44538bdce2ba26115afe040f3874688edefb5")
 


### PR DESCRIPTION
New version of fakeit detected (package version: 2.4.1, last github version: 2.5.0)