### PR TITLE
Auto-update vcpkg to 2025.12.12

### DIFF
--- a/packages/v/vcpkg/xmake.lua
+++ b/packages/v/vcpkg/xmake.lua
@@ -5,6 +5,7 @@ package("vcpkg")
     set_license("MIT")
 
     add_urls("https://github.com/microsoft/vcpkg/archive/refs/tags/$(version).tar.gz")
+    add_versions("2025.12.12", "fd3aedfae4d80fc9af5b2c4598ccc697586c7fda52e77c9a993f2ec2b4622d98")
     add_versions("2025.10.17", "bcbae273e5a589c5722178bcfa1787e7177a2c9938db82fb57e9675be9924e62")
     add_versions("2025.07.25", "dff617c636a6519d4f083e658d404970c9da7d940a974e1d17f855f26a334e2f")
     add_versions("2024.11.16", "ec932ad758fb2b3aefc0d712d4bde8d913cd97ad2a0067d52f23d05c31b42aa0")


### PR DESCRIPTION
New version of vcpkg detected (package version: 2025.10.17, last github version: 2025.12.12)