### PR TITLE
Auto-update libwebsockets to v4.5.8

### DIFF
--- a/packages/l/libwebsockets/xmake.lua
+++ b/packages/l/libwebsockets/xmake.lua
@@ -8,6 +8,7 @@ package("libwebsockets")
         add_urls("https://github.com/warmcat/libwebsockets/archive/refs/tags/$(version).tar.gz")
     end
 
+    add_versions("v4.5.8", "b6ade658f4af3a823d0dc806ae5ef0623f0f4f5e2aeb895a0f77c4783840c30e")
     add_versions("v4.5.2", "04244efb7a6438c8c6bfc79b21214db5950f72c9cf57e980af57ca321aae87b2")
     add_versions("v4.4.1", "472e6cfa77b6f80ff2cc176bc59f6cb2856df7e30e8f31afcbd1fc94ffd2f828")
     add_versions("v4.3.5", "87f99ad32803ed325fceac5327aae1f5c1b417d54ee61ad36cffc8df5f5ab276")


### PR DESCRIPTION
New version of libwebsockets detected (package version: v4.5.2, last github version: v4.5.8)