### PR TITLE
Auto-update faker-cxx to v4.1.0

### DIFF
--- a/packages/f/faker-cxx/xmake.lua
+++ b/packages/f/faker-cxx/xmake.lua
@@ -6,6 +6,7 @@ package("faker-cxx")
     add_urls("https://github.com/cieslarmichal/faker-cxx/archive/refs/tags/$(version).tar.gz",
              "https://github.com/cieslarmichal/faker-cxx.git", {submodules = false})
 
+    add_versions("v4.1.0", "e5b8d4b77d82947652d1a1b282573491208ed71b35c2d875084994486962b0fe")
     add_versions("v4.0.1", "ebeac25780878905d0e73cd6a5211bd0b5ce065d06961570f0de7f1a25ec7d9d")
     add_versions("v3.0.0", "63d6846376593e05da690136cabe8e7bf42ddcdd4edad3ae9b48696f86d80468")
     add_versions("v2.0.0", "8a7f5441f4453af868444675878a2d9a74918c1595caa65d537d3ea327e46a49")


### PR DESCRIPTION
New version of faker-cxx detected (package version: v4.0.1, last github version: v4.1.0)