### PR TITLE
Auto-update libxmake to v3.0.6

### DIFF
--- a/packages/l/libxmake/xmake.lua
+++ b/packages/l/libxmake/xmake.lua
@@ -7,6 +7,7 @@ package("libxmake")
              "https://github.com/xmake-io/xmake.git",
              "https://gitlab.com/tboox/xmake.git")
 
+    add_versions("v3.0.6", "1f7bd9ab7f7cbeade4ecd81f3580898e8d78aa5f64cea44239a9506ff41bc397")
     add_versions("v3.0.5", "b947666281222f79e082283b6f84e68880c499305890f6ab8b03b8bac82456dc")
     add_versions("v3.0.4", "b6968dbe266029987bee0a389175f8898042c0bd38f279befc40adaf8e67ce04")
     add_versions("v3.0.3", "49d70671f40f28a1d8125df1a2b318cbd44608a26fa3c60587be3a5ad835b0fb")


### PR DESCRIPTION
New version of libxmake detected (package version: v3.0.5, last github version: v3.0.6)