### PR TITLE
Auto-update efsw to 1.5.1

### DIFF
--- a/packages/e/efsw/xmake.lua
+++ b/packages/e/efsw/xmake.lua
@@ -5,6 +5,7 @@ package("efsw")
 
     set_urls("https://github.com/SpartanJ/efsw/archive/refs/tags/$(version).tar.gz",
              "https://github.com/SpartanJ/efsw.git")
+    add_versions("1.5.1", "403691e15b48dc0e67e7d3fe6e6aa3d116bc8420790df93d1d90d2cecaa06e70")
     add_versions("1.5.0", "20421778fd59a845393ff6a7a1f461228574fe5062b1bf5f82d533c0d25a41bd")
     add_versions("1.4.1", "f0ddee587928737c6a3dc92eb88266a804c77279cbdf29d47e5e6f6ad6c7fd9a")
     add_versions("1.4.0", "9eed5fc8471767faa44134f5379d4de02825e3756007dafa482fd1656e42bc4a")


### PR DESCRIPTION
New version of efsw detected (package version: 1.5.0, last github version: 1.5.1)