### PR TITLE
Auto-update openexr to v3.4.11

### DIFF
--- a/packages/o/openexr/xmake.lua
+++ b/packages/o/openexr/xmake.lua
@@ -6,6 +6,7 @@ package("openexr")
     add_urls("https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/$(version).tar.gz",
              "https://github.com/AcademySoftwareFoundation/openexr.git")
 
+    add_versions("v3.4.11", "63730442f5fd6c5a79395bdd199040ab3821c229066049f52a57424a984b16ed")
     add_versions("v3.4.10", "b61ae2d0fa4872c5f5fc45618f107945df37c0eba4853263091b949c513d3319")
     add_versions("v3.4.9", "328c6fcd794b2538d71c65b401264e6745cf65cbc18f404e55ec3c0230d2373c")
     add_versions("v3.4.7", "6f57641fb12b019867a766e602252ed4ccb26d7354e3a15688fe9c85a391716e")


### PR DESCRIPTION
New version of openexr detected (package version: v3.4.10, last github version: v3.4.11)