### PR TITLE
Auto-update msdfgen to v1.13

### DIFF
--- a/packages/m/msdfgen/xmake.lua
+++ b/packages/m/msdfgen/xmake.lua
@@ -6,6 +6,7 @@ package("msdfgen")
     add_urls("https://github.com/Chlumsky/msdfgen/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Chlumsky/msdfgen.git")
 
+    add_versions("v1.13", "93cd1ad8918c1a78c5c96e82d4f4c77f0eb86c2e7e8579a0967e54196c4b7167")
     add_versions("v1.12.1", "24541c9fbb459e8c62adeb3eb22cb21fa07a4b5091e2ae1f041d144a4baf08cd")
     add_versions("v1.12", "f058117496097217d12e4ea86adbff8467adaf6f12af793925d243b86b0c4f57")
     add_versions("v1.11", "fad74e33274f591e72511bc0546189e7aec439f2a512ef1b2fde243554d457cb")


### PR DESCRIPTION
New version of msdfgen detected (package version: v1.12.1, last github version: v1.13)