### PR TITLE
Auto-update vk-bootstrap to v1.4.336

### DIFF
--- a/packages/v/vk-bootstrap/xmake.lua
+++ b/packages/v/vk-bootstrap/xmake.lua
@@ -6,6 +6,7 @@ package("vk-bootstrap")
     add_urls("https://github.com/charles-lunarg/vk-bootstrap/archive/refs/tags/$(version).tar.gz",
              "https://github.com/charles-lunarg/vk-bootstrap.git")
 
+    add_versions("v1.4.336", "94fc0aebf5ce47a37998c443595766e76b93d92c48739d42b72640c2040b8eaf")
     add_versions("v1.4.325", "d9d69fb8f9716830ee71bd4a6bd096a6b46b966b5c81eb0a47f3b67cfb3572e1")
     add_versions("v1.4.315", "f28595b057e10033cc6b64319e76be4eeda5b7c9ee83cc1808218e69b040f353")
     add_versions("v1.4.312", "9bc21aea86859329e9939d4d44f40ef4ce9e2208a3fdd9cb67e2d2f0f2393814")


### PR DESCRIPTION
New version of vk-bootstrap detected (package version: v1.4.325, last github version: v1.4.336)