### PR TITLE
Auto-update pdfio to v1.6.1

### DIFF
--- a/packages/p/pdfio/xmake.lua
+++ b/packages/p/pdfio/xmake.lua
@@ -6,6 +6,7 @@ package("pdfio")
     add_urls("https://github.com/michaelrsweet/pdfio/archive/refs/tags/$(version).tar.gz",
              "https://github.com/michaelrsweet/pdfio.git")
 
+    add_versions("v1.6.1", "de733aad5d5b2d8199667ca28efe01fce17e00743ba021f88303c8a81a5eaa67")
     add_versions("v1.5.0", "895cfa22a895d0afc69a18402f19057ddaf8f035cc0a69f3f2a4cbe55ead9662")
     add_versions("v1.4.0", "c3657cca203801dc111fd41919979068a876473e1ba2c849c7d130c0d4a7ed89")
     add_versions("v1.3.2", "a814fd10e602ffcc9e243674c82268a097992b1c4ad1359d9ab236c56b648b71")


### PR DESCRIPTION
New version of pdfio detected (package version: v1.5.0, last github version: v1.6.1)