### PR TITLE
Auto-update libfswatch to 1.19.0

### DIFF
--- a/packages/l/libfswatch/xmake.lua
+++ b/packages/l/libfswatch/xmake.lua
@@ -6,6 +6,7 @@ package("libfswatch")
     add_urls("https://github.com/emcrisostomo/fswatch/archive/refs/tags/$(version).tar.gz",
              "https://github.com/emcrisostomo/fswatch.git")
 
+    add_versions("1.19.0", "0701283dd0eae6d21eb4c996ef4caf49921538c11f1c68ae2a5f7b3a2f1e36e7")
     add_versions("1.18.3", "07f9fec15138fe25ea92d869117811c7c4fba2e6c6231682d49b159bae2ebd53")
     add_versions("1.18.2", "698f21fe5489311dabe9e90463fb9d40796780abac8d207b857e86ade7345d86")
     add_versions("1.17.1", "bd492b6e203b10b30857778f4dd26f688426cd352937bd7779ee245139bafa2b")


### PR DESCRIPTION
New version of libfswatch detected (package version: 1.18.3, last github version: 1.19.0)