### PR TITLE
Add HarmonyOS target support for openssl/openssl3

### DIFF
--- a/packages/o/openssl/configure/patch.lua
+++ b/packages/o/openssl/configure/patch.lua
@@ -168,8 +168,30 @@ function _replace_NUL_with_null(package)
     io.replace("Configurations/10-main.conf", "NUL", "null", {plain = true})
 end
 
+function _add_ohos_targets(package)
+    if package:is_plat("harmony") then
+        io.gsub("Configurations/10-main.conf",
+            [=[("linux%-aarch64"%s-=>%s-{.-},)]=],
+            [=[%1
+
+    "ohos-aarch64" => {
+        inherit_from     => [ "linux-aarch64" ],
+        shared_extension => ".so"
+    },
+    "ohos-arm" => {
+        inherit_from     => [ "linux-armv4" ],
+        shared_extension => ".so"
+    },
+    "ohos-x86_64" => {
+        inherit_from     => [ "linux-x86_64" ],
+        shared_extension => ".so"
+    },]=])
+    end
+end
+
 function main(package)
     _remove_unused_pod_usage(package)
     _replace_NUL_with_null(package)
     _fix_overlong_make_recipe(package)
+    _add_ohos_targets(package)
 end

--- a/packages/o/openssl/xmake.lua
+++ b/packages/o/openssl/xmake.lua
@@ -114,7 +114,7 @@ package("openssl")
         end
     end)
 
-    on_install("linux", "macosx", "bsd", "cross", "android", "iphoneos", "mingw", function (package)
+    on_install("linux", "macosx", "bsd", "cross", "android", "iphoneos", "mingw", "harmony", function (package)
         -- https://wiki.openssl.org/index.php/Compilation_and_Installation#PREFIX_and_OPENSSLDIR
         local configs = (not package:version():le("1.1.0")) and {"no-tests"} or {}
         if package:is_cross() or package:is_plat("mingw") then
@@ -150,6 +150,15 @@ package("openssl")
                     target_arch = "riscv64"
                 elseif package:is_arch(".*64") then
                     target_arch = "generic64"
+                end
+            elseif package:is_plat("harmony") then
+                target_plat = "ohos"
+                if package:is_arch("x86_64") then
+                    target_arch = "x86_64"
+                elseif package:is_arch("arm64", "arm64-v8a") then
+                    target_arch = "aarch64"
+                elseif package:is_arch("arm.*") then
+                    target_arch = "arm"
                 end
             else
                 target_plat = "linux"

--- a/packages/o/openssl3/configure/patch.lua
+++ b/packages/o/openssl3/configure/patch.lua
@@ -1,0 +1,25 @@
+function _add_ohos_targets(package)
+    if package:is_plat("harmony") then
+        io.gsub("Configurations/10-main.conf",
+            [=[("linux%-x86_64"%s-=>%s-{.-},)]=],
+            [=[%1
+
+    "ohos-aarch64" => {
+        inherit_from     => [ "linux-aarch64" ],
+        shared_extension => ".so"
+    },
+    "ohos-arm" => {
+        inherit_from     => [ "linux-armv4" ],
+        ex_libs          => add("-lclang_rt.builtins"),
+        shared_extension => ".so"
+    },
+    "ohos-x86_64" => {
+        inherit_from     => [ "linux-x86_64" ],
+        shared_extension => ".so"
+    },]=])
+    end
+end
+
+function main(package)
+    _add_ohos_targets(package)
+end

--- a/packages/o/openssl3/xmake.lua
+++ b/packages/o/openssl3/xmake.lua
@@ -207,7 +207,7 @@ package("openssl3")
         end
     end)
 
-    on_install("linux", "cross", "android", "iphoneos", "wasm", function (package)
+    on_install("linux", "cross", "android", "iphoneos", "wasm", "harmony", function (package)
         local target_arch = "generic32"
         if package:is_arch("x86_64") then
             target_arch = "x86_64"
@@ -225,6 +225,13 @@ package("openssl3")
         if package:is_plat("macosx") then
             target_plat = "darwin64"
             target_arch = "x86_64-cc"
+        elseif package:is_plat("harmony") then
+            target_plat = "ohos"
+            if package:is_arch("arm64", "arm64-v8a") then
+                target_arch = "aarch64"
+            elseif package:is_arch("arm.*") then
+                target_arch = "arm"
+            end
         elseif package:is_plat("iphoneos") then
             local xcode = package:toolchain("xcode")
             local simulator = xcode and xcode:config("appledev") == "simulator"
@@ -258,6 +265,7 @@ package("openssl3")
             table.insert(configs, "no-afalgeng")
         end
 
+        import("configure.patch")(package)
         local buildenvs = import("package.tools.autoconf").buildenvs(package)
         if (package:is_cross() and package:is_plat("android") and is_subhost("windows")) or
             package:is_plat("wasm") then

--- a/scripts/packages.lua
+++ b/scripts/packages.lua
@@ -47,7 +47,7 @@ function main(opt)
             instance._BASE = _load_package(basename, basedir, basefile)
         end
         if instance then
-            for _, plat in ipairs({"windows", "linux", "macosx", "iphoneos", "android", "mingw", "msys", "bsd", "wasm", "cross"}) do
+            for _, plat in ipairs({"windows", "linux", "macosx", "iphoneos", "android", "mingw", "msys", "bsd", "wasm", "cross", "harmony"}) do
                 local archs = platform.archs(plat)
                 if archs then
                     local package_archs = {}


### PR DESCRIPTION
* Patch openssl/openssl3 `Configurations/10-main.conf` to inject ohos-aarch64/ohos-arm/ohos-x86_64 target definitions

* Add "harmony" to the platform list in the package test script

Patch files from:  https://github.com/ohos-rs/ohos-openssl/blob/main/patchs/openssl.patch & https://github.com/ohos-rs/ohos-openssl/blob/111/patchs/openssl.patch