### PR TITLE
Auto-update ncnn to 20250916

### DIFF
--- a/packages/n/ncnn/xmake.lua
+++ b/packages/n/ncnn/xmake.lua
@@ -13,6 +13,7 @@ package("ncnn")
         end
     })
 
+    add_versions("20250916", "7d463f1e5061facd02b8af5e792e059088695cdcfcc152c8f4892f6ffe5eab1a")
     add_versions("2025.09.16", "7d463f1e5061facd02b8af5e792e059088695cdcfcc152c8f4892f6ffe5eab1a")
     add_versions("2025.05.03", "3afea4cf092ce97d06305b72c6affbcfb3530f536ae8e81a4f22007d82b729e9")
 


### PR DESCRIPTION
New version of ncnn detected (package version: 2025.09.16, last github version: 20250916)