### PR TITLE
Auto-update steam-audio to v4.8.0

### DIFF
--- a/packages/s/steam-audio/xmake.lua
+++ b/packages/s/steam-audio/xmake.lua
@@ -30,7 +30,7 @@ package("steam-audio")
     end
 
     on_check(function (package)
-        if package:version() and package:version():eq("4.7.0") and package:has_tool("cxx", "clang") then
+        if package:version() and package:version():ge("4.7.0") and package:has_tool("cxx", "clang") then
             raise("package(steam-audio >=4.7.0) unsupported clang")
         end
     end)


### PR DESCRIPTION
New version of steam-audio detected (package version: v4.7.0, last github version: v4.8.0)