### PR TITLE
Auto-update colmap to 4.0.2

### DIFF
--- a/packages/c/colmap/xmake.lua
+++ b/packages/c/colmap/xmake.lua
@@ -6,6 +6,7 @@ package("colmap")
     add_urls("https://github.com/colmap/colmap/archive/refs/tags/$(version).tar.gz", 
              "https://github.com/colmap/colmap.git")
 
+    add_versions("4.0.2", "d220b54481b08212dcfe9e6deca6e998546a462a80140c3bd4ed9318d8c74482")
     add_versions("3.13.0", "98a8f8cf6358774be223239a9b034cc9d55bf66c43f54fc6ddea9128a1ee197a")
 
     add_patches(">3.0", "patches/deps.patch", "93f43c149b95195bf03f30b22710502faa4c26242e7a7059881464c0b1fde2e6")


### PR DESCRIPTION
New version of colmap detected (package version: 3.13.0, last github version: 4.0.2)