### PR TITLE
Auto-update yalantinglibs to 0.5.7

### DIFF
--- a/packages/y/yalantinglibs/xmake.lua
+++ b/packages/y/yalantinglibs/xmake.lua
@@ -7,6 +7,7 @@ package("yalantinglibs")
     set_urls("https://github.com/alibaba/yalantinglibs/archive/refs/tags/$(version).tar.gz",
              "https://github.com/alibaba/yalantinglibs.git")
 
+    add_versions("0.5.7", "1c1057289e5488f90dd326fd2bb9d3173bad11eb5b06bc0a8bf0fa80857e1cfa")
     add_versions("0.5.6", "b2656f794af30c5b83952b7c73c2dabf949061ddb6284d18d7f0c0560244b35a")
     add_versions("0.5.5", "7962579c1414d1ade4fd22316476723d54112c919514bf1e6015a1870e5e68f7")
     add_versions("0.5.3", "9d24612975d38fa4b4a05bd9f8f5cb65d447365e5eb3661d0eba9701d383523a")


### PR DESCRIPTION
New version of yalantinglibs detected (package version: 0.5.6, last github version: 0.5.7)