### PR TITLE
Auto-update tracy to v0.13.1

### DIFF
--- a/packages/t/tracy/xmake.lua
+++ b/packages/t/tracy/xmake.lua
@@ -56,6 +56,15 @@ package("tracy")
         add_syslinks("pthread", "execinfo")
     end
 
+    if on_check then
+        on_check("android", function (package)
+            if package:version() and package:version():eq("v0.13.1") then
+                local ndk = package:toolchain("ndk"):config("ndkver")
+                assert(ndk and tonumber(ndk) > 22, "package(tracy v0.13.1) require ndk version > 22")
+            end
+        end)
+    end
+
     on_load(function (package)
         if package:config("cmake") then
             package:add("deps", "cmake")


### PR DESCRIPTION
New version of tracy detected (package version: v0.13.0, last github version: v0.13.1)