### PR TITLE
Auto-update kokkos-kernels to 5.1.0

### DIFF
--- a/packages/k/kokkos-kernels/xmake.lua
+++ b/packages/k/kokkos-kernels/xmake.lua
@@ -6,6 +6,7 @@ package("kokkos-kernels")
     add_urls("https://github.com/kokkos/kokkos-kernels/archive/refs/tags/$(version).tar.gz",
              "https://github.com/kokkos/kokkos-kernels.git")
 
+    add_versions("5.1.0", "19bc02c0d758eaa6656732ac23ae4c729c1728fcbf3d740d7e0d368617dffbbf")
     add_versions("5.0.2", "bd7fc683bbbaa07a3db07419e480d7adcbe691d6ff3f76717e631b11592c0059")
     add_versions("5.0.0", "31a5b8b4b8a36bcc6a424a6f2ad9ccc111dc77304c3ccc735fd4597fba9a03e4")
     add_versions("4.6.00", "22c83eb31d9eed1bbc69d7bd6b3d4646395ff5e4bb50403dcadf98c76945562e")


### PR DESCRIPTION
New version of kokkos-kernels detected (package version: 5.0.2, last github version: 5.1.0)