### PR TITLE
Auto-update google-cloud-cpp to v2.45.0

### DIFF
--- a/packages/g/google-cloud-cpp/xmake.lua
+++ b/packages/g/google-cloud-cpp/xmake.lua
@@ -6,6 +6,7 @@ package("google-cloud-cpp")
     add_urls("https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/googleapis/google-cloud-cpp.git")
 
+    add_versions("v2.45.0", "3d1b5eb696832f9071bf7ef0b3f0c9fd27c1a39d5edcb8a9976c65193319fd01")
     add_versions("v2.43.0", "2aea914128db8a550bd926e1e08c155fae1caff8a451e1b644602952dd6d8b5c")
     add_versions("v2.42.0", "699955112a4c57ae9111fbadeff1698674a1762acd77daf36360e6dfc227dc93")
     add_versions("v2.39.0", "629cbfcc5bd581d38277ba8fa94a5b6591af1e0f6af0dab6d1d9ed796bf48b61")


### PR DESCRIPTION
New version of google-cloud-cpp detected (package version: v2.43.0, last github version: v2.45.0)