### PR TITLE
Auto-update samurai to v0.28.0

### DIFF
--- a/packages/s/samurai/xmake.lua
+++ b/packages/s/samurai/xmake.lua
@@ -7,6 +7,7 @@ package("samurai")
     add_urls("https://github.com/hpc-maths/samurai/archive/refs/tags/$(version).tar.gz",
              "https://github.com/hpc-maths/samurai.git")
 
+    add_versions("v0.28.0", "94a50fc30714b652157e27ac7870dc8487e1045289d87cb83b28d2c7f6834b94")
     add_versions("v0.27.1", "5cb1ffb87a6a3defbde45037bd80e8277c31d577e20559c6cb2853b82bc989ba")
     add_versions("v0.27.0", "23d3e6475fbc674a887af84333b49ff6ac68fa8326e9edfdb49fa47491c28f4f")
     add_versions("v0.26.1", "07971b2c5359cc33f5e3fb3f4f7d156b6aed91441139a1ae133378ba25e46d7a")


### PR DESCRIPTION
New version of samurai detected (package version: v0.27.1, last github version: v0.28.0)