### PR TITLE
Add vamp-plugin-sdk to xrepo

### DIFF
--- a/packages/v/vamp-plugin-sdk/xmake.lua
+++ b/packages/v/vamp-plugin-sdk/xmake.lua
@@ -1,0 +1,23 @@
+package("vamp-plugin-sdk")
+    set_homepage("https://www.vamp-plugins.org")
+    set_description("The SDK for Vamp plugins, an API for audio analysis and feature extraction plugins.")
+    set_license("BSD-3-Clause AND MIT")
+
+    add_urls("https://github.com/vamp-plugins/vamp-plugin-sdk/archive/refs/tags/vamp-plugin-sdk-v$(version).tar.gz",
+             "https://github.com/vamp-plugins/vamp-plugin-sdk.git")
+
+    --No new release tag since the addition of CMake build system, so use commit instead
+    add_versions("2.10+cmake", "44c2487763eb248a933e9eff9169cfadee375009")
+
+    add_deps("cmake")
+
+    on_install(function (package)
+        if package:is_plat("windows") then
+            io.replace("pkgconfig/vamp-hostsdk.pc.in", "-ldl", "", {plain = true})
+        end
+        import("package.tools.cmake").install(package)
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("vhGetLibraryCount", {includes = "vamp-hostsdk/host-c.h"}))
+    end)

--- a/packages/v/vamp-plugin-sdk/xmake.lua
+++ b/packages/v/vamp-plugin-sdk/xmake.lua
@@ -13,7 +13,16 @@ package("vamp-plugin-sdk")
         if package:is_plat("windows") then
             io.replace("pkgconfig/vamp-hostsdk.pc.in", "-ldl", "", {plain = true})
         end
-        import("package.tools.cmake").install(package)
+
+        local configs = {}
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+
+        --Exporting symbols isn't handled upstream; no visibility macros or such.
+        if package:is_plat("windows") and package:config("shared") then
+            table.insert(configs, "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON")
+        end
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/v/vamp-plugin-sdk/xmake.lua
+++ b/packages/v/vamp-plugin-sdk/xmake.lua
@@ -3,11 +3,9 @@ package("vamp-plugin-sdk")
     set_description("The SDK for Vamp plugins, an API for audio analysis and feature extraction plugins.")
     set_license("BSD-3-Clause AND MIT")
 
-    add_urls("https://github.com/vamp-plugins/vamp-plugin-sdk/archive/refs/tags/vamp-plugin-sdk-v$(version).tar.gz",
-             "https://github.com/vamp-plugins/vamp-plugin-sdk.git")
+    add_urls("https://github.com/vamp-plugins/vamp-plugin-sdk.git")
 
-    --No new release tag since the addition of CMake build system, so use commit instead
-    add_versions("2.10+cmake", "44c2487763eb248a933e9eff9169cfadee375009")
+    add_versions("2024.11.20", "44c2487763eb248a933e9eff9169cfadee375009")
 
     add_deps("cmake")
 


### PR DESCRIPTION
-For version, uses the latest commit instead of a tagged version. Last tag was in 2020, CMake support was added in 2021, to support most platforms. So to make it buildable on more platforms, I've used the latest commit's hash instead.

-No options used
vamp-plugin-sdk uses 3 CMake options and all 3 are off by default, and for most cases, no need to define any of them.

-One string replacement
Removes -ldl for windows in https://github.com/vamp-plugins/vamp-plugin-sdk/blob/master/pkgconfig/vamp-hostsdk.pc.in. Not sure which other build platform options need it!

Initially thought it should be called vamp-sdk, but seems like in most places it's named vamp-plugin-sdk, hence name mismatch compared to the initial request.

This closes #9831 .