### PR TITLE
Auto-update dlss to v310.6.0

### DIFF
--- a/packages/d/dlss/xmake.lua
+++ b/packages/d/dlss/xmake.lua
@@ -6,6 +6,7 @@ package("dlss")
     add_urls("https://github.com/NVIDIA/DLSS/archive/refs/tags/$(version).tar.gz",
              "https://github.com/NVIDIA/DLSS.git", {submodules = false})
 
+    add_versions("v310.6.0", "4c10c3093f9ae6c434c8dc374bc685be43c24e79d65119886f2d0e02e2a18791")
     add_versions("v310.5.3", "6b54a684b5b31e819a51742ad534abb4e8cdada76572f061a5d3149c7432a0a1")
     add_versions("v310.5.0", "9effc97025eb8c61f85e41b97e4ccaaed18313e245c7f0b739525c6f26a5d4e6")
     add_versions("v310.4.0", "a11a36977746cb0bb9ffc20171738db9bbb9cc81e3c2693d0aa65e5f412d6080")


### PR DESCRIPTION
New version of dlss detected (package version: v310.5.3, last github version: v310.6.0)