### PR TITLE
Auto-update cpp-peglib to 1.10.3

### DIFF
--- a/packages/c/cpp-peglib/xmake.lua
+++ b/packages/c/cpp-peglib/xmake.lua
@@ -8,6 +8,7 @@ package("cpp-peglib")
     set_urls("https://github.com/yhirose/cpp-peglib/archive/refs/tags/v$(version).tar.gz",
              "https://github.com/yhirose/cpp-peglib.git")
 
+    add_versions("1.10.3", "af654d345788715754cee3757433837620aed38a2efc30a3e94ee709bf407ba0")
     add_versions("1.10.2", "a20d79c32b91ed08f845b91a138c5958b3eb819d2127afcc64714ec1a6ad451b")
     add_versions("1.10.1", "3ba50bdc1be5521affc507e9fa589526372f6d7396ec490f706255a2b30d9635")
     add_versions("1.9.1", "f57aa0f14372cbb772af29e3a4549a8033ea07eb25c39949cba6178e0e2ba9cc")


### PR DESCRIPTION
New version of cpp-peglib detected (package version: 1.10.2, last github version: 1.10.3)