### PR TITLE
Auto-update urdfdom-headers to 3.0.0

### DIFF
--- a/packages/u/urdfdom-headers/xmake.lua
+++ b/packages/u/urdfdom-headers/xmake.lua
@@ -7,6 +7,7 @@ package("urdfdom-headers")
     add_urls("https://github.com/ros/urdfdom_headers/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ros/urdfdom_headers.git")
 
+    add_versions("3.0.0", "314b322696cbc64d87c31e859f1d4e9983873c1db2706d13d7c2aa8c1a31119e")
     add_versions("2.1.2", "3aeef6325b83f9283c9cee34f1e6f8d232acc7aeef2d47bc782a5193ae8aaec4")
     add_versions("2.1.0", "aa5509d1931d31acb070d34cee9f46a08e1d62b1f89d50a1392405cdf4f02966")
     add_versions("2.0.1", "3b624b05119cb9d9c89495b6580663ba8fd138b7fb28769c1f756c1d11102f52")


### PR DESCRIPTION
New version of urdfdom-headers detected (package version: 2.1.2, last github version: 3.0.0)