### PR TITLE
cglm: Fix CMake shared lib flag

### DIFF
--- a/packages/c/cglm/xmake.lua
+++ b/packages/c/cglm/xmake.lua
@@ -30,7 +30,7 @@ package("cglm")
     on_install(function (package)
         local configs = {}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
-        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        table.insert(configs, "-DCGLM_SHARED=" .. (package:config("shared") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)
     end)
 


### PR DESCRIPTION
Seems the flag for building cglm as a shared lib was incorrect.

Here's the CMakeLists.txt for cglm https://github.com/recp/cglm/blob/v0.9.6/CMakeLists.txt