### PR TITLE
Auto-update librime to 1.15.0

### DIFF
--- a/packages/l/librime/xmake.lua
+++ b/packages/l/librime/xmake.lua
@@ -6,6 +6,7 @@ package("librime")
     add_urls("https://github.com/rime/librime/archive/refs/tags/$(version).tar.gz",
              "https://github.com/rime/librime.git", {submodules = false})
 
+    add_versions("1.15.0", "a6283cb6a9fa9445dbd7fac58f614884edd662486fa79809ca63686c8f59c6da")
     add_versions("1.14.0", "b2b29c3551eec6b45af1ba8fd3fcffb99e2b7451aa974c1c9ce107e69ce3ea68")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of librime detected (package version: 1.14.0, last github version: 1.15.0)