### PR TITLE
Auto-update daw_header_libraries to v2.132.1

### DIFF
--- a/packages/d/daw_header_libraries/xmake.lua
+++ b/packages/d/daw_header_libraries/xmake.lua
@@ -7,6 +7,7 @@ package("daw_header_libraries")
     add_urls("https://github.com/beached/header_libraries/archive/refs/tags/$(version).tar.gz",
              "https://github.com/beached/header_libraries.git")
 
+    add_versions("v2.132.1", "20bbb68aceb569810f7000fc804e205b32b06072dacdf10fc18c3d448bbd3ff6")
     add_versions("v2.131.0", "b28317b02383c4659b2a6687bc9b1a85c4ce4e1b1686fcb19af2ba2f5a855563")
     add_versions("v2.123.2", "d8cdccdf5516e4afb5307bc286a1feb1521e570a72a8bc0be7cbca6036fa55d8")
     add_versions("v2.118.0", "2a3e093c2f69db979e7672d33b97f7f24cda23ff753fafe90a3aaf25ac965a70")


### PR DESCRIPTION
New version of daw_header_libraries detected (package version: v2.131.0, last github version: v2.132.1)