### PR TITLE
Auto-update urdfdom to 5.1.2

### DIFF
--- a/packages/u/urdfdom-headers/xmake.lua
+++ b/packages/u/urdfdom-headers/xmake.lua
@@ -1,12 +1,13 @@
 package("urdfdom-headers")
     set_kind("library", {headeronly = true})
-    set_homepage("http://ros.org/wiki/urdf")
+    set_homepage("https://ros.org/wiki/urdf")
     set_description("Headers for URDF parsers")
     set_license("BSD-3-Clause")
 
     add_urls("https://github.com/ros/urdfdom_headers/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ros/urdfdom_headers.git")
 
+    add_versions("2.1.2", "3aeef6325b83f9283c9cee34f1e6f8d232acc7aeef2d47bc782a5193ae8aaec4")
     add_versions("2.1.0", "aa5509d1931d31acb070d34cee9f46a08e1d62b1f89d50a1392405cdf4f02966")
     add_versions("2.0.1", "3b624b05119cb9d9c89495b6580663ba8fd138b7fb28769c1f756c1d11102f52")
     add_versions("2.0.0", "e12db588ccce52958264f6e4363ca642ab86c328c372e925681a12f7c39d963a")

--- a/packages/u/urdfdom/xmake.lua
+++ b/packages/u/urdfdom/xmake.lua
@@ -6,6 +6,7 @@ package("urdfdom")
     add_urls("https://github.com/ros/urdfdom/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ros/urdfdom.git")
 
+    add_versions("5.1.2", "f51e2f92a0830c41f98d5196ba5b01d2c7b900498a8c5ba767b7eb8a76852cdd")
     add_versions("5.1.0", "096478dc889fda2b375184304bd2511d4f33182ecd05732284c15978e2ef5d47")
     add_versions("5.0.4", "f47165c5f4d321216dbcd50d79bfccc459993b113400f507d8d72196388f9c7b")
     add_versions("5.0.3", "c98412daaa7498ecea2f2c68ce1c27767113d137468eb26b7dcfa291cba615b4")


### PR DESCRIPTION
New version of urdfdom detected (package version: 5.1.0, last github version: 5.1.2)