### PR TITLE
Auto-update tree-sitter to v0.26.3

### DIFF
--- a/packages/t/tree-sitter/xmake.lua
+++ b/packages/t/tree-sitter/xmake.lua
@@ -6,6 +6,7 @@ package("tree-sitter")
     add_urls("https://github.com/tree-sitter/tree-sitter/archive/refs/tags/$(version).zip",
              "https://github.com/tree-sitter/tree-sitter.git")
 
+    add_versions("v0.26.3", "ce5e0085a7f80ab77e0fecad9fcd9e4b492d3f403e887efe554bc6f427a44514")
     add_versions("v0.26.2", "294f42c5eff53f6d52e06dcd945abb495723db0e3cf5045eb914bd27374eb39c")
     add_versions("v0.25.10", "c0ba583621b14be4d603307360402ca11509876172d09c8e061f86f695e1b68f")
     add_versions("v0.25.8", "baae36c8f3e34ee588424135ef7a910cefca0f0e54da2281a7297ebcc25784e1")


### PR DESCRIPTION
New version of tree-sitter detected (package version: v0.26.2, last github version: v0.26.3)