### PR TITLE
Auto-update daxa to 3.6

### DIFF
--- a/packages/d/daxa/xmake.lua
+++ b/packages/d/daxa/xmake.lua
@@ -51,24 +51,34 @@ package("daxa")
     on_install("linux", function (package)
         -- GCC 15 changed uint64_t from unsigned long to unsigned long long on some platforms,
         -- causing ull/ll literals to mismatch u64/i64 in template deduction.
-        -- Also: imgui 1.91.x changed ImTextureID from void* to ImU64.
-        io.replace("src/impl_swapchain.cpp",
-            "std::max(0ll, self->cpu_frame_timeline)",
-            "std::max(i64{0}, self->cpu_frame_timeline)", {plain = true})
-        io.replace("src/utils/impl_task_graph_mk2.cpp",
-            "auto transient_heap_size = 0ull;",
-            "VkDeviceSize transient_heap_size = 0;", {plain = true})
-        io.replace("src/utils/impl_task_graph_mk2.cpp",
-            "auto transient_heap_alignment = 0ull;",
-            "VkDeviceSize transient_heap_alignment = 0;", {plain = true})
-        -- align_up(current_offset, sizeof(X)): current_offset is u64, sizeof is size_t
-        io.replace("src/utils/impl_task_graph_mk2.cpp",
-            "align_up(current_offset,",
-            "align_up<u64>(current_offset,", {plain = true})
-        -- std::min(actual_size, cinfo.size): usize vs u64 deduction conflict
-        io.replace("src/utils/impl_task_graph_mk2.cpp",
-            "std::min(actual_size, cinfo.size)",
-            "std::min<u64>(actual_size, cinfo.size)", {plain = true})
+        if package:version() and package:version():lt("3.6") then
+            io.replace("src/impl_swapchain.cpp",
+                "std::max(0ll, self->cpu_frame_timeline)",
+                "std::max(i64{0}, self->cpu_frame_timeline)", {plain = true})
+            io.replace("src/utils/impl_task_graph_mk2.cpp",
+                "auto transient_heap_size = 0ull;",
+                "VkDeviceSize transient_heap_size = 0;", {plain = true})
+            io.replace("src/utils/impl_task_graph_mk2.cpp",
+                "auto transient_heap_alignment = 0ull;",
+                "VkDeviceSize transient_heap_alignment = 0;", {plain = true})
+            -- align_up(current_offset, sizeof(X)): current_offset is u64, sizeof is size_t
+            io.replace("src/utils/impl_task_graph_mk2.cpp",
+                "align_up(current_offset,",
+                "align_up<u64>(current_offset,", {plain = true})
+            -- std::min(actual_size, cinfo.size): usize vs u64 deduction conflict
+            io.replace("src/utils/impl_task_graph_mk2.cpp",
+                "std::min(actual_size, cinfo.size)",
+                "std::min<u64>(actual_size, cinfo.size)", {plain = true})
+        else
+            -- align_up(current_offset, sizeof(X)): current_offset is u64, sizeof is size_t
+            io.replace("src/utils/impl_task_graph.cpp",
+                "align_up(current_offset,",
+                "align_up<u64>(current_offset,", {plain = true})
+            -- std::min(actual_size, cinfo.size): usize vs u64 deduction conflict
+            io.replace("src/utils/impl_task_graph.cpp",
+                "std::min(actual_size, cinfo.size)",
+                "std::min<u64>(actual_size, cinfo.size)", {plain = true})
+        end
         io.replace("src/utils/impl_task_graph_ui.cpp",
             "std::min(255ull, resource.name.size())",
             "std::min<size_t>(255, resource.name.size())", {plain = true})

--- a/packages/d/daxa/xmake.lua
+++ b/packages/d/daxa/xmake.lua
@@ -70,6 +70,12 @@ package("daxa")
                 "std::min(actual_size, cinfo.size)",
                 "std::min<u64>(actual_size, cinfo.size)", {plain = true})
         else
+            io.replace("src/utils/impl_task_graph.cpp",
+                "auto resource_heap_size = 0ull;",
+                "VkDeviceSize resource_heap_size = 0;", {plain = true})
+            io.replace("src/utils/impl_task_graph.cpp",
+                "auto resource_heap_alignment = 0ull;",
+                "VkDeviceSize resource_heap_alignment = 0;", {plain = true})
             -- align_up(current_offset, sizeof(X)): current_offset is u64, sizeof is size_t
             io.replace("src/utils/impl_task_graph.cpp",
                 "align_up(current_offset,",

--- a/packages/d/daxa/xmake.lua
+++ b/packages/d/daxa/xmake.lua
@@ -6,6 +6,7 @@ package("daxa")
     add_urls("https://github.com/Ipotrick/Daxa/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Ipotrick/Daxa.git")
 
+    add_versions("3.6", "85913c6169a08dea4f56095709b7571380a543a307de11bcb445ddd544d03442")
     add_versions("3.5", "e5c257a945cbd06a11031cf69fc887d59504777d9d127d8b6f9705ec6bdc08c7")
 
     add_configs("imgui", {description = "The ImGUI Daxa utility", default = true, type = "boolean"})


### PR DESCRIPTION
New version of daxa detected (package version: 3.5, last github version: 3.6)