### PR TITLE
Add lv2 v1.18.10 to xrepo

### DIFF
--- a/packages/l/lv2/xmake.lua
+++ b/packages/l/lv2/xmake.lua
@@ -2,7 +2,7 @@ package("lv2")
     set_kind("library", {headeronly = true})
     set_homepage("https://lv2plug.in")
     set_description("The LV2 audio plugin specification")
-    set_license("0BSD", "Apache-2.0", "CC-BY-1.0", "CC-BY-4.0", "ISC", "MIT", "W3C-19980720", "W3C-20150513")
+    set_license("ISC")
 
     add_urls("https://gitlab.com/lv2/lv2/-/archive/v$(version).tar.gz",
              "https://gitlab.com/lv2/lv2.git")

--- a/packages/l/lv2/xmake.lua
+++ b/packages/l/lv2/xmake.lua
@@ -4,10 +4,10 @@ package("lv2")
     set_description("The LV2 audio plugin specification")
     set_license("0BSD", "Apache-2.0", "CC-BY-1.0", "CC-BY-4.0", "ISC", "MIT", "W3C-19980720", "W3C-20150513")
 
-    add_urls("https://gitlab.com/lv2/lv2/-/archive/$(version).tar.gz",
+    add_urls("https://gitlab.com/lv2/lv2/-/archive/v$(version).tar.gz",
              "https://gitlab.com/lv2/lv2.git")
 
-    add_versions("v1.18.10", "15038fabd0313f281a5611f41502e3649274082b74c879bcc4a4bc5a2e79e85b")
+    add_versions("1.18.10", "15038fabd0313f281a5611f41502e3649274082b74c879bcc4a4bc5a2e79e85b")
 
     add_deps("meson", "ninja")
 	

--- a/packages/l/lv2/xmake.lua
+++ b/packages/l/lv2/xmake.lua
@@ -1,0 +1,28 @@
+package("lv2")
+    set_kind("library", {headeronly = true})
+    set_homepage("https://lv2plug.in")
+    set_description("The LV2 audio plugin specification")
+    set_license("0BSD", "Apache-2.0", "CC-BY-1.0", "CC-BY-4.0", "ISC", "MIT", "W3C-19980720", "W3C-20150513")
+
+    add_urls("https://gitlab.com/lv2/lv2/-/archive/$(version).tar.gz",
+             "https://gitlab.com/lv2/lv2.git")
+
+    add_versions("v1.18.10", "15038fabd0313f281a5611f41502e3649274082b74c879bcc4a4bc5a2e79e85b")
+
+    add_deps("meson", "ninja")
+	
+    add_configs("old_headers", { description = "Install backwards compatible headers at URI-style paths", default = true, type = "boolean"})
+
+    on_install(function (package)
+        local configs = {
+            "-Ddocs=disabled",
+            "-Dplugins=disabled",
+            "-Dtests=disabled",
+        }
+		table.insert(configs, "-Dold_headers=" .. (package:config("old_headers") and "true" or "false"))
+		import("package.tools.meson").install(package, configs)
+    end)
+
+    on_test(function (package)		
+        assert(package:has_cincludes("lv2/core/lv2.h"))
+    end)

--- a/packages/l/lv2/xmake.lua
+++ b/packages/l/lv2/xmake.lua
@@ -13,7 +13,7 @@ package("lv2")
 	
     add_configs("old_headers", { description = "Install backwards compatible headers at URI-style paths", default = true, type = "boolean"})
 
-    on_install(function (package)
+    on_install("!android", function (package)
         local configs = {
             "-Ddocs=disabled",
             "-Dplugins=disabled",

--- a/packages/l/lv2/xmake.lua
+++ b/packages/l/lv2/xmake.lua
@@ -24,5 +24,5 @@ package("lv2")
     end)
 
     on_test(function (package)		
-        assert(package:has_cfuncs("lv2_descriptor", {includes = "lv2/lv2.h"}))
+        assert(package:has_cfuncs("lv2_descriptor", {includes = "lv2/core/lv2.h"}))
     end)

--- a/packages/l/lv2/xmake.lua
+++ b/packages/l/lv2/xmake.lua
@@ -24,5 +24,5 @@ package("lv2")
     end)
 
     on_test(function (package)		
-        assert(package:has_cincludes("lv2/core/lv2.h"))
+        assert(package:has_cfuncs("lv2_descriptor", {includes = "lv2/lv2.h"}))
     end)


### PR DESCRIPTION
It is a header-only library.
Many licenses. I'm not sure if I'm supposed to list them all, or just one. Or just 0BSD and ISC.
 -https://gitlab.com/lv2/lv2/-/tree/main/LICENSES?ref_type=heads
Added option to disable including old headers, though it is on by default.
 -All options: https://gitlab.com/lv2/lv2/-/blob/main/meson_options.txt?ref_type=heads

Tested locally (Windows/MSVC) with `xmake l scripts/test.lua -v -D lv2`

This will close #9834 .