### PR TITLE
Auto-update openjph to 0.26.0

### DIFF
--- a/packages/o/openjph/xmake.lua
+++ b/packages/o/openjph/xmake.lua
@@ -24,8 +24,14 @@ package("openjph")
     end
 
     on_install(function (package)
+        local ojph_header_path
+        if package:version():lt("0.26.0") then
+            ojph_header_path = "src/core/common"
+        else
+            ojph_header_path = "src/core/openjph"
+        end
         if package:is_plat("windows", "mingw") and package:config("shared") then
-            io.replace("src/core/common/ojph_arch.h", [[#else
+            io.replace(path.join(ojph_header_path, "ojph_arch.h"), [[#else
 #define OJPH_EXPORT
 #endif]], [[#else
 #define OJPH_EXPORT __declspec(dllimport)


### PR DESCRIPTION
New version of openjph detected (package version: 0.25.2, last github version: 0.26.0)