### PR TITLE
fix: opencv-mobile link issue on windows

### DIFF
--- a/packages/o/opencv-mobile/xmake.lua
+++ b/packages/o/opencv-mobile/xmake.lua
@@ -117,7 +117,7 @@ package("opencv-mobile")
         end
 
         if package:is_plat("windows", "mingw") then
-            package:add("syslinks""user32", "gdi32")
+            package:add("syslinks", "user32", "gdi32")
         end
     end)
 


### PR DESCRIPTION
On the windows platform, if you import opencv-mobile with static, it will crash by the missing of user32 & gdi32:

```
error: opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_BitBlt，函数 "protected: virtual __int64 __cdecl BitmapWindow::windowProc(unsigned int,unsigned __int64,__int64)" (?windowProc@BitmapWindow@@MEAA_JI_K_J@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_CreateCompatibleBitmap，函 数 "public: __cdecl BitmapWindow::BitmapWindow(void)" (??0BitmapWindow@@QEAA@XZ) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_CreateCompatibleDC，函数 "public: __cdecl BitmapWindow::BitmapWindow(void)" (??0BitmapWindow@@QEAA@XZ) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_CreateSolidBrush，函数 "protected: virtual __int64 __cdecl BitmapWindow::windowProc(unsigned int,unsigned __int64,__int64)" (?windowProc@BitmapWindow@@MEAA_JI_K_J@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_DeleteDC，函数 "public: virtual __cdecl BitmapWindow::~BitmapWindow(void)" (??1BitmapWindow@@UEAA@XZ) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_DeleteObject，函数 "public: virtual __cdecl BitmapWindow::~BitmapWindow(void)" (??1BitmapWindow@@UEAA@XZ) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_GetDeviceCaps，函数 "public: static double __cdecl SimpleWindow::getDesktopDpiFactor(void)" (?getDesktopDpiFactor@SimpleWindow@@SANXZ) 中引用 了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_SelectObject，函数 "public: __cdecl BitmapWindow::BitmapWindow(void)" (??0BitmapWindow@@QEAA@XZ) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_StretchDIBits，函数 "protected: virtual __int64 __cdecl BitmapWindow::windowProc(unsigned int,unsigned __int64,__int64)" (?windowProc@BitmapWindow@@MEAA_JI_K_J@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_GetMessageA，函数 "public: static int __cdecl BitmapWindow::waitKey(unsigned int)" (?waitKey@BitmapWindow@@SAHI@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_TranslateMessage，函数 "public: static int __cdecl BitmapWindow::waitKey(unsigned int)" (?waitKey@BitmapWindow@@SAHI@Z) 中引用了该符号        
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_DispatchMessageA，函数 "public: static int __cdecl BitmapWindow::waitKey(unsigned int)" (?waitKey@BitmapWindow@@SAHI@Z) 中引用了该符号        
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_PeekMessageA，函数 "public: static int __cdecl BitmapWindow::waitKey(unsigned int)" (?waitKey@BitmapWindow@@SAHI@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_PostMessageA，函数 "protected: virtual __int64 __cdecl BitmapWindow::windowProc(unsigned int,unsigned __int64,__int64)" (?windowProc@BitmapWindow@@MEAA_JI_K_J@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_DefWindowProcA，函数 "__int64 __cdecl __globalWndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64)" (?__globalWndProc@@YA_JPEAUHWND__@@I_K_J@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_PostQuitMessage，函数 "protected: virtual __int64 __cdecl BitmapWindow::windowProc(unsigned int,unsigned __int64,__int64)" (?windowProc@BitmapWindow@@MEAA_JI_K_J@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_RegisterClassA，函数 "public: bool __cdecl SimpleWindow::create(char const *,unsigned long,int,int,int,int,struct HWND__ *,unsigned long,struct HMENU__ *,void *)" (?create@SimpleWindow@@QEAA_NPEBDKHHHHPEAUHWND__@@KPEAUHMENU__@@PEAX@Z) 中引用了该符号        
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_CreateWindowExA，函数 "public: bool __cdecl SimpleWindow::create(char const *,unsigned long,int,int,int,int,struct HWND__ *,unsigned long,struct HMENU__ *,void *)" (?create@SimpleWindow@@QEAA_NPEBDKHHHHPEAUHWND__@@KPEAUHMENU__@@PEAX@Z) 中引用了该符号       
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_ShowWindow，函数 "public: static void __cdecl BitmapWindow::show(char const *,unsigned char const *)" (?show@BitmapWindow@@SAXPEBDPEBE@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_SetWindowPos，函数 "public: void __cdecl SimpleWindow::centerWindow(void)const " (?centerWindow@SimpleWindow@@QEBAXXZ) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_SetTimer，函数 "public: static int __cdecl BitmapWindow::waitKey(unsigned int)" (?waitKey@BitmapWindow@@SAHI@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_KillTimer，函数 "public: static int __cdecl BitmapWindow::waitKey(unsigned int)" (?waitKey@BitmapWindow@@SAHI@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_GetSystemMetrics，函数 "public: __cdecl BitmapWindow::BitmapWindow(void)" (??0BitmapWindow@@QEAA@XZ) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_UpdateWindow，函数 "public: static void __cdecl BitmapWindow::show(char const *,unsigned char const *)" (?show@BitmapWindow@@SAXPEBDPEBE@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_GetDC，函数 "public: __cdecl BitmapWindow::BitmapWindow(void)" (??0BitmapWindow@@QEAA@XZ) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_ReleaseDC，函数 "public: __cdecl BitmapWindow::BitmapWindow(void)" (??0BitmapWindow@@QEAA@XZ) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_BeginPaint，函数 "protected: virtual __int64 __cdecl BitmapWindow::windowProc(unsigned int,unsigned __int64,__int64)" (?windowProc@BitmapWindow@@MEAA_JI_K_J@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_EndPaint，函数 "protected: virtual __int64 __cdecl BitmapWindow::windowProc(unsigned int,unsigned __int64,__int64)" (?windowProc@BitmapWindow@@MEAA_JI_K_J@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_InvalidateRect，函数 "protected: void __cdecl BitmapWindow::drawBitmap(int,int)" (?drawBitmap@BitmapWindow@@IEAAXHH@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_SetScrollPos，函数 "protected: void __cdecl BitmapWindow::updateScrollBarStatus(void)" (?updateScrollBarStatus@BitmapWindow@@IEAAXXZ) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_GetScrollPos，函数 "protected: void __cdecl BitmapWindow::drawBitmap(int,int)" (?drawBitmap@BitmapWindow@@IEAAXHH@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_SetScrollRange，函数 "protected: void __cdecl BitmapWindow::updateScrollBarStatus(void)" (?updateScrollBarStatus@BitmapWindow@@IEAAXXZ) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_EnableScrollBar，函数 "protected: void __cdecl BitmapWindow::updateScrollBarStatus(void)" (?updateScrollBarStatus@BitmapWindow@@IEAAXXZ) 中引 用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_GetClientRect，函数 "protected: void __cdecl BitmapWindow::drawBitmap(int,int)" (?drawBitmap@BitmapWindow@@IEAAXHH@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_GetWindowRect，函数 "public: void __cdecl SimpleWindow::centerWindow(void)const " (?centerWindow@SimpleWindow@@QEBAXXZ) 中引用了该符号        
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_AdjustWindowRect，函数 "protected: virtual __int64 __cdecl BitmapWindow::windowProc(unsigned int,unsigned __int64,__int64)" (?windowProc@BitmapWindow@@MEAA_JI_K_J@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_FillRect，函数 "protected: virtual __int64 __cdecl BitmapWindow::windowProc(unsigned int,unsigned __int64,__int64)" (?windowProc@BitmapWindow@@MEAA_JI_K_J@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_GetWindowLongPtrA，函数 "protected: virtual __int64 __cdecl BitmapWindow::windowProc(unsigned int,unsigned __int64,__int64)" (?windowProc@BitmapWindow@@MEAA_JI_K_J@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_FindWindowA，函数 "protected: static class BitmapWindow * __cdecl BitmapWindow::findOCVMWindowByName(char const *)" (?findOCVMWindowByName@BitmapWindow@@KAPEAV1@PEBD@Z) 中引用了该符号
opencv_highgui4120.lib(display_win32.cpp.obj) : error LNK2019: 无法解析的外部符号 __imp_LoadCursorA，函数 "public: bool __cdecl SimpleWindow::create(char const *,unsigned long,int,int,int,int,struct HWND__ *,unsigned long,struct HMENU__ *,void *)" (?create@SimpleWindow@@QEAA_NPEBDKHHHHPEAUHWND__@@KPEAUHMENU__@@PEAX@Z) 中引用了该符号
build\windows\x64\release\test_recognizer.exe : fatal error LNK1120: 40 个无法解析的外部命令
```