### PR TITLE
MINGW32 support

### DIFF
--- a/.github/workflows/mingw_msys2.yml
+++ b/.github/workflows/mingw_msys2.yml
@@ -15,9 +15,9 @@ jobs:
           - { msystem: MINGW64, kind: shared, arch: x86_64, prefix: /mingw64,
               install: "git base-devel unzip p7zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc-fortran" }
           - { msystem: MINGW32, kind: static, arch: i686,   prefix: /mingw32,
-              install: "git base-devel unzip p7zip" }
+              install: "git base-devel unzip p7zip mingw-w64-i686-toolchain" }
           - { msystem: MINGW32, kind: shared, arch: i686,   prefix: /mingw32,
-              install: "git base-devel unzip p7zip" }
+              install: "git base-devel unzip p7zip mingw-w64-i686-toolchain" }
     concurrency:
         group: ${{ github.ref }}-${{ github.base_ref }}-${{ github.head_ref }}-MSYS2_MINGW-${{ matrix.msystem }}-${{ matrix.kind }}-${{ matrix.arch }}
         cancel-in-progress: true
@@ -29,17 +29,19 @@ jobs:
           install: ${{ matrix.install }}
           update: true
 
-      # Pin the i686 GCC toolchain (incl. Fortran) to 15.2.0-14.
-      # MSYS2 has stopped publishing newer i686 Fortran builds, and the live
-      # toolchain group has moved to gcc 16.1.0. Installing matched 15.2.0-14
-      # tarballs together with --nodeps keeps the i686 environment internally
-      # consistent. Stopgap until we drop MINGW32 or migrate to WinLibs.
-      - name: Pin i686 toolchain to 15.2.0-14 (with Fortran)
+      # Downgrade i686 GCC packages to 15.2.0-14, the last revision for which
+      # MSYS2 still publishes a matching gcc-fortran build. The toolchain
+      # group (binutils, crt, headers, winpthreads, etc.) installed above
+      # stays at its current version and supplies the assembler, linker,
+      # CRT, and Windows headers; --nodeps lets us replace just gcc, gcc-libs,
+      # gcc-libgfortran, and gcc-fortran without pacman objecting to the
+      # version skew. Stopgap until we drop MINGW32 or migrate to WinLibs.
+      - name: Pin i686 GCC + Fortran to 15.2.0-14
         if: matrix.arch == 'i686'
         shell: msys2 {0}
         run: |
           set -euo pipefail
-          BASE="https://mirror.msys2.org/mingw/mingw32"
+          BASE="https://repo.msys2.org/mingw/mingw32"
           pacman -U --noconfirm --nodeps --nodeps \
             "$BASE/mingw-w64-i686-gcc-15.2.0-14-any.pkg.tar.zst" \
             "$BASE/mingw-w64-i686-gcc-libs-15.2.0-14-any.pkg.tar.zst" \

--- a/.github/workflows/mingw_msys2.yml
+++ b/.github/workflows/mingw_msys2.yml
@@ -1,34 +1,52 @@
 name: MingW (Msys2)
-
 on:
   pull_request:
     branches:
       - dev
-
 jobs:
   build:
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
-        include: [
-            { msystem: MINGW64, kind: static, arch: x86_64, prefix: /mingw64 },
-            { msystem: MINGW64, kind: shared, arch: x86_64, prefix: /mingw64 },
-            { msystem: MINGW32, kind: static, arch: i686,   prefix: /mingw32 },
-            { msystem: MINGW32, kind: shared, arch: i686,   prefix: /mingw32 }
-        ]
-
+        include:
+          - { msystem: MINGW64, kind: static, arch: x86_64, prefix: /mingw64,
+              install: "git base-devel unzip p7zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc-fortran" }
+          - { msystem: MINGW64, kind: shared, arch: x86_64, prefix: /mingw64,
+              install: "git base-devel unzip p7zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc-fortran" }
+          - { msystem: MINGW32, kind: static, arch: i686,   prefix: /mingw32,
+              install: "git base-devel unzip p7zip" }
+          - { msystem: MINGW32, kind: shared, arch: i686,   prefix: /mingw32,
+              install: "git base-devel unzip p7zip" }
     concurrency:
         group: ${{ github.ref }}-${{ github.base_ref }}-${{ github.head_ref }}-MSYS2_MINGW-${{ matrix.msystem }}-${{ matrix.kind }}-${{ matrix.arch }}
         cancel-in-progress: true
     steps:
-
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6.0.2
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}
-          install: git base-devel unzip p7zip mingw-w64-${{ matrix.arch }}-toolchain mingw-w64-${{ matrix.arch }}-gcc-fortran
+          install: ${{ matrix.install }}
           update: true
+
+      # Pin the entire i686 GCC toolchain (incl. Fortran) to 15.2.0-14.
+      # MSYS2 has stopped publishing newer i686 Fortran builds, and the live
+      # toolchain group has moved to gcc 16.1.0. Installing matched 15.2.0-14
+      # tarballs together with --nodeps keeps the i686 environment internally
+      # consistent. Stopgap until we drop MINGW32 or migrate to WinLibs.
+      - name: Pin i686 toolchain to 15.2.0-14 (with Fortran)
+        if: matrix.arch == 'i686'
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          BASE="https://mirror.msys2.org/mingw/mingw32"
+          pacman -U --noconfirm --nodeps --nodeps \
+            "$BASE/mingw-w64-i686-gcc-15.2.0-14-any.pkg.tar.zst" \
+            "$BASE/mingw-w64-i686-gcc-libs-15.2.0-14-any.pkg.tar.zst" \
+            "$BASE/mingw-w64-i686-gcc-libgfortran-15.2.0-14-any.pkg.tar.zst" \
+            "$BASE/mingw-w64-i686-gcc-fortran-15.2.0-14-any.pkg.tar.zst"
+          gcc --version
+          gfortran --version
 
       - name: Prepare
         shell: msys2 {0}
@@ -42,7 +60,6 @@ jobs:
           cd ..
           git reset --hard HEAD
           git clean -fdx
-
       - name: Tests
         shell: msys2 {0}
         run: |
@@ -51,4 +68,3 @@ jobs:
           else
             xmake l ./scripts/test.lua -vD -p mingw -a i386 -k ${{ matrix.kind }}
           fi
-

--- a/.github/workflows/mingw_msys2.yml
+++ b/.github/workflows/mingw_msys2.yml
@@ -10,14 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { msystem: MINGW64, kind: static, arch: x86_64, prefix: /mingw64,
-              install: "git base-devel unzip p7zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc-fortran" }
-          - { msystem: MINGW64, kind: shared, arch: x86_64, prefix: /mingw64,
-              install: "git base-devel unzip p7zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc-fortran" }
-          - { msystem: MINGW32, kind: static, arch: i686,   prefix: /mingw32,
-              install: "git base-devel unzip p7zip mingw-w64-i686-toolchain" }
-          - { msystem: MINGW32, kind: shared, arch: i686,   prefix: /mingw32,
-              install: "git base-devel unzip p7zip mingw-w64-i686-toolchain" }
+          - { msystem: MINGW64, kind: static, arch: x86_64, prefix: /mingw64 }
+          - { msystem: MINGW64, kind: shared, arch: x86_64, prefix: /mingw64 }
+          - { msystem: MINGW32, kind: static, arch: i686,   prefix: /mingw32 }
+          - { msystem: MINGW32, kind: shared, arch: i686,   prefix: /mingw32 }
     concurrency:
         group: ${{ github.ref }}-${{ github.base_ref }}-${{ github.head_ref }}-MSYS2_MINGW-${{ matrix.msystem }}-${{ matrix.kind }}-${{ matrix.arch }}
         cancel-in-progress: true
@@ -29,8 +25,18 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}
-          install: ${{ matrix.install }}
           update: true
+
+      - name: Install build dependencies
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          pacman -S --noconfirm --needed \
+            git base-devel unzip p7zip \
+            mingw-w64-${{ matrix.arch }}-toolchain
+          if [ "${{ matrix.arch }}" == "x86_64" ]; then
+            pacman -S --noconfirm --needed mingw-w64-x86_64-gcc-fortran
+          fi
 
       # Downgrade i686 GCC packages to 15.2.0-14, the last revision for which
       # MSYS2 still publishes a matching gcc-fortran build. The toolchain
@@ -65,6 +71,7 @@ jobs:
           cd ..
           git reset --hard HEAD
           git clean -fdx
+
       - name: Tests
         shell: msys2 {0}
         run: |

--- a/.github/workflows/mingw_msys2.yml
+++ b/.github/workflows/mingw_msys2.yml
@@ -29,7 +29,7 @@ jobs:
           install: ${{ matrix.install }}
           update: true
 
-      # Pin the entire i686 GCC toolchain (incl. Fortran) to 15.2.0-14.
+      # Pin the i686 GCC toolchain (incl. Fortran) to 15.2.0-14.
       # MSYS2 has stopped publishing newer i686 Fortran builds, and the live
       # toolchain group has moved to gcc 16.1.0. Installing matched 15.2.0-14
       # tarballs together with --nodeps keeps the i686 environment internally
@@ -45,12 +45,12 @@ jobs:
             "$BASE/mingw-w64-i686-gcc-libs-15.2.0-14-any.pkg.tar.zst" \
             "$BASE/mingw-w64-i686-gcc-libgfortran-15.2.0-14-any.pkg.tar.zst" \
             "$BASE/mingw-w64-i686-gcc-fortran-15.2.0-14-any.pkg.tar.zst"
-          gcc --version
-          gfortran --version
 
       - name: Prepare
         shell: msys2 {0}
         run: |
+          gcc --version
+          gfortran --version
           git clone https://github.com/xmake-io/xmake.git --recurse-submodules -b master
           cd xmake
           ./configure

--- a/.github/workflows/mingw_msys2.yml
+++ b/.github/workflows/mingw_msys2.yml
@@ -23,6 +23,9 @@ jobs:
         cancel-in-progress: true
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}

--- a/packages/g/glad/xmake.lua
+++ b/packages/g/glad/xmake.lua
@@ -39,7 +39,6 @@ package("glad")
         if package:is_plat("windows") then
             table.insert(configs, "-DUSE_MSVC_RUNTIME_LIBRARY_DLL=" .. (package:config("vs_runtime"):startswith("MT") and "OFF" or "ON"))
         end
-
         table.insert(configs, "-DGLAD_NO_LOADER=" .. (package:config("loader") and "OFF" or "ON"))
         table.insert(configs, "-DGLAD_REPRODUCIBLE=" .. (package:config("reproducible") and "ON" or "OFF"))
         table.insert(configs, "-DGLAD_PROFILE=" .. package:config("profile"))


### PR DESCRIPTION
MSYS drops MINGW32 packages such as pkgconfig and now as we see fortran has failed to fetch as it got removed recently for 16th gcc... Downgrade to workaround this. Or either just drop MINGW32