### PR TITLE
Add geo-utils-cpp v1.0.1

### DIFF
--- a/packages/g/geo-utils-cpp/xmake.lua
+++ b/packages/g/geo-utils-cpp/xmake.lua
@@ -16,9 +16,10 @@ package("geo-utils-cpp")
 
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
-            geo::LatLng a{0.0, 0.0};
-            geo::LatLng b{1.0, 1.0};
-            volatile double d = geo::distance_between(a, b);
-            (void)d;
+            void test() {
+                geo::LatLng a{0.0, 0.0};
+                geo::LatLng b{1.0, 1.0};
+                volatile double d = geo::distance_between(a, b);
+            }
         ]]}, {configs = {languages = "c++17"}, includes = "geo/geo.hpp"}))
     end)

--- a/packages/g/geo-utils-cpp/xmake.lua
+++ b/packages/g/geo-utils-cpp/xmake.lua
@@ -1,0 +1,24 @@
+package("geo-utils-cpp")
+    set_kind("library", {headeronly = true})
+    set_homepage("https://github.com/gistrec/geo-utils-cpp")
+    set_description("Header-only C++17 library for spherical (lat/lng) geometry on Earth coordinates: distance, bearing, polygon area, point-in-polygon, and path proximity.")
+    set_license("Apache-2.0")
+
+    add_urls("https://github.com/gistrec/geo-utils-cpp/archive/refs/tags/v$(version).tar.gz",
+             "https://github.com/gistrec/geo-utils-cpp.git")
+
+    add_versions("1.0.1", "2594b5dd736dab3ee99dc586dd326f699b90243b6074df582a32547f90b82a08")
+
+    on_install(function (package)
+        os.cp("include/geo", package:installdir("include"))
+        os.cp("LICENSE", package:installdir("share", package:name()))
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            geo::LatLng a{0.0, 0.0};
+            geo::LatLng b{1.0, 1.0};
+            volatile double d = geo::distance_between(a, b);
+            (void)d;
+        ]]}, {configs = {languages = "c++17"}, includes = "geo/geo.hpp"}))
+    end)


### PR DESCRIPTION
Adds [geo-utils-cpp](https://github.com/gistrec/geo-utils-cpp) — a header-only C++17 library for spherical (lat/lng) geometry on Earth coordinates: distance, bearing, polygon area, point-in-polygon, and path proximity.

- License: Apache-2.0
- Header-only, no runtime dependencies
- Headers under `include/geo/` (entry point: `<geo/geo.hpp>`)
- Already published in [microsoft/vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/geo-utils-cpp); Conan recipe in flight ([conan-io/conan-center-index#30152](https://github.com/conan-io/conan-center-index/pull/30152))

Install path is a straight `os.cp("include/geo", ...)` since the library is fully header-only — no CMake involvement needed for the consumer side.

Test snippet exercises the public API surface:
```cpp
#include <geo/geo.hpp>
void test() {
    geo::LatLng a{0.0, 0.0};
    geo::LatLng b{1.0, 1.0};
    volatile double d = geo::distance_between(a, b);
    (void)d;
}
```
Compiled with `c++17`.