### PR TITLE
Auto-update robin-map to v1.4.1

### DIFF
--- a/packages/r/robin-map/xmake.lua
+++ b/packages/r/robin-map/xmake.lua
@@ -7,6 +7,7 @@ package("robin-map")
     add_urls("https://github.com/Tessil/robin-map/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Tessil/robin-map.git")
 
+    add_versions("v1.4.1", "0e3f53a377fdcdc5f9fed7a4c0d4f99e82bbb64175233bd13427fef9a771f4a1")
     add_versions("v1.4.0", "7930dbf9634acfc02686d87f615c0f4f33135948130b8922331c16d90a03250c")
     add_versions("v1.3.0", "a8424ad3b0affd4c57ed26f0f3d8a29604f0e1f2ef2089f497f614b1c94c7236")
     add_versions("v1.2.2", "c72767ecea2a90074c7efbe91620c8f955af666505e22782e82813c652710821")


### PR DESCRIPTION
New version of robin-map detected (package version: v1.4.0, last github version: v1.4.1)