### PR TITLE
minizip-ng: Repair MinGW cross build Linux => Mingw. Change syslink from 'Bcrypt' to 'bcrypt'

### DIFF
--- a/packages/m/minizip-ng/xmake.lua
+++ b/packages/m/minizip-ng/xmake.lua
@@ -41,7 +41,7 @@ package("minizip-ng")
             if package:is_plat("macosx", "iphoneos") then
                 package:add("deps", "openssl")
             elseif package:is_plat("windows", "mingw") then
-                package:add("syslinks", "Bcrypt")
+                package:add("syslinks", "bcrypt")
             end
         end
         for name, enabled in pairs(package:configs()) do


### PR DESCRIPTION
This bug maybe affected by FFMPeg and gamenetworkingsockets

Fix
```
-- Installing: /home/lin/.xmake/packages/m/minizip-ng/4.0.10/65024def0ac446ffbfdae05a2ea1f085/lib/pkgconfig/minizip.pc
finding minizip-ng from xmake ..
checking for xmake::minizip-ng ... minizip-ng 4.0.10
{ 
  license = "zlib",
  libfiles = { 
    "/home/lin/.xmake/packages/m/minizip-ng/4.0.10/65024def0ac446ffbfdae05a2ea1f085/lib/libminizip.a" 
  },
  static = true,
  links = { 
    "minizip" 
  },
  syslinks = { 
    "crypt32",
    "advapi32",
    "Bcrypt" 
  },
  linkdirs = { 
    "/home/lin/.xmake/packages/m/minizip-ng/4.0.10/65024def0ac446ffbfdae05a2ea1f085/lib" 
  },
  sysincludedirs = { 
    "/home/lin/.xmake/packages/m/minizip-ng/4.0.10/65024def0ac446ffbfdae05a2ea1f085/include" 
  },
  version = "4.0.10" 
}

> /usr/bin/x86_64-w64-mingw32-gcc -c -m64 -isystem /home/lin/.xmake/packages/m/minizip-ng/4.0.10/65024def0ac446ffbfdae05a2ea1f085/include -isystem /home/lin/.xmake/packages/z/zlib/v1.3.1/c7c23c5e1518475f91a7172443771802/include -o /tmp/.xmake1000/260115/_77b482b4c57decc5abce35903aad4ac7.o /tmp/.xmake1000/260115/_f7ce7d57586abb8bfdc021df636bca14.c
checking for /usr/bin/x86_64-w64-mingw32-gcc ... ok
checking for flags (-fdiagnostics-color=always) ... ok
> x86_64-w64-mingw32-gcc "-fdiagnostics-color=always" "-m64"
checking for flags (-Wno-gnu-line-marker -Werror) ... ok
> x86_64-w64-mingw32-gcc "-Wno-gnu-line-marker" "-Werror" "-m64"
> /usr/bin/x86_64-w64-mingw32-g++ -o /tmp/.xmake1000/260115/_77b482b4c57decc5abce35903aad4ac7.b /tmp/.xmake1000/260115/_77b482b4c57decc5abce35903aad4ac7.o -m64 -L/home/lin/.xmake/packages/m/minizip-ng/4.0.10/65024def0ac446ffbfdae05a2ea1f085/lib -L/home/lin/.xmake/packages/z/zlib/v1.3.1/c7c23c5e1518475f91a7172443771802/lib -lminizip -lz -lcrypt32 -ladvapi32 -lBcrypt
/usr/lib/gcc/x86_64-w64-mingw32/15.2.0/../../../../x86_64-w64-mingw32/bin/ld: cannot find -lBcrypt: No such file or directory
collect2: error: ld returned 1 exit status
> checking for c includes(minizip/mz.h, minizip/zip.h)
> checking for c funcs(zipOpen)
> checking for c links(minizip, z, crypt32, advapi32, Bcrypt)
> checking for c snippet(has_cfuncs)
checkinfo: ...gramdir/core/sandbox/modules/import/core/tool/linker.lua:75: @programdir/core/sandbox/modules/os.lua:378: execv(/usr/bin/x86_64-w64-mingw32-g++ -o /tmp/.xmake1000/260115/_77b482b4c57decc5abce35903aad4ac7.b /tmp/.xmake1000/260115/_77b482b4c57decc5abce35903aad4ac7.o -m64 -L/home/lin/.xmake/packages/m/minizip-ng/4.0.10/65024def0ac446ffbfdae05a2ea1f085/lib -L/home/lin/.xmake/packages/z/zlib/v1.3.1/c7c23c5e1518475f91a7172443771802/lib -lminizip -lz -lcrypt32 -ladvapi32 -lBcrypt) failed(1)
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:1125]:
    [@programdir/core/sandbox/modules/os.lua:378]: in function 'execv'
    [@programdir/modules/core/tools/gcc.lua:965]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:258]:
    [@programdir/core/tool/linker.lua:234]: in function 'link'
    [...gramdir/core/sandbox/modules/import/core/tool/linker.lua:73]: in function 'link'
    [@programdir/modules/lib/detect/check_cxsnippets.lua:249]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:258]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [@programdir/modules/lib/detect/check_cxsnippets.lua:237]:
    [/home/lin/xmake-repo/packages/m/minizip-ng/xmake.lua:91]: in function 'script'
    [...dir/modules/private/action/require/impl/utils/filter.lua:114]: in function 'call'
    [...dir/modules/private/action/require/impl/actions/test.lua:41]:
    [.../modules/private/action/require/impl/actions/install.lua:523]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:258]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [.../modules/private/action/require/impl/actions/install.lua:447]:
    [...modules/private/action/require/impl/install_packages.lua:514]: in function 'job_func'
    [@programdir/modules/async/runjobs.lua:441]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:258]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [@programdir/modules/async/runjobs.lua:410]: in function 'cotask'
    [@programdir/core/base/scheduler.lua:514]:

error: /home/lin/xmake-repo/packages/m/minizip-ng/xmake.lua:91: ...gramdir/core/sandbox/modules/import/core/tool/linker.lua:75: @programdir/core/sandbox/modules/os.lua:378: execv(/usr/bin/x86_64-w64-mingw32-g++ -o /tmp/.xmake1000/260115/_77b482b4c57decc5abce35903aad4ac7.b /tmp/.xmake1000/260115/_77b482b4c57decc5abce35903aad4ac7.o -m64 -L/home/lin/.xmake/packages/m/minizip-ng/4.0.10/65024def0ac446ffbfdae05a2ea1f085/lib -L/home/lin/.xmake/packages/z/zlib/v1.3.1/c7c23c5e1518475f91a7172443771802/lib -lminizip -lz -lcrypt32 -ladvapi32 -lBcrypt) failed(1)
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:1125]:
    [@programdir/core/sandbox/modules/os.lua:378]: in function 'execv'
    [@programdir/modules/core/tools/gcc.lua:965]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:258]:
    [@programdir/core/tool/linker.lua:234]: in function 'link'
    [...gramdir/core/sandbox/modules/import/core/tool/linker.lua:73]: in function 'link'
    [@programdir/modules/lib/detect/check_cxsnippets.lua:249]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:258]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [@programdir/modules/lib/detect/check_cxsnippets.lua:237]:
    [/home/lin/xmake-repo/packages/m/minizip-ng/xmake.lua:91]: in function 'script'
    [...dir/modules/private/action/require/impl/utils/filter.lua:114]: in function 'call'
    [...dir/modules/private/action/require/impl/actions/test.lua:41]:
    [.../modules/private/action/require/impl/actions/install.lua:523]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:258]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [.../modules/private/action/require/impl/actions/install.lua:447]:
    [...modules/private/action/require/impl/install_packages.lua:514]: in function 'job_func'
    [@programdir/modules/async/runjobs.lua:441]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:258]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [@programdir/modules/async/runjobs.lua:410]: in function 'cotask'
    [@programdir/core/base/scheduler.lua:514]:

  => install minizip-ng 4.0.10 .. failed
error: @programdir/core/main.lua:274: @programdir/modules/async/runjobs.lua:261: .../modules/private/action/require/impl/actions/install.lua:592: install failed!
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:1125]:
    [.../modules/private/action/require/impl/actions/install.lua:592]: in function 'catch'
    [@programdir/core/sandbox/modules/try.lua:123]: in function 'try'
    [.../modules/private/action/require/impl/actions/install.lua:447]:
    [...modules/private/action/require/impl/install_packages.lua:514]: in function 'job_func'
    [@programdir/modules/async/runjobs.lua:441]:

stack traceback:
        [C]: in function 'error'
        @programdir/core/base/os.lua:1125: in function 'os.raiselevel'
        (...tail calls...)
        @programdir/core/main.lua:274: in upvalue 'cotask'
        @programdir/core/base/scheduler.lua:514: in function <@programdir/core/base/scheduler.lua:507>
error: execv(/usr/bin/xmake require -f -y --build -v -D --shallow --extra={configs={shared=false}} minizip-ng) failed(255)
```
