### PR TITLE
Auto-update lief to 0.17.6

### DIFF
--- a/packages/l/lief/xmake.lua
+++ b/packages/l/lief/xmake.lua
@@ -6,6 +6,7 @@ package("lief")
     set_urls("https://github.com/lief-project/LIEF/archive/refs/tags/$(version).tar.gz",
              "https://github.com/lief-project/LIEF.git")
 
+    add_versions("0.17.6", "5fbbd19c85912d417eabbaef2b98e70144496356964685b82e0792d708b9be87")
     add_versions("0.17.3", "00158beac9432b350fb528d571457a0bea8de154633a31735524a74fa69ea196")
     add_versions("0.17.2", "bece1be25aa657b94d1c97ddf88c47e0b94faa1d971c42532c4eb59fbb507fc2")
     add_versions("0.17.1", "9dea0f09c7b98e8d0c9a47f8629fbd1646ddc9bf1cae7c2f4ce42fe8934dc315")


### PR DESCRIPTION
New version of lief detected (package version: 0.17.3, last github version: 0.17.6)