### PR TITLE
Auto-update ptex to v2.5.2

### DIFF
--- a/packages/p/ptex/xmake.lua
+++ b/packages/p/ptex/xmake.lua
@@ -6,6 +6,7 @@ package("ptex")
     add_urls("https://github.com/wdas/ptex/archive/refs/tags/$(version).tar.gz",
              "https://github.com/wdas/ptex.git")
 
+    add_versions("v2.5.2", "dd95fbea4b50e9e68fd042f540fb83157a0ff25053066c3439d4527de3621d34")
     add_versions("v2.5.1", "6b4b55f562a0f9492655fcb7686ecc335a2a4dacc1de9f9a057a32f3867a9d9e")
     add_versions("v2.3.2", "30aeb85b965ca542a8945b75285cd67d8e207d23dbb57fcfeaab587bb443402b")
     add_versions("v2.4.1", "664253b84121251fee2961977fe7cf336b71cd846dc235cd0f4e54a0c566084e")


### PR DESCRIPTION
New version of ptex detected (package version: v2.5.1, last github version: v2.5.2)