### PR TITLE
Auto-update google-cloud-cpp to v3.1.0

### DIFF
--- a/packages/g/google-cloud-cpp/xmake.lua
+++ b/packages/g/google-cloud-cpp/xmake.lua
@@ -6,6 +6,7 @@ package("google-cloud-cpp")
     add_urls("https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/googleapis/google-cloud-cpp.git")
 
+    add_versions("v3.1.0", "e868bdb537121d2169fbc1ef69b81f4b4f96e97891c4567a6533d4adf62bffde")
     add_versions("v2.46.0", "492734e092e5150d8395797f0d269f3d1e49ba3a959db4a332d15a1f382ff7ee")
     add_versions("v2.45.0", "3d1b5eb696832f9071bf7ef0b3f0c9fd27c1a39d5edcb8a9976c65193319fd01")
     add_versions("v2.43.0", "2aea914128db8a550bd926e1e08c155fae1caff8a451e1b644602952dd6d8b5c")

--- a/packages/g/google-cloud-cpp/xmake.lua
+++ b/packages/g/google-cloud-cpp/xmake.lua
@@ -126,12 +126,13 @@ package("google-cloud-cpp")
             table.insert(configs, "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON")
         end
 
-        local openssl = package:dep("openssl")
+        local openssl = package:dep("openssl") or package:dep("openssl3")
         if openssl then
             if not openssl:is_system() then
                 table.insert(configs, "-DOPENSSL_ROOT_DIR=" .. openssl:installdir())
             end
         end
+        table.insert(configs, "-DGOOGLE_CLOUD_CPP_ENABLE_GRPC=" .. (package:dep("grpc") and "ON" or "OFF"))
 
         local libraries = package:config("libraries")
         if libraries then


### PR DESCRIPTION
New version of google-cloud-cpp detected (package version: v2.46.0, last github version: v3.1.0)