### PR TITLE
Auto-update libde265 to 1.0.18

### DIFF
--- a/packages/l/libde265/xmake.lua
+++ b/packages/l/libde265/xmake.lua
@@ -6,6 +6,7 @@ package("libde265")
     add_urls("https://github.com/strukturag/libde265/releases/download/v$(version)/libde265-$(version).tar.gz",
              "https://github.com/strukturag/libde265.git")
 
+    add_versions("1.0.18", "800478f3bf35f0621b14928ceb317579f3e8b23de4bd2aac29b6cb8be962bbd8")
     add_versions("1.0.16", "b92beb6b53c346db9a8fae968d686ab706240099cdd5aff87777362d668b0de7")
     add_versions("1.0.15", "00251986c29d34d3af7117ed05874950c875dd9292d016be29d3b3762666511d")
     add_versions("1.0.8", "24c791dd334fa521762320ff54f0febfd3c09fc978880a8c5fbc40a88f21d905")


### PR DESCRIPTION
New version of libde265 detected (package version: 1.0.16, last github version: 1.0.18)