### PR TITLE
Auto-update double-conversion to v3.4.0

### DIFF
--- a/packages/d/double-conversion/xmake.lua
+++ b/packages/d/double-conversion/xmake.lua
@@ -11,6 +11,10 @@ package("double-conversion")
     add_versions("v3.3.0", "04ec44461850abbf33824da84978043b22554896b552c5fd11a9c5ae4b4d296e")
     add_versions("v3.1.5", "a63ecb93182134ba4293fd5f22d6e08ca417caafa244afaa751cbfddf6415b13")
 
+    if is_plat("wasm") then
+        add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+    end
+
     add_deps("cmake")
 
     on_install(function (package)


### PR DESCRIPTION
New version of double-conversion detected (package version: v3.3.1, last github version: v3.4.0)