### PR TITLE
Auto-update thrust to 2.1.0

### DIFF
--- a/packages/t/thrust/xmake.lua
+++ b/packages/t/thrust/xmake.lua
@@ -6,6 +6,7 @@ package("thrust")
 
     add_urls("https://github.com/NVIDIA/thrust/archive/refs/tags/$(version).tar.gz",
              "https://github.com/NVIDIA/thrust.git")
+    add_versions("2.1.0", "ebfa1a31867a95b8b0555ae45fc7c45538edfa5929ec718951eae0bbc7ed3108")
     add_versions("1.17.0", "b02aca5d2325e9128ed9d46785b8e72366f758b873b95001f905f22afcf31bbf")
 
     add_deps("cuda", {system = true})


### PR DESCRIPTION
New version of thrust detected (package version: 1.17.0, last github version: 2.1.0)