### PR TITLE
Auto-update liboqs to 0.15.0

### DIFF
--- a/packages/l/liboqs/xmake.lua
+++ b/packages/l/liboqs/xmake.lua
@@ -6,6 +6,7 @@ package("liboqs")
     add_urls("https://github.com/open-quantum-safe/liboqs/archive/refs/tags/$(version).tar.gz",
              "https://github.com/open-quantum-safe/liboqs.git")
 
+    add_versions("0.15.0", "3983f7cd1247f37fb76a040e6fd684894d44a84cecdcfbdb90559b3216684b5c")
     add_versions("0.14.0", "5b0df6138763b3fc4e385d58dbb2ee7c7c508a64a413d76a917529e3a9a207ea")
     add_versions("0.13.0", "789e9b56bcb6b582467ccaf5cdb5ab85236b0c1007d30c606798fa8905152887")
     add_versions("0.12.0", "df999915204eb1eba311d89e83d1edd3a514d5a07374745d6a9e5b2dd0d59c08")


### PR DESCRIPTION
New version of liboqs detected (package version: 0.14.0, last github version: 0.15.0)