### PR TITLE
Auto-update limonp to v1.0.2

### DIFF
--- a/packages/l/limonp/xmake.lua
+++ b/packages/l/limonp/xmake.lua
@@ -7,6 +7,7 @@ package("limonp")
     add_urls("https://github.com/yanyiwu/limonp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/yanyiwu/limonp.git")
 
+    add_versions("v1.0.2", "0d98bd9c87bd82bcfc234107908969e7416145d8b5e996e43c5d2513c419b2c0")
     add_versions("v1.0.1", "c7b18794f020dbaa1006229b49a39217a463da0cb3586aee83eb7471f4ae71df")
     add_versions("v1.0.0", "57c088a10ceda774e05281b1fc7779455af2cc824969e331874871822452e24f")
     add_versions("v0.9.0", "92d90b262ab2e3375dd386731deeb028f88ee7d07d0695d53d10bef6887d2f5f")


### PR DESCRIPTION
New version of limonp detected (package version: v1.0.1, last github version: v1.0.2)