### PR TITLE
Auto-update libpng to v1.6.55

### DIFF
--- a/packages/l/libpng/xmake.lua
+++ b/packages/l/libpng/xmake.lua
@@ -24,6 +24,10 @@ package("libpng")
     add_versions("v1.6.35", "6d59d6a154ccbb772ec11772cb8f8beb0d382b61e7ccc62435bf7311c9f4b210")
     add_versions("v1.6.34", "e45ce5f68b1d80e2cb9a2b601605b374bdf51e1798ef1c2c2bd62131dfcf9eef")
 
+    if is_plat("wasm") then
+        add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+    end
+
     add_deps("zlib")
 
     if is_plat("linux") then


### PR DESCRIPTION
New version of libpng detected (package version: v1.6.54, last github version: v1.6.55)