### PR TITLE
openal-soft: update to 1.25.1

### DIFF
--- a/packages/o/openal-soft/xmake.lua
+++ b/packages/o/openal-soft/xmake.lua
@@ -67,16 +67,5 @@ package("openal-soft")
     end)
 
     on_test(function (package)
-        if package:version():ge("1.25.0") then
-            local required_cpp_ver = "c++20"
-        elseif  package:version():ge("1.24.0") then
-            local required_cpp_ver = "c++17"
-        else
-            local required_cpp_ver = "c++11"
-        end
-
-        assert(package:has_cfuncs("alGetProcAddress",
-            {configs = { languages = required_cpp_ver}},
-            {includes = "AL/al.h"}
-        ))
+        assert(package:has_cfuncs("alGetProcAddress", {includes = "AL/al.h"}))
     end)

--- a/packages/o/openal-soft/xmake.lua
+++ b/packages/o/openal-soft/xmake.lua
@@ -53,8 +53,14 @@ package("openal-soft")
 
     on_install("windows", "linux", "mingw", "macosx", "android", "iphoneos", "cross", "bsd" , function (package)
         if package:version():ge("1.25.0") then
-            assert(package:check_cxxsnippets({test = ""}, {configs = {languages = "c++20"}}),
-                "openal-soft >= 1.25.0 requires a C++20 compiler (NDK >= r23 for Android)")
+            assert(package:check_cxxsnippets({test = [[
+                template<typename... Ts>
+                struct overloaded : Ts... { using Ts::operator()...; };
+                void test() {
+                    auto f = overloaded{[](){}, [](){}};
+                }
+            ]]}, {configs = {languages = "c++20"}}),
+            "openal-soft >= 1.25.0 requires CTAD for aggregates (Clang 17+, Apple Clang 16+/Xcode 16+, GCC 12+)")
         elseif package:version():ge("1.24.0") then
             assert(package:check_cxxsnippets({test = ""}, {configs = {languages = "c++17"}}),
                 "openal-soft >= 1.24.0 requires a C++17 compiler")

--- a/packages/o/openal-soft/xmake.lua
+++ b/packages/o/openal-soft/xmake.lua
@@ -9,6 +9,8 @@ package("openal-soft")
     end})
     add_urls("https://github.com/kcat/openal-soft.git")
 
+    add_versions("1.25.1", "5f8efe8dfba5e9307a50251ba615ace857c7fa9dddfe34130b83e213d7f7cf24")
+    add_versions("1.25.0", "c07424e16cc53632a58f7ccaf7f4cd1cf2efde7fe4d2cdca1edbf618ea9470d1")
     add_versions("1.24.3", "7e1fecdeb45e7f78722b776c5cf30bd33934b961d7fd2a11e0494e064cc631ce")
     add_versions("1.23.1", "dfddf3a1f61059853c625b7bb03de8433b455f2f79f89548cbcbd5edca3d4a4a")
     add_versions("1.22.2", "3e58f3d4458f5ee850039b1a6b4dac2343b3a5985a6a2e7ae2d143369c5b8135")
@@ -65,5 +67,16 @@ package("openal-soft")
     end)
 
     on_test(function (package)
-        assert(package:has_cfuncs("alGetProcAddress", {includes = "AL/al.h"}))
+        if package:version():ge("v1.25.0") then
+            required_cpp_ver = "c++20"
+        elseif  package:version():ge("v1.24.0") then
+            required_cpp_ver = "c++17"
+        else
+            required_cpp_ver = "c++11"
+        end
+
+        assert(package:has_cfuncs("alGetProcAddress",
+            {configs = { languages = required_cpp_ver}},
+            {includes = "AL/al.h"}
+        ))
     end)

--- a/packages/o/openal-soft/xmake.lua
+++ b/packages/o/openal-soft/xmake.lua
@@ -67,12 +67,12 @@ package("openal-soft")
     end)
 
     on_test(function (package)
-        if package:version():ge("v1.25.0") then
-            required_cpp_ver = "c++20"
-        elseif  package:version():ge("v1.24.0") then
-            required_cpp_ver = "c++17"
+        if package:version():ge("1.25.0") then
+            local required_cpp_ver = "c++20"
+        elseif  package:version():ge("1.24.0") then
+            local required_cpp_ver = "c++17"
         else
-            required_cpp_ver = "c++11"
+            local required_cpp_ver = "c++11"
         end
 
         assert(package:has_cfuncs("alGetProcAddress",

--- a/packages/o/openal-soft/xmake.lua
+++ b/packages/o/openal-soft/xmake.lua
@@ -52,6 +52,14 @@ package("openal-soft")
     end)
 
     on_install("windows", "linux", "mingw", "macosx", "android", "iphoneos", "cross", "bsd" , function (package)
+        if package:version():ge("1.25.0") then
+            assert(package:check_cxxsnippets({test = ""}, {configs = {languages = "c++20"}}),
+                "openal-soft >= 1.25.0 requires a C++20 compiler (NDK >= r23 for Android)")
+        elseif package:version():ge("1.24.0") then
+            assert(package:check_cxxsnippets({test = ""}, {configs = {languages = "c++17"}}),
+                "openal-soft >= 1.24.0 requires a C++17 compiler")
+        end
+
         -- https://github.com/kcat/openal-soft/issues/864
         io.replace("CMakeLists.txt", "if(HAVE_GCC_PROTECTED_VISIBILITY)", "if(0)", { plain = true })
         local configs = {"-DALSOFT_EXAMPLES=OFF", "-DALSOFT_UTILS=OFF"}


### PR DESCRIPTION
Added openal-soft versions 1.25.0 and 1.25.1. I also added conditional code to check for minimal c++ compiler support which didn't exist before.