### PR TITLE
Auto-update aws-c-cal to v0.9.13

### DIFF
--- a/packages/a/aws-c-cal/xmake.lua
+++ b/packages/a/aws-c-cal/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-cal")
     add_urls("https://github.com/awslabs/aws-c-cal/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-cal.git")
 
+    add_versions("v0.9.13", "80b7c6087b0af461b4483e4c9483aea2e0dac5d9fb2289b057159ea6032409e1")
     add_versions("v0.9.11", "319720ca46f2d23c3b5e44f4b48a1d468c49983bd0970d09cf0ddee4f4450d39")
     add_versions("v0.9.10", "a41b389e942fadd599a6a0f692b75480d663f1e702c0301177f00f365e0c9b94")
     add_versions("v0.9.5", "5cedd82d093960a09a91bf8d8c3540425e49972ed9b565763bf2a5b2ba1a2a7c")


### PR DESCRIPTION
New version of aws-c-cal detected (package version: v0.9.11, last github version: v0.9.13)