### PR TITLE
Auto-update awk to 20260426

### DIFF
--- a/packages/a/awk/xmake.lua
+++ b/packages/a/awk/xmake.lua
@@ -7,6 +7,7 @@ package("awk")
     add_urls("https://github.com/onetrueawk/awk/archive/refs/tags/$(version).tar.gz", 
              "https://github.com/onetrueawk/awk.git")
 
+    add_versions("20260426", "7ae5b9fc6a8149bc45ea0ba3ba434a69a16d1460d19f6d01b6f04cc885b8e02b")
     add_versions("20251225", "626d7d19f8e4ceae70f60e2e662291789e0f54ab86945317a3d5693c30f847a2")
 
     add_deps("bison")


### PR DESCRIPTION
New version of awk detected (package version: 20251225, last github version: 20260426)