### PR TITLE
Auto-update simdutf to v8.0.0

### DIFF
--- a/packages/s/simdutf/xmake.lua
+++ b/packages/s/simdutf/xmake.lua
@@ -5,6 +5,7 @@ package("simdutf")
 
     add_urls("https://github.com/simdutf/simdutf/archive/refs/tags/$(version).tar.gz",
              "https://github.com/simdutf/simdutf.git")
+    add_versions("v8.0.0", "a21c34c52d91a229591e4ebc8822a876604cf2fffeac9ec065bfda7cbfb9d680")
     add_versions("v7.7.1", "3b119d55c47196f6310f5b7b300563e6f2789b7de352536809438a3de1eb4432")
     add_versions("v7.7.0", "0180de81a1dd48a87b8c0442ffa81734f3db91a7350914107a449935124e3c6f")
     add_versions("v7.5.0", "3cad2f554912ecd77222272e5d1a7c1e5e33b4011bee823269cdc9095d2fdce2")


### PR DESCRIPTION
New version of simdutf detected (package version: v7.7.1, last github version: v8.0.0)