### PR TITLE
[libsigcplusplus] Add 2.12.1, + some formatting changes

### DIFF
--- a/packages/l/libsigcplusplus/xmake.lua
+++ b/packages/l/libsigcplusplus/xmake.lua
@@ -18,9 +18,11 @@ package("libsigcplusplus")
 
     add_deps("meson", "ninja")
     on_load(function (package)
+        local version = package:version()
+        local major = (version and version:major()) or 3
         package:add("includedirs",
-            "include/sigc++-" .. package:version():major() .. ".0",
-            "lib/sigc++-" .. package:version():major() .. ".0/include")
+            "include/sigc++-" .. major .. ".0",
+            "lib/sigc++-" .. major .. ".0/include")
     end)
 
     on_install("windows", "linux", "macosx", "mingw", "msys", "iphoneos", "cross", "wasm", function (package)

--- a/packages/l/libsigcplusplus/xmake.lua
+++ b/packages/l/libsigcplusplus/xmake.lua
@@ -3,12 +3,13 @@ package("libsigcplusplus")
     set_description("libsigc++ implements a typesafe callback system for standard C++. It allows you to define signals and to connect those signals to any callback function, either global or a member function, regardless of whether it is static or virtual.")
     set_license("LGPL-3.0")
 
-    add_urls("https://github.com/libsigcplusplus/libsigcplusplus/archive/refs/tags/$(version).tar.gz",
+    add_urls("https://github.com/libsigcplusplus/libsigcplusplus/releases/download/$(version)/libsigc++-$(version).tar.xz",
              "https://github.com/libsigcplusplus/libsigcplusplus.git")
 
-    add_versions("3.8.0", "fb2356847434c2cef8fc6093b2fd571cf9de9ba795d3b8ffe4ab70d1b8553cd9")
-    add_versions("3.6.0", "bbe81e4f6d8acb41a9795525a38c0782751dbc4af3d78a9339f4a282e8a16c38")
-    add_versions("3.4.0", "445d889079041b41b368ee3b923b7c71ae10a54da03bc746f2d0723e28ba2291")
+    add_versions("3.8.0", "502a743bb07ed7627dd41bd85ec4b93b4954f06b531adc45818d24a959f54e36")
+    add_versions("3.6.0", "c3d23b37dfd6e39f2e09f091b77b1541fbfa17c4f0b6bf5c89baef7229080e17")
+    add_versions("3.4.0", "02e2630ffb5ce93cd52c38423521dfe7063328863a6e96d41d765a6116b8707e")
+	add_versions("2.12.1", "a9dbee323351d109b7aee074a9cb89ca3e7bcf8ad8edef1851f4cf359bd50843")
 
     add_configs("deprecated_api", {description = "Build deprecated API and include it in the library", default = false, type = "boolean"})
     if is_plat("wasm") then
@@ -16,7 +17,11 @@ package("libsigcplusplus")
     end
 
     add_deps("meson", "ninja")
-    add_includedirs("include/sigc++-3.0", "lib/sigc++-3.0/include")
+    on_load(function (package)
+        package:add("includedirs",
+            "include/sigc++-" .. package:version():major() .. ".0",
+            "lib/sigc++-" .. package:version():major() .. ".0/include")
+    end)
 
     on_install("windows", "linux", "macosx", "mingw", "msys", "iphoneos", "cross", "wasm", function (package)
         local configs = {"-Dvalidation=false", "-Dbuild-examples=false", "-Dbuild-tests=false"}

--- a/packages/l/libsigcplusplus/xmake.lua
+++ b/packages/l/libsigcplusplus/xmake.lua
@@ -26,7 +26,7 @@ package("libsigcplusplus")
     end)
 
     on_install("windows", "linux", "macosx", "mingw", "msys", "iphoneos", "cross", "wasm", function (package)
-        local configs = {"-Dvalidation=false", "-Dbuild-examples=false", "-Dbuild-tests=false"}
+        local configs = {"-Dvalidation=false", "-Dbuild-examples=false", "-Dbuild-tests=false", "-Dbuild-documentation=false"}
         table.insert(configs, "-Dbuild-deprecated-api=" .. (package:config("deprecated_api") and "true" or "false"))
 
         local shflags = {}


### PR DESCRIPTION
-Add support for libsigcplusplus 2.12.1.

-Some formatting changes to libsigcplusplus' xmake.lua:
--Add an on_load block to handle include path for 2.x.x and 3.x.x versions differently.
--Change the add_url link, and the sha256 for all versions of libsigcplusplus

After first adding the 2.12.1 version and sha256, I got an error relating to an untracked folder from meson, which subsequently made xmake errors:
`sigc++\meson.build:155:19: ERROR: File ../untracked/sigc++/adaptors/lambda/lambda.cc does not exist.`

Looking into the cause, found some insightful sources:
1. https://github.com/libsigcplusplus/libsigcplusplus/issues/62
2. https://github.com/libsigcplusplus/libsigcplusplus#building-from-a-release-tarball

At least for the versions in the build files, doesn't seem like there's a need to define maintainer-mode.
Tested all 4 versions locally (Windows). Don't know if my changes adds support for any more platforms.

This closes #9852 .