### PR TITLE
Auto-update re2c to 4.4

### DIFF
--- a/packages/r/re2c/xmake.lua
+++ b/packages/r/re2c/xmake.lua
@@ -7,6 +7,7 @@ package("re2c")
     add_urls("https://github.com/skvadrik/re2c/archive/refs/tags/$(version).tar.gz",
              "https://github.com/skvadrik/re2c.git", {submodules = false})
 
+    add_versions("4.4", "490a9f3a733c3b56f52067ceddc9b7a53065a55e3945f6dd1770012d97c25acd")
     add_versions("4.3.1", "6963eabb99eb6ca1dd0ee37a9fa6900778c998f99f46b5ba746076d16d78300f")
     add_versions("4.3", "39cd7048a817cf3d7d0c2e58a52fb3597d6e1bc86b1df32b8a3cd755c458adfd")
     add_versions("4.2", "01b56c67ca2d5054b1aafc41ef5c15c50fbb6a7e760b1b2346e6116ef039525e")


### PR DESCRIPTION
New version of re2c detected (package version: 4.3.1, last github version: 4.4)