### PR TITLE
opencv-mobile: add version parse and update

### DIFF
--- a/packages/o/opencv-mobile/xmake.lua
+++ b/packages/o/opencv-mobile/xmake.lua
@@ -118,7 +118,7 @@ package("opencv-mobile")
     end)
 
     on_install("android", "iphoneos", "linux", "macosx", "windows", "mingw@windows,msys", function (package)
-        if is_plat("windows", "mingw") then
+        if package:is_plat("windows", "mingw") then
             -- fix for v30-v34
             io.replace("modules/highgui/src/display_win32.cpp", "#include <mutex>\n\n", "#include <mutex>\n#include <cstdio>\n\n", {plain = true})
             -- fix for v30, v31


### PR DESCRIPTION
This pr adds 3 main versions for opencv-mobile(v31, v33, v34)

I use `on_source` to parse opencv-mobile versions like `4.12.0-v34` (`4.12.0` is opencv version, `v34` is opencv-mobile version). After parsing, I set and add relevant versions.

detailed versions:
```
["v31"] = {
    "4.10.0", "3.4.20"
},
["v33"] = {
    "4.11.0", "3.4.20"
},
["v34"] = {
    "4.12.0", "3.4.20"
}
```

I will add them separately and let ci test them.