### PR TITLE
fix(luajit): fix cross-compilation issues.

### DIFF
--- a/packages/l/luajit/port/v2.1.0-beta4.20260109/xmake.lua
+++ b/packages/l/luajit/port/v2.1.0-beta4.20260109/xmake.lua
@@ -16,6 +16,7 @@ option("gc64", {default = false})
 target("minilua")
     set_kind("binary")
     set_plat(os.host())
+    set_toolchains("envs")
     if is_arch("x64", "x86_64", "arm64.*", "mips64") then
         set_arch(os.arch())
     else
@@ -116,6 +117,7 @@ target("buildvm_headers")
 target("buildvm")
     set_kind("binary")
     set_plat(os.host())
+    set_toolchains("envs")
     if is_arch("x64", "x86_64", "arm64.*", "mips64") then
         set_arch(os.arch())
     else


### PR DESCRIPTION
- 使用了 set_toolchains("envs") 来修复交叉编译时仍然在使用原来的 msvc toolchain的问题

本地测试没问题。刚接触xmake，不是特别熟悉，如果有哪里写得不对，或者有更好的方案，欢迎指出。