### PR TITLE
Auto-update librealsense to v2.57.5

### DIFF
--- a/packages/l/librealsense/xmake.lua
+++ b/packages/l/librealsense/xmake.lua
@@ -6,6 +6,7 @@ package("librealsense")
     add_urls("https://github.com/IntelRealSense/librealsense/archive/refs/tags/$(version).tar.gz",
              "https://github.com/IntelRealSense/librealsense.git", {submodules = false})
 
+    add_versions("v2.57.5", "6fe337090becb668289178b20dfce07d553d4a71fd54ffbfee18b45847bcdee4")
     add_versions("v2.57.4", "3e82f9b545d9345fd544bb65f8bf7943969fb40bcfc73d983e7c2ffcdc05eaeb")
 
     add_patches(">=2.57.3", "patches/2.57.3/missing-headers.patch", "13834e38528e5009cdffc653515602f32a72e042497457c424de684ff5c69723")


### PR DESCRIPTION
New version of librealsense detected (package version: v2.57.4, last github version: v2.57.5)