### PR TITLE
Auto-update botan to 3.12.0

### DIFF
--- a/packages/b/botan/xmake.lua
+++ b/packages/b/botan/xmake.lua
@@ -6,6 +6,7 @@ package("botan")
     set_urls("https://github.com/randombit/botan/archive/refs/tags/$(version).tar.gz",
              "https://github.com/randombit/botan.git")
 
+    add_versions("3.12.0", "cf152f47723876a7b8544925fc37183089933b95b9b30f41e79ab2f263ab7995")
     add_versions("3.11.1", "444e41174889d8404cd409e260d85814aadcd1c49076da8fd6763f58ce36608d")
     add_versions("3.8.1", "8eb79a49c1a3f7e5e7563c13752a37557de935cdac48d9221ea4b580158e8965")
     add_versions("3.7.1", "8d2a072c7cdca6cadd16f89bb966fce1b3ec77cb4614bf1d87dec1337a3d2330")


### PR DESCRIPTION
New version of botan detected (package version: 3.11.1, last github version: 3.12.0)