### PR TITLE
Auto-update freerdp to 3.25.0

### DIFF
--- a/packages/f/freerdp/xmake.lua
+++ b/packages/f/freerdp/xmake.lua
@@ -6,6 +6,7 @@ package("freerdp")
     add_urls("https://github.com/FreeRDP/FreeRDP/releases/download/$(version)/freerdp-$(version).tar.gz",
              "https://github.com/FreeRDP/FreeRDP.git")
 
+    add_versions("3.25.0", "2d8f8ef34f607f4c5b978e3d0d96d936d88099f4918d21ba84ac334a89219f7f")
     add_versions("3.24.0", "168011bd58eae8d898842ef39c6c9bf5761ab617a68ccad80d623a3e535d0367")
     add_versions("3.23.0", "929273003f35b0b4f211e48d5abed4ebcef99da94784a50b6dc85cd0b7e257b1")
     add_versions("3.22.0", "656670f3aac2c995cb4b1ba181549cc122cc9c95ec31be68a582c1182f474376")

--- a/packages/f/freerdp/xmake.lua
+++ b/packages/f/freerdp/xmake.lua
@@ -126,7 +126,7 @@ package("freerdp")
         end
     end)
 
-    on_install("!bsd and !iphoneos", function (package)
+    on_install("!bsd and !iphoneos and !wasm", function (package)
         if package:is_plat("mingw") then
             io.replace("winpr/include/winpr/wtypes.h", "typedef ssize_t SSIZE_T;", "#ifndef _SSIZE_T_DEFINED\ntypedef ssize_t SSIZE_T;\n#endif", {plain = true})
         end


### PR DESCRIPTION
New version of freerdp detected (package version: 3.24.0, last github version: 3.25.0)