### PR TITLE
Auto-update geode-sdk-tuliphook to v3.1.12

### DIFF
--- a/packages/g/geode-sdk-tuliphook/xmake.lua
+++ b/packages/g/geode-sdk-tuliphook/xmake.lua
@@ -10,8 +10,7 @@ package("geode-sdk-tuliphook")
     add_versions("v3.1.9", "c1b2930511e4e4abeb9b68db6c21bbdd0bc0d02869ea03498f4329011e07626c")
     add_versions("v3.1.7", "83f200a43002a343a17f57f861532d64018f8e7691a3c0097356df3dc1743543")
 
-    add_patches("v3.1.9", "patches/v3.1.7/fix-mingw.patch", "22592dc5afbbf87fb36fd89cb9a2f3b9af41e23b98a22f7eebf748423bff6295")
-    add_patches("v3.1.7", "patches/v3.1.7/fix-mingw.patch", "22592dc5afbbf87fb36fd89cb9a2f3b9af41e23b98a22f7eebf748423bff6295")
+    add_patches(">=3.1.7", "patches/v3.1.7/fix-mingw.patch", "22592dc5afbbf87fb36fd89cb9a2f3b9af41e23b98a22f7eebf748423bff6295")
 
     add_deps("geode-sdk-result")
 

--- a/packages/g/geode-sdk-tuliphook/xmake.lua
+++ b/packages/g/geode-sdk-tuliphook/xmake.lua
@@ -6,6 +6,7 @@ package("geode-sdk-tuliphook")
     add_urls("https://github.com/geode-sdk/TulipHook/archive/refs/tags/$(version).tar.gz",
              "https://github.com/geode-sdk/TulipHook.git")
 
+    add_versions("v3.1.12", "af3cd6d58f822282d929bcb1e3b12c0f78fedaab3b66d288c55480bbc98d0aea")
     add_versions("v3.1.9", "c1b2930511e4e4abeb9b68db6c21bbdd0bc0d02869ea03498f4329011e07626c")
     add_versions("v3.1.7", "83f200a43002a343a17f57f861532d64018f8e7691a3c0097356df3dc1743543")
 


### PR DESCRIPTION
New version of geode-sdk-tuliphook detected (package version: v3.1.9, last github version: v3.1.12)