### PR TITLE
Auto-update mujoco to 3.6.0

### DIFF
--- a/packages/m/mujoco/xmake.lua
+++ b/packages/m/mujoco/xmake.lua
@@ -6,6 +6,7 @@ package("mujoco")
     set_urls("https://github.com/google-deepmind/mujoco/archive/refs/tags/$(version).tar.gz",
              "https://github.com/google-deepmind/mujoco.git")
 
+    add_versions("3.6.0", "0d6bb25612da5d1c398d21cf5b039367d4deef15c064b049c3127043d613b539")
     add_versions("3.4.0", "adff5e9397aac20189ee1525aabf1fbecc63c43697e8ad66a61220222983810f")
 
     add_configs("simulate", {description = "Build simulate library for MuJoCo", default = false, type = "boolean"})


### PR DESCRIPTION
New version of mujoco detected (package version: 3.4.0, last github version: 3.6.0)