### PR TITLE
Auto-update tinycolormap to v0.8.0

### DIFF
--- a/packages/t/tinycolormap/xmake.lua
+++ b/packages/t/tinycolormap/xmake.lua
@@ -7,6 +7,7 @@ package("tinycolormap")
     add_urls("https://github.com/yuki-koyama/tinycolormap/archive/refs/tags/$(version).tar.gz",
              "https://github.com/yuki-koyama/tinycolormap.git")
 
+    add_versions("v0.8.0", "32790e512cf94342647c899b4748056d3b2c09a801de659d5be743fa6eb9a7af")
     add_versions("v0.7.0", "5e03b6c35c658aa7273ca6fb38ef9df06f885a2429191059c8770d5ff8b65951")
 
     on_install(function (package)


### PR DESCRIPTION
New version of tinycolormap detected (package version: v0.7.0, last github version: v0.8.0)