### PR TITLE
glslang-nihui: add new package for ncnn

### DIFF
--- a/packages/g/glslang-nihui/xmake.lua
+++ b/packages/g/glslang-nihui/xmake.lua
@@ -5,8 +5,8 @@ package("glslang-nihui")
 
     add_urls("https://github.com/nihui/glslang.git")
 
-    add_versions("20250916", "cpp14-2")  -- 8cd77a808d0bffa442ae9462d5e3a8141892ba5a
-    add_versions("20250503", "a9ac7d5f307e5db5b8c4fbf904bdba8fca6283bc")
+    add_versions("2025.09.16", "8cd77a808d0bffa442ae9462d5e3a8141892ba5a")
+    add_versions("2025.05.03", "a9ac7d5f307e5db5b8c4fbf904bdba8fca6283bc")
 
     if is_plat("wasm") then
         add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})


### PR DESCRIPTION
https://github.com/Tencent/ncnn/blob/37336e7302175e85f3d964e043a90e6fcd99c988/.gitmodules#L3

`ncnn` requires `nihui/glslang` which is a fork of `KhronosGroup/glslang` for C++14 compatibility.

`nihui/glslang` mainly uses these two branches: https://github.com/nihui/glslang/tree/cpp14 and https://github.com/nihui/glslang/tree/cpp14-2 