### PR TITLE
sqlgen: fix build

### DIFF
--- a/packages/d/duckdb/xmake.lua
+++ b/packages/d/duckdb/xmake.lua
@@ -22,14 +22,16 @@ package("duckdb")
     add_versions("v0.10.0", "385e27aa67712813e4a07389465c4c5c45c431d97cddd35713b8a306d2a86f2d")
 
     on_install("macosx", "linux", function (package)
-        io.writefile("xmake.lua", [[
+        io.writefile("xmake.lua", string.format([[
             add_rules("mode.debug", "mode.release")
+            add_rules("utils.install.cmake_importfiles")
+            set_version("%s")
             set_languages("c++17")
             target("duckdb")
                 set_kind("$(kind)")
                 add_files("duckdb.cpp")
                 add_headerfiles("duckdb.hpp", "duckdb.h")
-        ]])
+        ]], package:version()))
         import("package.tools.xmake").install(package)
     end)
 

--- a/packages/s/sqlgen/patches/0.6.0/cmake.patch
+++ b/packages/s/sqlgen/patches/0.6.0/cmake.patch
@@ -1,7 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0b9b367..9429588 100644
+index 0b9b367..3bac799 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -99,7 +99,7 @@ target_include_directories(
+ if (SQLGEN_DUCKDB OR SQLGEN_CHECK_HEADERS)
+     list(APPEND SQLGEN_SOURCES src/sqlgen_duckdb.cpp)
+     if (NOT TARGET DuckDB)
+-        find_package(DuckDB REQUIRED)
++        find_package(duckdb REQUIRED)
+     endif()
+-    target_link_libraries(sqlgen PUBLIC $<IF:$<TARGET_EXISTS:duckdb>,duckdb,duckdb_static>)
++    target_link_libraries(sqlgen PUBLIC duckdb::duckdb)
+ endif()
 @@ -137,8 +137,8 @@ if (SQLGEN_SQLITE3 OR SQLGEN_CHECK_HEADERS)
          endif()
          target_link_libraries(sqlgen PUBLIC unofficial::sqlite3::sqlite3)

--- a/packages/s/sqlgen/xmake.lua
+++ b/packages/s/sqlgen/xmake.lua
@@ -9,7 +9,7 @@ package("sqlgen")
     add_versions("v0.6.0", "a872fdcbca290f0dd0e57905e032d676b0c1911b307573e9183d6fa5f37c21f2")
     add_versions("v0.2.0", "c093036ebdf2aaf1003b2d1623713b97106ed43b1d39dc3d4f38e381f371799e")
 
-    add_patches("0.6.0", "patches/0.6.0/cmake.patch", "baa0534759ad62e6acb27d720bfea19cf60af4ee41af47fa134b886e966df76b")
+    add_patches("0.6.0", "patches/0.6.0/cmake.patch", "d118f07af7392d2268e0530cf90f1f36aa0a7836391a2950d24829ad0950d3c9")
     add_patches("0.2.0", "patches/0.2.0/cmake.patch", "e9819b9a8a2c8f8a5b6c553eac3bb10fc65856aa9af451f83e2dbf55ca6c66c0")
 
     add_deps("cmake", "reflect-cpp")
@@ -17,7 +17,7 @@ package("sqlgen")
     add_configs("mysql", {description = "Enable MySQL Support", default = false, type = "boolean", readonly = true})
     add_configs("postgres", {description = "Enable PostgreSQL Support", default = true, type = "boolean"})
     add_configs("sqlite", {description = "Enable SQLite Support", default = true, type = "boolean"})
-    add_configs("duckdb", {description = "Enable DuckDB Support", default = false, type = "boolean", readonly = true})
+    add_configs("duckdb", {description = "Enable DuckDB Support", default = true, type = "boolean"})
 
     if is_plat("windows") then
         add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})


### PR DESCRIPTION
Temporarily disable the `duckdb` option because the DuckDB installed via xmake-repo lacks CMake support.

Fixes #9005 
Fixes #8463 

Edit: DuckDB has been supported.

