### PR TITLE
Auto-update cppcheck to 2.19.1

### DIFF
--- a/packages/c/cppcheck/xmake.lua
+++ b/packages/c/cppcheck/xmake.lua
@@ -4,6 +4,7 @@ package("cppcheck")
     set_description("A static analysis tool for C/C++ code")
 
     add_urls("https://github.com/danmar/cppcheck/archive/refs/tags/$(version).tar.gz")
+    add_versions("2.19.1", "49bdf1d7826d60053575b78d3192d81d54970dbfb356590f7476de250b1a4234")
     add_versions("2.18.3", "e37c94e190cdddc65682649b02b72939761585bddd8ada595f922e190a26a2be")
     add_versions("2.18.1", "528841c0f00de5ed41428269df7a30b102af0b1f8ad50f5b7d4ee2997b54c04c")
     add_versions("2.18.0", "dc74e300ac59f2ef9f9c05c21d48ae4c8dd1ce17f08914dd30c738ff482e748f")


### PR DESCRIPTION
New version of cppcheck detected (package version: 2.18.3, last github version: 2.19.1)