### PR TITLE
llhttp: fix broken static build for v9.3.1

### DIFF
--- a/packages/l/llhttp/xmake.lua
+++ b/packages/l/llhttp/xmake.lua
@@ -34,14 +34,19 @@ package("llhttp")
                 opt.cflags = {"-flax-vector-conversions"}
             end
             table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
-            table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
-            table.insert(configs, "-DBUILD_STATIC_LIBS=" .. (package:config("shared") and "OFF" or "ON"))
+            if package:version():ge("9.3.1") then
+                table.insert(configs, "-DLLHTTP_BUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+                table.insert(configs, "-DLLHTTP_BUILD_STATIC_LIBS=" .. (package:config("shared") and "OFF" or "ON"))
+            else
+                table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+                table.insert(configs, "-DBUILD_STATIC_LIBS=" .. (package:config("shared") and "OFF" or "ON"))
+            end
             import("package.tools.cmake").install(package, configs, opt)
         else
             xmake_configs.export_symbol = true
+            os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
+            import("package.tools.xmake").install(package, xmake_configs)
         end
-        os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
-        import("package.tools.xmake").install(package, xmake_configs)
 
         if package:config("shared") then
             io.replace(package:installdir("include/llhttp.h"), "__declspec(dllexport)", "__declspec(dllimport)", {plain = true})


### PR DESCRIPTION
fix #9802
1. nodejs/llhttp#657 replaced the `BUILD_SHARED_LIBS` and `BUILD_STATIC_LIBS` with `LLHTTP_BUILD_SHARED_LIBS` and `LLHTTP_BUILD_STATIC_LIBS`.
2. Fix double compilation bug

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

