### PR TITLE
Auto-update pocketpy to v2.1.6

### DIFF
--- a/packages/p/pocketpy/xmake.lua
+++ b/packages/p/pocketpy/xmake.lua
@@ -14,6 +14,7 @@ package("pocketpy")
     add_versions("v1.4.5", "144f63ed8a21fd2a65e252df53939f7af453d544eb35570603af319ce1af5a46")
     add_versions("v0.9.0", "0da63afb3ea4ebb8b686bfe33b4c7556c0a927cd98ccf3c7a3fb4aa216fbf30b")
 
+    add_resources("v2.1.6", "c", "https://github.com/pocketpy/pocketpy/releases/download/v2.1.6/pocketpy.c", "effd2aa317f2e1086b999d0e2f7d882fc6ff21dc23d9397f2082abbbc042e8f7")
     add_resources("v2.1.3", "c", "https://github.com/pocketpy/pocketpy/releases/download/v2.1.3/pocketpy.c", "ab4cbf3edd50dbbc5ca5a7ec7e7f2d001169541d9912330596400e0d34980d6b")
     add_resources("v2.1.1", "c", "https://github.com/pocketpy/pocketpy/releases/download/v2.1.1/pocketpy.c", "587a83977525e11616d1bae748ae80dc50960e567b8c000a9ca6610b20681623")
     add_resources("v2.0.8", "c", "https://github.com/pocketpy/pocketpy/releases/download/v2.0.8/pocketpy.c", "497f926dc270bfe1f9289db24068e596499c563aa8c946f63763a114c5d2bf5d")


### PR DESCRIPTION
New version of pocketpy detected (package version: v2.1.3, last github version: v2.1.6)