### PR TITLE
Auto-update watcher to 0.14.4

### DIFF
--- a/packages/w/watcher/xmake.lua
+++ b/packages/w/watcher/xmake.lua
@@ -7,6 +7,7 @@ package("watcher")
     set_urls("https://github.com/e-dant/watcher/archive/refs/tags/release/$(version).tar.gz",
              "https://github.com/e-dant/watcher.git")
 
+    add_versions("0.14.4", "26863d5fbcf241146def09da50dbcbd6c57b43350b85c9d362d58eb1c69b4293")
     add_versions("0.14.3", "ada4dd30bddc78b49f112b0310e4964710c8dcf8a16966c8e958f75bb7abde5e")
     add_versions("0.13.8", "ca415bb6e63012bb92543c2a0c76aec347fb36df48d6c1af8538018dd6584e06")
     add_versions("0.13.6", "b58b3a9f91d96d90080fd56cd998b1649633c43f92fc1bfe5562a000db472016")


### PR DESCRIPTION
New version of watcher detected (package version: 0.14.3, last github version: 0.14.4)