### PR TITLE
Auto-update libdatrie to 0.2.14

### DIFF
--- a/packages/l/libdatrie/xmake.lua
+++ b/packages/l/libdatrie/xmake.lua
@@ -5,6 +5,7 @@ package("libdatrie")
     set_license("LGPL-2.1")
 
     add_urls("https://github.com/tlwg/libdatrie/releases/download/v$(version)/libdatrie-$(version).tar.xz")
+    add_versions("0.2.14", "f04095010518635b51c2313efa4f290b7db828d6273e39b2b8858f859dfe81d5")
     add_versions("0.2.13", "12231bb2be2581a7f0fb9904092d24b0ed2a271a16835071ed97bed65267f4be")
     
     add_deps("m4", "pkg-config", "autoconf", "automake", "libtool")


### PR DESCRIPTION
New version of libdatrie detected (package version: 0.2.13, last github version: 0.2.14)