### PR TITLE
Auto-update aws-c-auth to v0.9.4

### DIFF
--- a/packages/a/aws-c-auth/xmake.lua
+++ b/packages/a/aws-c-auth/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-auth")
     add_urls("https://github.com/awslabs/aws-c-auth/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-auth.git")
 
+    add_versions("v0.9.4", "704b2f965c31d9d0fd8d9ab207bc8c838e3683c56bd8407e472bbc8fa9f9a209")
     add_versions("v0.9.1", "adae1e725d9725682366080b8bf8e49481650c436b846ceeb5efe955d5e03273")
     add_versions("v0.9.0", "aa6e98864fefb95c249c100da4ae7aed36ba13a8a91415791ec6fad20bec0427")
     add_versions("v0.8.7", "b961cbed0b82248d3ea7a47f5a49bf174d5a0a977bbdd7ef3e1b2d2eb5468af5")


### PR DESCRIPTION
New version of aws-c-auth detected (package version: v0.9.1, last github version: v0.9.4)