### PR TITLE
Auto-update libgit2 to v1.9.3

### DIFF
--- a/packages/l/libgit2/xmake.lua
+++ b/packages/l/libgit2/xmake.lua
@@ -6,6 +6,7 @@ package("libgit2")
     set_urls("https://github.com/libgit2/libgit2/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libgit2/libgit2.git")
 
+    add_versions("v1.9.3", "d532172d7ab24d2a25944e2434212d63ee85f3650e97b5f7579e7f201a78ad64")
     add_versions("v1.9.2", "6f097c82fc06ece4f40539fb17e9d41baf1a5a2fc26b1b8562d21b89bc355fe6")
     add_versions("v1.9.1", "14cab3014b2b7ad75970ff4548e83615f74d719afe00aa479b4a889c1e13fc00")
     add_versions("v1.9.0", "75b27d4d6df44bd34e2f70663cfd998f5ec41e680e1e593238bbe517a84c7ed2")


### PR DESCRIPTION
New version of libgit2 detected (package version: v1.9.2, last github version: v1.9.3)