### PR TITLE
Auto-update eastl to 3.27.01

### DIFF
--- a/packages/e/eastl/xmake.lua
+++ b/packages/e/eastl/xmake.lua
@@ -6,6 +6,7 @@ package("eastl")
 
     set_urls("https://github.com/electronicarts/EASTL/archive/refs/tags/$(version).tar.gz",
              "https://github.com/electronicarts/EASTL.git")
+    add_versions("3.27.01", "fce43bf443f5569b00a8deae735394ea0b16f6c3f96867a17ded50775ffcdd12")
     add_versions("3.17.03", "50a072066e30fda364d482df6733572d8ca440a33825d81254b59a6ca9f4375a")
     add_versions("3.17.06", "9ebeef26cdf091877ee348450d2711cd0bb60ae435309126c0adf8fec9a01ea5")
     add_versions("3.18.00", "a3c5b970684be02e81fb16fbf92ed2584e055898704fde87c72d0331afdea12b")


### PR DESCRIPTION
New version of eastl detected (package version: 3.27.00, last github version: 3.27.01)