### PR TITLE
Auto-update opencolorio to v2.5.1

### DIFF
--- a/packages/o/opencolorio/xmake.lua
+++ b/packages/o/opencolorio/xmake.lua
@@ -65,7 +65,10 @@ package("opencolorio")
 
         local opt = {}
         if minizip_ng then
-            opt.packagedeps = "minizip-ng"
+            opt.packagedeps = {"minizip-ng"}
+            if package:is_plat("macosx") then
+                table.insert(opt.packagedeps, "openssl")
+            end
         end
         import("package.tools.cmake").install(package, configs, opt)
     end)

--- a/packages/o/opencolorio/xmake.lua
+++ b/packages/o/opencolorio/xmake.lua
@@ -6,6 +6,7 @@ package("opencolorio")
     add_urls("https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/refs/tags/$(version).tar.gz",
              "https://github.com/AcademySoftwareFoundation/OpenColorIO.git")
 
+    add_versions("v2.5.1", "08cb6213ea4edee550ab050509d38204004bee6742c658166b1cf825d0a9381b")
     add_versions("v2.4.2", "2d8f2c47c40476d6e8cea9d878f6601d04f6d5642b47018eaafa9e9f833f3690")
     add_versions("v2.3.2", "6bbf4e7fa4ea2f743a238cb22aff44890425771a2f57f62cece1574e46ceec2f")
     add_versions("v2.1.1", "16ebc3e0f21f72dbe90fe60437eb864f4d4de9c255ef8e212f837824fc9b8d9c")


### PR DESCRIPTION
New version of opencolorio detected (package version: v2.4.2, last github version: v2.5.1)