### PR TITLE
miniaudio: Disable worklets by default

### DIFF
--- a/packages/m/miniaudio/xmake.lua
+++ b/packages/m/miniaudio/xmake.lua
@@ -32,7 +32,7 @@ package("miniaudio")
     add_configs("sse2", {description = "Enable SSE2 optimizations", default = true, type = "boolean"})
     add_configs("threading", {description = "Enable the threading API", default = true, type = "boolean"})
     add_configs("wav", {description = "Enable the builtin WAV decoder and encoder", default = true, type = "boolean"})
-    add_configs("worklets", {description = "Enable AudioWorklets when targeting web", default = true, type = "boolean"})
+    add_configs("worklets", {description = "Enable AudioWorklets when targeting web", default = false, type = "boolean"})
 
     if is_plat("iphoneos") then
         add_frameworks("AudioToolbox", "AVFoundation", "CoreFoundation", "Foundation")


### PR DESCRIPTION
Worklets are disabled by default and may require some flags to be compiled: https://github.com/mackron/miniaudio/blob/f40cf03f80cdb7e741d43e53b7e706e8c1394bcf/CHANGES.md?plain=1#L54
