### PR TITLE
Auto-update vk-bootstrap to v1.4.349

### DIFF
--- a/packages/v/vk-bootstrap/xmake.lua
+++ b/packages/v/vk-bootstrap/xmake.lua
@@ -6,6 +6,7 @@ package("vk-bootstrap")
     add_urls("https://github.com/charles-lunarg/vk-bootstrap/archive/refs/tags/$(version).tar.gz",
              "https://github.com/charles-lunarg/vk-bootstrap.git")
 
+    add_versions("v1.4.349", "0db474bcd9417bbcc40f66bb3b65d3179d48373ff979b604172ca5b670eb5b04")
     add_versions("v1.4.342", "c879c6a300d4504fbf8d91b3ce942e378350d17473dd5c7470b0c4413b7aa723")
     add_versions("v1.4.325", "d9d69fb8f9716830ee71bd4a6bd096a6b46b966b5c81eb0a47f3b67cfb3572e1")
     add_versions("v1.4.315", "f28595b057e10033cc6b64319e76be4eeda5b7c9ee83cc1808218e69b040f353")


### PR DESCRIPTION
New version of vk-bootstrap detected (package version: v1.4.342, last github version: v1.4.349)