### PR TITLE
Auto-update audit to v4.1.3

### DIFF
--- a/packages/a/audit/xmake.lua
+++ b/packages/a/audit/xmake.lua
@@ -3,6 +3,7 @@ package("audit")
 
     add_urls("https://github.com/linux-audit/audit-userspace/archive/refs/tags/$(version).tar.gz",
              "https://github.com/linux-audit/audit-userspace.git")
+    add_versions("v4.1.3", "866a659c91746ee4436fa6f99d4f80768fc1a3aa92e6ec2081e353fcfc79589f")
     add_versions("v4.1.2", "5c638bbeef9adb6c5715d3a60f0f5adb93e9b81633608af13d23c61f5e5db04d")
 
     add_configs("listener",       {description = "Enable auditd network listener support.", default = true, type = "boolean"})


### PR DESCRIPTION
New version of audit detected (package version: v4.1.2, last github version: v4.1.3)