### PR TITLE
Auto-update xsimd to 14.1.0

### DIFF
--- a/packages/x/xsimd/xmake.lua
+++ b/packages/x/xsimd/xmake.lua
@@ -7,6 +7,7 @@ package("xsimd")
     add_urls("https://github.com/xtensor-stack/xsimd/archive/refs/tags/$(version).tar.gz",
              "https://github.com/xtensor-stack/xsimd.git")
 
+    add_versions("14.1.0", "8da77b66214e73565f6111ba494322c853552b7b40cff69779b42e2100eed16f")
     add_versions("13.2.0", "edd8cd3d548c185adc70321c53c36df41abe64c1fe2c67bc6d93c3ecda82447a")
     add_versions("13.1.0", "88c9dc6da677feadb40fe09f467659ba0a98e9987f7491d51919ee13d897efa4")
     add_versions("13.0.0", "8bdbbad0c3e7afa38d88d0d484d70a1671a1d8aefff03f4223ab2eb6a41110a3")


### PR DESCRIPTION
New version of xsimd detected (package version: 13.2.0, last github version: 14.1.0)