### PR TITLE
Auto-update blake3 to 1.8.5

### DIFF
--- a/packages/b/blake3/xmake.lua
+++ b/packages/b/blake3/xmake.lua
@@ -6,6 +6,7 @@ package("blake3")
     add_urls("https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/$(version).tar.gz",
              "https://github.com/BLAKE3-team/BLAKE3.git")
 
+    add_versions("1.8.5", "220bd81286e2a0585beac66d41ac3f4c2c33ae8a4e339fc88cf22d5e00514fe9")
     add_versions("1.8.4", "b5ee5f5c5e025eb2733ae3af8d4c0e53bb66dff35095decfd377f1083e8ac9be")
     add_versions("1.8.3", "5a11e3f834719b6c1cae7aced1e848a37013f6f10f97272e7849aa0da769f295")
     add_versions("1.8.2", "6b51aefe515969785da02e87befafc7fdc7a065cd3458cf1141f29267749e81f")


### PR DESCRIPTION
New version of blake3 detected (package version: 1.8.4, last github version: 1.8.5)