### PR TITLE
Auto-update urdfdom to 5.1.0

### DIFF
--- a/packages/u/urdfdom/xmake.lua
+++ b/packages/u/urdfdom/xmake.lua
@@ -6,6 +6,7 @@ package("urdfdom")
     add_urls("https://github.com/ros/urdfdom/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ros/urdfdom.git")
 
+    add_versions("5.1.0", "096478dc889fda2b375184304bd2511d4f33182ecd05732284c15978e2ef5d47")
     add_versions("5.0.4", "f47165c5f4d321216dbcd50d79bfccc459993b113400f507d8d72196388f9c7b")
     add_versions("5.0.3", "c98412daaa7498ecea2f2c68ce1c27767113d137468eb26b7dcfa291cba615b4")
     add_versions("5.0.2", "f929a33ec6171a57d4ff7d4c0eff6fb79d4725c279189d4f4c8806c4aa4e71ac")


### PR DESCRIPTION
New version of urdfdom detected (package version: 5.0.4, last github version: 5.1.0)