### PR TITLE
cpptrace: fix find libdwarf.

### DIFF
--- a/packages/c/cpptrace/xmake.lua
+++ b/packages/c/cpptrace/xmake.lua
@@ -61,8 +61,7 @@ package("cpptrace")
             "-DBUILD_TESTING=OFF",
             "-DCPPTRACE_USE_EXTERNAL_LIBDWARF=ON",
             "-DCPPTRACE_FIND_LIBDWARF_WITH_PKGCONFIG=ON",
-            "-DCPPTRACE_USE_EXTERNAL_ZSTD=ON",
-            "-DCPPTRACE_VCPKG=ON",
+            "-DCPPTRACE_USE_EXTERNAL_ZSTD=ON"
         }
         table.insert(configs, "-DCPPTRACE_UNWIND_WITH_LIBUNWIND=" .. (package:config("libunwind") and "ON" or "OFF"))
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))


### PR DESCRIPTION
Some distributions use meson to package libdwarf, resulting in a missing `libdwarfConfig.cmake`. Consider using pkg-config to find it.

```
$ pacman -Ql libdwarf
libdwarf /usr/
libdwarf /usr/bin/
libdwarf /usr/bin/dwarfdump
libdwarf /usr/include/
libdwarf /usr/include/libdwarf-2/
libdwarf /usr/include/libdwarf-2/dwarf.h
libdwarf /usr/include/libdwarf-2/libdwarf.h
libdwarf /usr/lib/
libdwarf /usr/lib/libdwarf.so
libdwarf /usr/lib/libdwarf.so.2
libdwarf /usr/lib/libdwarf.so.2.2.0
libdwarf /usr/lib/pkgconfig/
libdwarf /usr/lib/pkgconfig/libdwarf.pc
libdwarf /usr/share/
libdwarf /usr/share/doc/
libdwarf /usr/share/doc/libdwarf/
libdwarf /usr/share/doc/libdwarf/NEWS
libdwarf /usr/share/doc/libdwarf/README
libdwarf /usr/share/dwarfdump/
libdwarf /usr/share/dwarfdump/dwarfdump.conf
libdwarf /usr/share/licenses/
libdwarf /usr/share/licenses/libdwarf/
libdwarf /usr/share/licenses/libdwarf/COPYING
libdwarf /usr/share/licenses/libdwarf/DWARFDUMPCOPYRIGHT
libdwarf /usr/share/licenses/libdwarf/LIBDWARFCOPYRIGHT
libdwarf /usr/share/man/
libdwarf /usr/share/man/man1/
libdwarf /usr/share/man/man1/dwarfdump.1.gz
```