### PR TITLE
Auto-update xgrammar to v0.1.31

### DIFF
--- a/packages/x/xgrammar/xmake.lua
+++ b/packages/x/xgrammar/xmake.lua
@@ -5,6 +5,7 @@ package("xgrammar")
 
     add_urls("https://github.com/mlc-ai/xgrammar/archive/refs/tags/$(version).tar.gz",
              "https://github.com/mlc-ai/xgrammar.git")
+    add_versions("v0.1.31", "f250b421c444b8a94a68bbcab8638354b0c141f4719c1c2ee80d729bc649cab3")
     add_versions("v0.1.29", "46bf72bf92f17305218ad9a0cfbc6e317646de31f22131e3bc5462a0681914a3")
     add_versions("v0.1.27", "44c11de70e7bfed0dd856459ad08dfa9cb884959948165c5f4bb072cbb63e980")
     add_versions("v0.1.26", "e6e524e8fbdcc7970a93892e8ab2fe2769450006deb0dacf612139d5dee52976")


### PR DESCRIPTION
New version of xgrammar detected (package version: v0.1.29, last github version: v0.1.31)