### PR TITLE
fix: add comdlg32 system link for Windows platform

### DIFF
--- a/packages/d/diligentcore/xmake.lua
+++ b/packages/d/diligentcore/xmake.lua
@@ -38,6 +38,10 @@ package("diligentcore")
         add_syslinks("pthread", "dl")
     end
 
+    if is_plat("windows") then
+        add_syslinks("comdlg32")
+    end
+
     if is_plat("macosx") then
         add_frameworks("AppKit")
     elseif is_plat("iphoneos") then


### PR DESCRIPTION
When using `diligentcore` filesystem functions, we get the following error

```
1>LINK : warning LNK4098: defaultlib 'LIBCMT' conflicts with use of other libs; use /NODEFAULTLIB:library
1>Diligent-Win32Platform.lib(Win32FileSystem.cpp.obj) : error LNK2019: unresolved external symbol __imp_GetOpenFileNameA referenced in function "public: static class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl Diligent::WindowsFileSystem::FileDialog(struct Diligent::FileDialogAttribs const &)" (?FileDialog@WindowsFileSystem@Diligent@@SA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBUFileDialogAttribs@2@@Z)
1>Diligent-Win32Platform.lib(Win32FileSystem.cpp.obj) : error LNK2019: unresolved external symbol __imp_GetSaveFileNameA referenced in function "public: static class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl Diligent::WindowsFileSystem::FileDialog(struct Diligent::FileDialogAttribs const &)" (?FileDialog@WindowsFileSystem@Diligent@@SA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBUFileDialogAttribs@2@@Z)
1>build\windows\x64\debug\AmeEngine.dll : fatal error LNK1120: 2 unresolved externals
```

code sample:
```c++
#include <DiligentCore/Platforms/interface/FileSystem.hpp>
int main() {
	Diligent::FileSystem::OpenFile({ "test.txt", Diligent::EFileAccessMode::Read });
	return 0;
}
```

xmake project:
```lua
add_rules("mode.debug", "mode.release")

add_requires("diligentcore", {configs = {
    shared = true,
    hlsl = true,
    glslang = true,
    archiver = true,
    format_validation = true,

    vulkan = true,
    d3d12 = true,
    d3d11 = true,
    opengl = false,

    debug = is_mode("debug"),
}})

target("test")
    set_kind("binary")
    add_files("main.cpp")
    add_packages("diligentcore")
```

Adding `comdlg32` syslink fixes the issue.