### PR TITLE
Auto-update immer to v0.9.0

### DIFF
--- a/packages/i/immer/xmake.lua
+++ b/packages/i/immer/xmake.lua
@@ -7,6 +7,7 @@ package("immer")
 
     add_urls("https://github.com/arximboldi/immer/archive/refs/tags/$(version).tar.gz",
              "https://github.com/arximboldi/immer.git")
+    add_versions("v0.9.0", "4e9f9a9018ac6c12f5fa92540feeedffb0a0a7db0de98c07ee62688cc329085a")
     add_versions("v0.8.0", "4ed9e86a525f293e0ba053107b937d88b032674ec6e5db958816f2e412677fde")
     add_versions("v0.8.1", "de8411c84830864604bb685dc8f2e3c0dbdc40b95b2f6726092f7dcc85e75209")
 


### PR DESCRIPTION
New version of immer detected (package version: v0.8.1, last github version: v0.9.0)