### PR TITLE
Auto-update aws-checksums to v0.2.8

### DIFF
--- a/packages/a/aws-checksums/xmake.lua
+++ b/packages/a/aws-checksums/xmake.lua
@@ -6,6 +6,7 @@ package("aws-checksums")
     add_urls("https://github.com/awslabs/aws-checksums/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-checksums.git")
 
+    add_versions("v0.2.8", "e624754cc57e0da28e643e89fc76bcc86cb0c359ead0745bae643f910b2bcfa7")
     add_versions("v0.2.7", "178e8398d98111f29150f7813a70c20ad97ab30be0de02525440355fe84ccb1d")
     add_versions("v0.2.3", "c688f311db8a1b70bb6d22f6e8f2817b39e1419546e339cf753d61340969eeb4")
     add_versions("v0.2.2", "96acfea882c06acd5571c845e4968892d6ffc0fae81b31a0b1565100049743b2")


### PR DESCRIPTION
New version of aws-checksums detected (package version: v0.2.7, last github version: v0.2.8)