### PR TITLE
Auto-update libfyaml to v0.9.2

### DIFF
--- a/packages/l/libfyaml/xmake.lua
+++ b/packages/l/libfyaml/xmake.lua
@@ -19,7 +19,7 @@ package("libfyaml")
         end)
     end
 
-    on_install("!windows and !mingw", function (package)
+    on_install("linux", "macosx", "android", "iphoneos", "cross", function (package)
         io.replace("CMakeLists.txt", "-fPIC", "", {plain = true})
 
         local configs = {"-DBUILD_TESTING=OFF", "-DENABLE_LIBCLANG=OFF"}


### PR DESCRIPTION
New version of libfyaml detected (package version: v0.9, last github version: v0.9.2)