### PR TITLE
Auto-update stlab to v2.3.0

### DIFF
--- a/packages/s/stlab/xmake.lua
+++ b/packages/s/stlab/xmake.lua
@@ -7,6 +7,7 @@ package("stlab")
 
     add_urls("https://github.com/stlab/libraries/archive/refs/tags/$(version).tar.gz",
              "https://github.com/stlab/libraries.git")
+    add_versions("v2.3.0", "22ec971dff4b4ffdc331bc31d243b50583e17a78abc284021bb22064cba8aa9c")
     add_versions("v1.6.2", "d0369d889c7bf78068d0c4f4b5125d7e9fe9abb0ad7a3be35bf13b6e2c271676")
 
     add_deps("cmake")

--- a/packages/s/stlab/xmake.lua
+++ b/packages/s/stlab/xmake.lua
@@ -13,6 +13,9 @@ package("stlab")
     add_deps("cmake")
     add_deps("boost")
     on_install("windows", "macosx", "linux", function (package)
+        if package:version() and package:version():eq("2.3.0") then
+            io.replace("include/stlab/CMakeLists.txt", "iterator/set_next.hpp\n", "iterator/set_next.hpp\niterator/concepts.hpp\n", {plain = true})
+        end
         import("package.tools.cmake").install(package, {"-Dstlab.testing=OFF", "-Dstlab.coverage=OFF"})
     end)
 

--- a/packages/s/stlab/xmake.lua
+++ b/packages/s/stlab/xmake.lua
@@ -15,6 +15,7 @@ package("stlab")
     on_install("windows", "macosx", "linux", function (package)
         if package:version() and package:version():eq("2.3.0") then
             io.replace("include/stlab/CMakeLists.txt", "iterator/set_next.hpp\n", "iterator/set_next.hpp\niterator/concepts.hpp\n", {plain = true})
+            io.replace("cmake/stlab/development/MSVC.cmake", "/WX # Treat warnings as errors", "", {plain = true})
         end
         import("package.tools.cmake").install(package, {"-Dstlab.testing=OFF", "-Dstlab.coverage=OFF"})
     end)


### PR DESCRIPTION
New version of stlab detected (package version: v1.6.2, last github version: v2.3.0)