### PR TITLE
Auto-update libraw to 0.21.5

### DIFF
--- a/packages/l/libraw/xmake.lua
+++ b/packages/l/libraw/xmake.lua
@@ -6,6 +6,7 @@ package("libraw")
     add_urls("https://github.com/LibRaw/LibRaw/archive/refs/tags/$(version).tar.gz",
              "https://github.com/LibRaw/LibRaw.git")
 
+    add_versions("0.21.5", "4b7f183a68f6e46e579e80ba32ab121687e75bd30a2e5566f34c36a6bcba1679")
     add_versions("0.21.4", "8baeb5253c746441fadad62e9c5c43ff4e414e41b0c45d6dcabccb542b2dff4b")
     add_versions("0.20.2", "dc1b486c2003435733043e4e05273477326e51c3ea554c6864a4eafaff1004a6")
     add_versions("0.19.5", "9a2a40418e4fb0ab908f6d384ff6f9075f4431f8e3d79a0e44e5a6ea9e75abdc")


### PR DESCRIPTION
New version of libraw detected (package version: 0.21.4, last github version: 0.21.5)