### PR TITLE
Auto-update openvdb to v13.0.0

### DIFF
--- a/packages/o/openvdb/xmake.lua
+++ b/packages/o/openvdb/xmake.lua
@@ -6,6 +6,7 @@ package("openvdb")
     add_urls("https://github.com/AcademySoftwareFoundation/openvdb/archive/refs/tags/$(version).tar.gz",
              "https://github.com/AcademySoftwareFoundation/openvdb.git")
 
+    add_versions("v13.0.0", "4d6a91df5f347017496fe8d22c3dbb7c4b5d7289499d4eb4d53dd2c75bb454e1")
     add_versions("v12.1.1", "ccd0ea1669a53c7c13087a08ac5a1351041c4cdd308f6d6f591074a106fcb565")
     add_versions("v7.1.0", "0c3588c1ca6e647610738654ec2c6aaf41a203fd797f609fbeab1c9f7c3dc116")
     add_versions("v8.0.1", "a6845da7c604d2c72e4141c898930ac8a2375521e535f696c2cd92bebbe43c4f")


### PR DESCRIPTION
New version of openvdb detected (package version: v12.1.1, last github version: v13.0.0)