### PR TITLE
Auto-update protobuf-cpp to 33.2

### DIFF
--- a/packages/p/protobuf-cpp/xmake.lua
+++ b/packages/p/protobuf-cpp/xmake.lua
@@ -13,6 +13,7 @@ package("protobuf-cpp")
     end})
 
     -- TODO: Use x.y.z version? https://protobuf.dev/support/version-support
+    add_versions("33.2", "d0c6246dc7817d26e809cae88f69b019a92827096811c85e65d3d01102974710")
     add_versions("33.1", "801c7d44b2ec2ffaaf94555eda48a2239ef21e6602808ca8d22a9005fc2c03ef")
     add_versions("32.1", "2d25be4d5bf3bf28a97de553ae76c49f2a6fa3c21b04d3ccd5b3e0abc9262d00")
     add_versions("32.0", "62b6b80ab91a5379c03533bd6d59b6932b4385f0b0dd5299990bbe5e2cc6c428")


### PR DESCRIPTION
New version of protobuf-cpp detected (package version: 33.1, last github version: 33.2)