### PR TITLE
Auto-update secilc to 3.10

### DIFF
--- a/packages/s/secilc/xmake.lua
+++ b/packages/s/secilc/xmake.lua
@@ -4,6 +4,7 @@ package("secilc")
     set_description("SELinux Common Intermediate Language Compiler")
 
     add_urls("https://github.com/SELinuxProject/selinux/releases/download/$(version)/secilc-$(version).tar.gz")
+    add_versions("3.10", "6658071d6f1044184d3973062a798187537ae1c3ddb4c31afd417df333316c10")
     add_versions("3.9", "c53fb7218ac158c05f28de186e48404857eb191bd4f9415802f85449fdf6da7f")
 
     on_load(function (package)


### PR DESCRIPTION
New version of secilc detected (package version: 3.9, last github version: 3.10)