### PR TITLE
Auto-update libsodium to 1.0.22

### DIFF
--- a/packages/l/libsodium/xmake.lua
+++ b/packages/l/libsodium/xmake.lua
@@ -7,6 +7,7 @@ package("libsodium")
              "https://github.com/jedisct1/libsodium/releases/download/$(version)-RELEASE/libsodium-$(version).tar.gz",
              "https://github.com/jedisct1/libsodium.git")
 
+    add_versions("1.0.22", "adbdd8f16149e81ac6078a03aca6fc03b592b89ef7b5ed83841c086191be3349")
     add_versions("1.0.21", "9e4285c7a419e82dedb0be63a72eea357d6943bc3e28e6735bf600dd4883feaf")
     add_versions("1.0.20", "ebb65ef6ca439333c2bb41a0c1990587288da07f6c7fd07cb3a18cc18d30ce19")
     add_versions("1.0.19", "018d79fe0a045cca07331d37bd0cb57b2e838c51bc48fd837a1472e50068bbea")


### PR DESCRIPTION
New version of libsodium detected (package version: 1.0.21, last github version: 1.0.22)