### PR TITLE
Auto-update mongoose to 7.21

### DIFF
--- a/packages/m/mongoose/xmake.lua
+++ b/packages/m/mongoose/xmake.lua
@@ -8,6 +8,7 @@ package("mongoose")
     add_urls("https://github.com/cesanta/mongoose/archive/refs/tags/$(version).tar.gz",
              "https://github.com/cesanta/mongoose.git")
 
+    add_versions("7.21", "d4ddbd12c12f223abefcc0a74417a638ae5c118d7cf10ba546553c6b0e0b5ada")
     add_versions("7.20", "ede2371ff4e41e95fd7b2de83a7df727388307a64d3706046ead320defe35e7e")
     add_versions("7.19", "7ae38c9d673559d1d9c1bd72c0bdd4a98a2cae995e87cae98b4604d5951762b8")
     add_versions("7.18", "8b661e8aceb00528fc21993afe218b1da0f0154575a61b63ce0791ad8b66b112")


### PR DESCRIPTION
New version of mongoose detected (package version: 7.20, last github version: 7.21)