### PR TITLE
Auto-update zpp_bits to v4.6

### DIFF
--- a/packages/z/zpp_bits/xmake.lua
+++ b/packages/z/zpp_bits/xmake.lua
@@ -7,6 +7,7 @@ package("zpp_bits")
     add_urls("https://github.com/eyalz800/zpp_bits/archive/refs/tags/$(version).tar.gz",
              "https://github.com/eyalz800/zpp_bits.git")
 
+    add_versions("v4.6", "ca5889fd2328df7411c0e4f4ddd64b396277dec5ed589b5f009dadc36ef3a24d")
     add_versions("v4.5.1", "2589469c86700264e4746b3efb0319b6911f2b9899fbd7cefddb6a01a7001f3b")
     add_versions("v4.5", "2ed5058b1394cd79b5130916e6beb275efbfb73f1713ed1d08a7d3ba1b36970e")
     add_versions("v4.4.25", "d4afb8cf73aec19686928445e912dbbe8d39bffdac43ea69b4781f145195a09e")


### PR DESCRIPTION
New version of zpp_bits detected (package version: v4.5.1, last github version: v4.6)