### PR TITLE
Auto-update csfml to 3.0.0

### DIFF
--- a/packages/c/csfml/xmake.lua
+++ b/packages/c/csfml/xmake.lua
@@ -92,7 +92,7 @@ package("csfml")
         end
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-        import("package.tools.cmake").install(package, configs)
+        import("package.tools.cmake").install(package, configs, {packagedeps = "zlib"})
     end)
 
     on_test(function (package)


### PR DESCRIPTION
New version of csfml detected (package version: 2.6.1, last github version: 3.0.0)