### PR TITLE
Auto-update aws-sdk-cpp to 1.11.792

### DIFF
--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -5,6 +5,7 @@ package("aws-sdk-cpp")
 
     add_urls("https://github.com/aws/aws-sdk-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/aws/aws-sdk-cpp.git")
+    add_versions("1.11.792", "ec13533d28167fdfd2935af0599078c210ffb1721bef8887fd0ab2f57ef0c7db")
     add_versions("1.11.788", "1b9b87325dcb7f36b89c4a1bc20af7ecfd57b0c87a3d70047399526dbe8547dc")
     add_versions("1.11.784", "2bf8c389957b914371491da6efd3fb585f85ecbc7622b120150548e94c157ec7")
     add_versions("1.11.779", "7a1a15d59f181b0c759510af52f7bf722758f60c55e22d0b0ccf87028c3fc7d2")


### PR DESCRIPTION
New version of aws-sdk-cpp detected (package version: 1.11.788, last github version: 1.11.792)