### PR TITLE
Auto-update aws-lc to v1.72.1

### DIFF
--- a/packages/a/aws-lc/xmake.lua
+++ b/packages/a/aws-lc/xmake.lua
@@ -5,6 +5,7 @@ package("aws-lc")
     add_urls("https://github.com/aws/aws-lc/archive/refs/tags/$(version).tar.gz",
              "https://github.com/aws/aws-lc.git")
 
+    add_versions("v1.72.1", "7ea49769625a20b7e21230be3692286877473cc075f214ce28231d427e2e757e")
     add_versions("v1.72.0", "f214c0e06e043c4f18b836059ccb5ecbed781173e8eed106839ee2dd4f4cc157")
     add_versions("v1.71.0", "31b1eed775294825f084c0d4e09df53e1cf036fb98a202a8c2c342543828a985")
     add_versions("v1.70.0", "533dd3f35639f44784c8ad9b73c279ec3959aba79c63b9726dd8066564b2058f")


### PR DESCRIPTION
New version of aws-lc detected (package version: v1.72.0, last github version: v1.72.1)