### PR TITLE
Auto-update uwebsockets to v20.77.0

### DIFF
--- a/packages/u/uwebsockets/xmake.lua
+++ b/packages/u/uwebsockets/xmake.lua
@@ -7,6 +7,7 @@ package("uwebsockets")
     add_urls("https://github.com/uNetworking/uWebSockets/archive/refs/tags/$(version).tar.gz",
              "https://github.com/uNetworking/uWebSockets.git")
 
+    add_versions("v20.77.0", "9884f7bce0d34c776d450f1a1f31858aaced74c4454f2758543ed557df07d1e0")
     add_versions("v20.75.0", "05c384e410d374ce81abc17c9ee9574f33611d4a020f1da26f444f0dfe9691d7")
     add_versions("v20.74.0", "e1d9c99b8e87e78a9aaa89ca3ebaa450ef0ba22304d24978bb108777db73676c")
     add_versions("v20.72.0", "ee15b503e85fcfd6d3e7f67e229bf8ffaee521a1fbdb6224a04265aaec4ea5c3")


### PR DESCRIPTION
New version of uwebsockets detected (package version: v20.75.0, last github version: v20.77.0)