### PR TITLE
add missing raylib wasm linker flags, add wasm support for raylib-cpp.

### DIFF
--- a/packages/r/raylib-cpp/xmake.lua
+++ b/packages/r/raylib-cpp/xmake.lua
@@ -13,7 +13,7 @@ package("raylib-cpp")
 
 	add_deps("raylib 5.x")
 
-    on_install("windows", "linux", "macosx", "mingw", "android", function (package)
+    on_install("windows", "linux", "macosx", "mingw", "wasm", "android", function (package)
         os.cp("include/*.hpp", package:installdir("include/raylib-cpp"))
     end)
 

--- a/packages/r/raylib/xmake.lua
+++ b/packages/r/raylib/xmake.lua
@@ -45,6 +45,8 @@ package("raylib")
     elseif is_plat("linux") then
         add_syslinks("pthread", "dl", "m")
         add_deps("libx11", "libxrandr", "libxrender", "libxinerama", "libxcursor", "libxi", "libxfixes", "libxext")
+    elseif is_plat("wasm") then
+        add_ldflags("-sUSE_GLFW=3", "-sASSERTIONS=1", "-sWASM=1", "-sASYNCIFY", "-sGL_ENABLE_GET_PROC_ADDRESS=1", {force = true})
     elseif is_plat("android") then
         add_syslinks("log", "android", "EGL", "GLESv2", "OpenSLES", "m")
     end


### PR DESCRIPTION
Current raylib lacks linker flags. Also, raylib-cpp doesn't have WASM support.

Following the [raylib wiki](https://github.com/raysan5/raylib/wiki/Working-for-Web-(HTML5)):
```
...but keep in mind that you also have to add some additional setting in your CMakeLists.txt for emscripten. For the linker to execute successfully it will need the GLFW symbols which cannot be built by you. Luckily emscripten provides those symbols when you add the "-s USE_GLFW=3" to your linker. To do so you can add these lines somewhere in the root of your CMakeLists.txt

if (EMSCRIPTEN)
    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s USE_GLFW=3 -s ASSERTIONS=1 -s WASM=1 -s ASYNCIFY -s GL_ENABLE_GET_PROC_ADDRESS=1")
    set(CMAKE_EXECUTABLE_SUFFIX ".html") # This line is used to set your executable to build with the emscripten html template so that you can directly open it.
endif ()
```
 I added essential linker flags. 
 
 I also added the missing "wasm" platform declaration for raylib-cpp.

