### PR TITLE
Auto-update librdkafka to v2.13.0

### DIFF
--- a/packages/l/librdkafka/xmake.lua
+++ b/packages/l/librdkafka/xmake.lua
@@ -30,6 +30,12 @@ package("librdkafka")
 
     add_links("rdkafka++", "rdkafka")
 
+    if on_check then
+        on_check("iphoneos", function (package)
+            assert(package:version():lt("2.13.0"), "package(librdkafka >= v2.13.0): unsupport iOS")
+        end)
+    end
+
     -- These syslinks come from PKG_CONFIG_LIBS_PRIVATE in librdkafka/src/CMakeLists.txt
     if is_plat("linux") or is_plat("bsd") then
         add_syslinks("pthread", "dl")


### PR DESCRIPTION
New version of librdkafka detected (package version: v2.12.1, last github version: v2.13.0)