### PR TITLE
Auto-update lzav to 5.5

### DIFF
--- a/packages/l/lzav/xmake.lua
+++ b/packages/l/lzav/xmake.lua
@@ -7,6 +7,7 @@ package("lzav")
     add_urls("https://github.com/avaneev/lzav/archive/refs/tags/$(version).tar.gz",
              "https://github.com/avaneev/lzav.git")
 
+    add_versions("5.5", "0283a7470198f7cb289e9030b3e42f7240d7bb6c3eda34af7143cf3f49dfbdf3")
     add_versions("5.4", "c57deda23298ee3a2b73a78d1daeab90267e4c01f6a845f29c597f621cf52789")
     add_versions("5.3", "1d66d3702b8b380fccbe8aeef24e59e36e79468ecc0e7a18cdfe105bde6c3f5d")
     add_versions("4.23", "f3ea9cfbbc99da786ff6c336ea43cc629502638d457b07e64c182d4ab98c5c09")


### PR DESCRIPTION
New version of lzav detected (package version: 5.4, last github version: 5.5)