### PR TITLE
protobuf-cpp: Fixed on_test when compiling without tools.

### DIFF
--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -215,7 +215,7 @@ package("protobuf-cpp")
     end)
 
     on_test(function (package)
-        if not package:config("tools") and not package:is_cross() and
+        if package:config("tools") and not package:is_cross() and
             -- Missing libgcc_s_xxx.dll, Maybe msys2 bug
             not (is_subhost("msys") and package:is_plat("mingw", "msys") and package:is_arch("i386")) then
             io.writefile("test.proto", [[


### PR DESCRIPTION
When trying to use the protobuf-cpp package, the install step would fail for me because I disabled tools as part of my config. With this small fix, it will check in on_test if the tools have actually been enabled before trying to use protoc.