### PR TITLE
Auto-update watcher to 0.14.3

### DIFF
--- a/packages/w/watcher/xmake.lua
+++ b/packages/w/watcher/xmake.lua
@@ -7,6 +7,7 @@ package("watcher")
     set_urls("https://github.com/e-dant/watcher/archive/refs/tags/release/$(version).tar.gz",
              "https://github.com/e-dant/watcher.git")
 
+    add_versions("0.14.3", "ada4dd30bddc78b49f112b0310e4964710c8dcf8a16966c8e958f75bb7abde5e")
     add_versions("0.13.8", "ca415bb6e63012bb92543c2a0c76aec347fb36df48d6c1af8538018dd6584e06")
     add_versions("0.13.6", "b58b3a9f91d96d90080fd56cd998b1649633c43f92fc1bfe5562a000db472016")
     add_versions("0.13.5", "5bb0ea65b94d9444a6853eacff3a9b2121f0415d0ac895388d241f6f8be1e695")


### PR DESCRIPTION
New version of watcher detected (package version: 0.13.8, last github version: 0.14.3)