### PR TITLE
Auto-update libdatachannel to v0.24.1

### DIFF
--- a/packages/l/libdatachannel/xmake.lua
+++ b/packages/l/libdatachannel/xmake.lua
@@ -76,6 +76,7 @@ package("libdatachannel")
         io.replace("CMakeLists.txt", "set(CMAKE_POSITION_INDEPENDENT_CODE ON)", "", {plain = true})
         -- add -DJUICE_STATIC from config mode 
         io.replace("CMakeLists.txt", "find_package(LibJuice REQUIRED)", "find_package(LibJuice CONFIG REQUIRED)", {plain = true})
+        io.replace("CMakeLists.txt", "find_package(LibJuice 1.7.0 REQUIRED)", "find_package(LibJuice CONFIG REQUIRED)", {plain = true}) -- 0.24.0
         -- Error evaluating generator expression: $<TARGET_PDB_FILE:datachannel>
         -- TARGET_PDB_FILE is allowed only for targets with linker created artifacts.
         if package:is_plat("windows") then


### PR DESCRIPTION
New version of libdatachannel detected (package version: v0.23.2, last github version: v0.24.1)