### PR TITLE
Auto-update openmvs to v2.4.0

### DIFF
--- a/packages/o/openmvs/xmake.lua
+++ b/packages/o/openmvs/xmake.lua
@@ -6,6 +6,7 @@ package("openmvs")
     add_urls("https://github.com/cdcseacave/openMVS/archive/refs/tags/$(version).tar.gz",
              "https://github.com/cdcseacave/openMVS.git")
 
+    add_versions("v2.4.0", "1668a991fa1fdd3540ee47fdba282a7579ed876af713e8fa907625be1cf8dfc8")
     add_versions("v2.3.0", "ac7312fb71dbab18c5b2755ad9ac3caa40ec689f6f369c330ca73c87c1f34258")
 
     if is_plat("windows") then


### PR DESCRIPTION
New version of openmvs detected (package version: v2.3.0, last github version: v2.4.0)