### PR TITLE
test.lua: replace "--vs_runtime" with "--runtimes"

### DIFF
--- a/scripts/test.lua
+++ b/scripts/test.lua
@@ -94,11 +94,7 @@ function _config_packages(argv, packages)
     end
     local runtimes = argv.runtimes or argv.vs_runtime
     if runtimes then
-        if is_host("windows") then
-            table.insert(config_argv, "--vs_runtime=" .. runtimes)
-        else
-            table.insert(config_argv, "--runtimes=" .. runtimes)
-        end
+        table.insert(config_argv, "--runtimes=" .. runtimes)
     end
     if argv.xcode_sdkver then
         table.insert(config_argv, "--xcode_sdkver=" .. argv.xcode_sdkver)


### PR DESCRIPTION
Fix the annoying warning:

<img width="467" height="118" alt="image" src="https://github.com/user-attachments/assets/20cf5d2c-2fe6-4288-95e1-404831c51f60" />

<img width="520" height="113" alt="image" src="https://github.com/user-attachments/assets/0709f134-10a0-4982-97f4-d02784c2473e" />


