### PR TITLE
Auto-update ncnn to 20260113

### DIFF
--- a/packages/n/ncnn/xmake.lua
+++ b/packages/n/ncnn/xmake.lua
@@ -6,6 +6,7 @@ package("ncnn")
     add_urls("https://github.com/Tencent/ncnn/archive/refs/tags/$(version).tar.gz",
             "https://github.com/Tencent/ncnn.git", { submodules = false })
 
+    add_versions("20260113", "2fdc5c6e37f8552921a9daad498a1be54a6fa6edd32c1a9e3030b27fab253b47")
     add_versions("20250916", "7d463f1e5061facd02b8af5e792e059088695cdcfcc152c8f4892f6ffe5eab1a")
     add_versions("20250503", "3afea4cf092ce97d06305b72c6affbcfb3530f536ae8e81a4f22007d82b729e9")
 


### PR DESCRIPTION
New version of ncnn detected (package version: 20250916, last github version: 20260113)