### PR TITLE
Auto-update doctest to 2.5.2

### DIFF
--- a/packages/d/doctest/xmake.lua
+++ b/packages/d/doctest/xmake.lua
@@ -9,6 +9,7 @@ package("doctest")
              "https://github.com/onqtam/doctest/archive/$(version).tar.gz",
              "https://github.com/onqtam/doctest.git")
 
+    add_versions("2.5.2", "9189960c2bbbc4f3382ce0773b2bb5f13e3afd8fed47f55f193e11e85a4f9854")
     add_versions("2.5.0", "eb917c80bef7aceb9eca59d9328142351facdcdabe90b5242632b93c34b9e345")
     add_versions("2.4.12", "73381c7aa4dee704bd935609668cf41880ea7f19fa0504a200e13b74999c2d70")
     add_versions("2.4.11", "632ed2c05a7f53fa961381497bf8069093f0d6628c5f26286161fbd32a560186")


### PR DESCRIPTION
New version of doctest detected (package version: 2.5.0, last github version: 2.5.2)