### PR TITLE
Auto-update miniaudio to 0.11.24

### DIFF
--- a/packages/m/miniaudio/xmake.lua
+++ b/packages/m/miniaudio/xmake.lua
@@ -5,6 +5,7 @@ package("miniaudio")
 
     set_urls("https://github.com/mackron/miniaudio/archive/refs/tags/$(version).tar.gz",
              "https://github.com/mackron/miniaudio.git")
+    add_versions("0.11.24", "3fdeb62a9387a3164e901475c663f5ab5c8318de268fd2c64af937c6a65980bd")
     add_versions("0.11.23", "1062155cc5882b55c48cb37f57a4dc783669e83ae0838535c62b206eeb1587a6")
     add_versions("0.11.22", "bcb07bfb27e6fa94d34da73ba2d5642d4940b208ec2a660dbf4e52e6b7cd492f")
     add_versions("0.11.21", "6afb5c231613d2fab4f1c668b7243ff9a7d6d78a7f5a2692c133f026fe508506")


### PR DESCRIPTION
New version of miniaudio detected (package version: 0.11.23, last github version: 0.11.24)