### PR TITLE
Auto-update sqlite-vec to 0.1.9

### DIFF
--- a/packages/s/sqlite-vec/xmake.lua
+++ b/packages/s/sqlite-vec/xmake.lua
@@ -6,6 +6,7 @@ package("sqlite-vec")
     add_urls("https://github.com/asg017/sqlite-vec/releases/download/v$(version)/sqlite-vec-$(version)-amalgamation.tar.gz",
              "https://github.com/asg017/sqlite-vec.git")
 
+    add_versions("0.1.9", "3acd67cb4aff080c7050926fd3cf8227905fe5b7ee3829d8ee5024ab1283cf61")
     add_versions("0.1.7", "fa0bbe5057414b587402536741178b65d18f5bf3dbb429bb3aaa7375af2d3ee0")
     add_versions("0.1.6", "99b6ec36e9d259d91bd6cb2c053c3a7660f8791eaa66126c882a6a4557e57d6a")
     add_versions("0.1.3", "cd4da66333caa62dc63dcac99baeed1b38aa327e1d29f12a4a76df34860de442")


### PR DESCRIPTION
New version of sqlite-vec detected (package version: 0.1.7, last github version: 0.1.9)