### PR TITLE
Auto-update openal-soft to 1.25.1

### DIFF
--- a/packages/o/openal-soft/xmake.lua
+++ b/packages/o/openal-soft/xmake.lua
@@ -9,6 +9,7 @@ package("openal-soft")
     end})
     add_urls("https://github.com/kcat/openal-soft.git")
 
+    add_versions("1.25.1", "5f8efe8dfba5e9307a50251ba615ace857c7fa9dddfe34130b83e213d7f7cf24")
     add_versions("1.24.3", "7e1fecdeb45e7f78722b776c5cf30bd33934b961d7fd2a11e0494e064cc631ce")
     add_versions("1.23.1", "dfddf3a1f61059853c625b7bb03de8433b455f2f79f89548cbcbd5edca3d4a4a")
     add_versions("1.22.2", "3e58f3d4458f5ee850039b1a6b4dac2343b3a5985a6a2e7ae2d143369c5b8135")


### PR DESCRIPTION
New version of openal-soft detected (package version: 1.24.3, last github version: 1.25.1)