### PR TITLE
Auto-update sqlgen to v0.6.0

### DIFF
--- a/packages/s/sqlgen/xmake.lua
+++ b/packages/s/sqlgen/xmake.lua
@@ -6,6 +6,7 @@ package("sqlgen")
     add_urls("https://github.com/getml/sqlgen/archive/refs/tags/$(version).tar.gz",
              "https://github.com/getml/sqlgen.git")
 
+    add_versions("v0.6.0", "a872fdcbca290f0dd0e57905e032d676b0c1911b307573e9183d6fa5f37c21f2")
     add_versions("v0.2.0", "c093036ebdf2aaf1003b2d1623713b97106ed43b1d39dc3d4f38e381f371799e")
 
     add_patches("0.2.0", "patches/0.2.0/cmake.patch", "e9819b9a8a2c8f8a5b6c553eac3bb10fc65856aa9af451f83e2dbf55ca6c66c0")


### PR DESCRIPTION
New version of sqlgen detected (package version: v0.2.0, last github version: v0.6.0)