### PR TITLE
Auto-update fluidsynth to v2.5.3

### DIFF
--- a/packages/f/fluidsynth/xmake.lua
+++ b/packages/f/fluidsynth/xmake.lua
@@ -6,6 +6,7 @@ package("fluidsynth")
 
     add_urls("https://github.com/FluidSynth/fluidsynth/archive/refs/tags/$(version).zip",
              "https://github.com/FluidSynth/fluidsynth.git")
+    add_versions("v2.5.3", "8eaf1226b19b0527ce7d9c7cf2f48e4ec5333c972aeef3913bdaf7a06d0fa684")
     add_versions("v2.3.3", "0ab6f1aae1c7652b9249de2d98070313f3083046fddd673277556f1cca65568e")
     add_versions("v2.3.5", "3cdaa24777f11fbc6da506d7f7b41fef31822006f83886dcf6e758a9941cae40")
 


### PR DESCRIPTION
New version of fluidsynth detected (package version: v2.3.5, last github version: v2.5.3)