### PR TITLE
Auto-update idna to 0.5.2

### DIFF
--- a/packages/i/idna/xmake.lua
+++ b/packages/i/idna/xmake.lua
@@ -6,6 +6,7 @@ package("idna")
     set_urls("https://github.com/ada-url/idna/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ada-url/idna.git")
 
+    add_versions("0.5.2", "8a5a844a8893542b770a31a309bfd767c1d1e7ac7a4278dcfeb5c201bb367d4d")
     add_versions("0.5.0", "4b6f2f8307cbac33625f1904136501dd5582d47d5fe07793916cd58475560a84")
     add_versions("0.4.0", "82f168993cdbb79f633242538e70f3b753118b091a9a91aaf4d0522a1e5ec285")
     add_versions("0.3.4", "67d15822575ef4ea3c9b71e0dc72cead86c45e0ba51c11722f9166f1f595c613")


### PR DESCRIPTION
New version of idna detected (package version: 0.5.0, last github version: 0.5.2)