### PR TITLE
Auto-update node-api-headers to v1.7.0

### DIFF
--- a/packages/n/node-api-headers/xmake.lua
+++ b/packages/n/node-api-headers/xmake.lua
@@ -6,6 +6,7 @@ package("node-api-headers")
 
     set_urls("https://github.com/nodejs/node-api-headers/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nodejs/node-api-headers.git")
+    add_versions("v1.7.0", "2f964cac4f90b4379ea6db4ac9635b39cd29ba63a0a1f892b0075871ff6d0216")
     add_versions("v1.6.0", "199b465efd4276b85f6b6132745aba1804c2372c848247aca3a5a6895799d9ae")
     add_versions("v1.5.0", "c31ce81b98b034d6daaa2b97112ba83b51b6e4454bea00696bbc7881e851a29c")
     add_versions("v1.4.0", "08a96c351ab5cb0aaac55e292eb3e8b63b0b82324cb8182cc8d6c30d9bade595")


### PR DESCRIPTION
New version of node-api-headers detected (package version: v1.6.0, last github version: v1.7.0)