### PR TITLE
Auto-update aws-c-s3 to v0.12.3

### DIFF
--- a/packages/a/aws-c-s3/xmake.lua
+++ b/packages/a/aws-c-s3/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-s3")
     add_urls("https://github.com/awslabs/aws-c-s3/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-s3.git")
 
+    add_versions("v0.12.3", "65dcc547b8680c8598754ff3273a00a898ad357cff6d0056bc0f1d1bea550760")
     add_versions("v0.12.2", "76348249b4bc305c1a40d089270a5a419f58c03c231b757de0a49a7a234eec76")
     add_versions("v0.12.0", "1a8a8ceda0585d52028a1f3daa5861f924e7d8d2f6a17bec05813dc0b74d6eed")
     add_versions("v0.11.5", "bc76ad6e4ef40703477cd2e411553b85216def71a0073cfe8b7fad8d3728b37c")


### PR DESCRIPTION
New version of aws-c-s3 detected (package version: v0.12.2, last github version: v0.12.3)