### PR TITLE
slikenet: Fix cross Linux => MinGW build

### DIFF
--- a/packages/s/slikenet/xmake.lua
+++ b/packages/s/slikenet/xmake.lua
@@ -34,7 +34,7 @@ package("slikenet")
     end)
 
     on_install(function (package)
-        io.replace("CMakeLists.txt", "ws2_32.lib", "iphlpapi ws2_32", {plain = true})
+        io.replace("CMakeLists.txt", "ws2_32.lib", "iphlpapi ws2_32 winmm", {plain = true})
         io.replace("Source/include/slikenet/WindowsIncludes.h", [[#include <IPHlpApi.h>]], [[#include <iphlpapi.h>]], {plain = true})
         io.replace("Source/include/slikenet/WindowsIncludes.h", [[#pragma comment(lib, "IPHLPAPI.lib")]], [[]], {plain = true})
         io.replace("Source/src/GetTime.cpp", [[#pragma comment(lib, "Winmm.lib")]], [[]], {plain = true})


### PR DESCRIPTION
It is unable to find **IPHlpApi.h**, as so lowercasing resolves this issue. Additionally I removed .lib postfix for libs, as MinGW uses .a as file ext for libs.

well finally I would build at least some usage case of **floatengine**

https://github.com/xmake-io/xmake-repo/issues/8877

repo: https://github.com/Fls-Float/MineSweeper

`wine /home/lin/MineSweeper/build/mingw/x86_64/release/MineSweeper.exe`

<img width="659" height="498" alt="image" src="https://github.com/user-attachments/assets/1258063b-dce2-45f7-a289-2b997db738f7" />

<img width="643" height="488" alt="image" src="https://github.com/user-attachments/assets/2891104e-a80e-4a70-aeb3-f85c64ba9e64" />

<img width="653" height="487" alt="image" src="https://github.com/user-attachments/assets/974e90a8-6755-4f53-af6e-7ed42d14baad" />


```lua
set_languages("c11", "c++17")
add_rules("mode.release", "mode.debug")

add_requires("floatengine")

target("MineSweeper")
    set_kind("binary")
    add_packages("floatengine")
    add_files("扫雷/main.cpp", "扫雷/MineSweeper.cpp")
    add_headerfiles("扫雷/MineSweeper.h")
    add_includedirs("扫雷", {public = true})

    if is_plat("mingw") then
        add_ldflags("-static", {force = true})
    end
```