### PR TITLE
Auto-update meshoptimizer to v1.0.1

### DIFF
--- a/packages/m/meshoptimizer/xmake.lua
+++ b/packages/m/meshoptimizer/xmake.lua
@@ -6,6 +6,7 @@ package("meshoptimizer")
     add_urls("https://github.com/zeux/meshoptimizer/archive/refs/tags/$(version).tar.gz",
              "https://github.com/zeux/meshoptimizer.git")
 
+    add_versions("v1.0.1", "9579624541e27e1cd01379c87e1295407e72c49e4b5b3e2f948393f3b68258ac")
     add_versions("v1.0", "30d1c3651986b2074e847b17223a7269c9612ab7f148b944250f81214fed4993")
     add_versions("v0.25", "68b2fef4e4eaad98e00c657c1e7f8982a7176e61dd7efdeaec67a025b8519be9")
     add_versions("v0.24", "af5f6bc410e2df9f0f80dce1f1d77ff55f53dc08c17fdc07e58367b613c27603")


### PR DESCRIPTION
New version of meshoptimizer detected (package version: v1.0, last github version: v1.0.1)