### PR TITLE
Auto-update fcgi to 2.4.7

### DIFF
--- a/packages/f/fcgi/xmake.lua
+++ b/packages/f/fcgi/xmake.lua
@@ -6,6 +6,7 @@ package("fcgi")
     set_urls("https://github.com/FastCGI-Archives/fcgi2/archive/refs/tags/$(version).tar.gz",
              "https://github.com/FastCGI-Archives/fcgi2.git")
 
+    add_versions("2.4.7", "e41ddc3a473b555bdc0cbd80703dcb1f4610c1a7700d3b9d3d0c14a416e1074b")
     add_versions("2.4.6", "39af4fb21a6d695a5f0b1c4fa95776d2725f6bc6c77680943a2ab314acd505c1")
 
     if is_plat("windows", "mingw") and is_arch("x64", "x86_64") then


### PR DESCRIPTION
New version of fcgi detected (package version: 2.4.6, last github version: 2.4.7)