### PR TITLE
Auto-update omath to v5.2.0

### DIFF
--- a/packages/o/omath/xmake.lua
+++ b/packages/o/omath/xmake.lua
@@ -6,6 +6,7 @@ package("omath")
     add_urls("https://github.com/orange-cpp/omath/archive/refs/tags/$(version).tar.gz",
              "https://github.com/orange-cpp/omath.git", {submodules = false})
 
+    add_versions("v5.2.0", "23f1a6cd054006cb9f7d4cfadfa4a037fca4be3637ab606476a5a06a3308acdf")
     add_versions("v5.0.0", "1ec20f2216f46ca67fc24b9b3fef39e9397470e486ca40c5a3c3dd1574cfcdc3")
     add_versions("v4.7.0", "39ae487634d8df85bc3e21a72f6f58c76a0f654883ea2ee23f14a1db1c4ed802")
     add_versions("v4.6.1", "2d110f10340eede0b4ed7891af2da76bcfbaeb4fe48a8a2d69f617759361f4e0")


### PR DESCRIPTION
New version of omath detected (package version: v5.0.0, last github version: v5.2.0)