### PR TITLE
ffmpeg: ffplay needs libsdl2

### DIFF
--- a/packages/f/ffmpeg/xmake.lua
+++ b/packages/f/ffmpeg/xmake.lua
@@ -116,6 +116,7 @@ package("ffmpeg")
             libdav1d    = "dav1d",
             nvenc       = "nv-codec-headers",
             nvdec       = "nv-codec-headers",
+            ffplay      = "libsdl2",
         }
         for name, dep in pairs(configdeps) do
             if package:config(name) then


### PR DESCRIPTION
ffplay needs libsdl2 [as can be seen in configure script](https://github.com/FFmpeg/FFmpeg/blob/f2e5eff3ff2141479da980fc9474a8f8ecf768a8/configure#L4379)