### PR TITLE
Auto-update vcpkg to 2026.04.27

### DIFF
--- a/packages/v/vcpkg/xmake.lua
+++ b/packages/v/vcpkg/xmake.lua
@@ -5,6 +5,7 @@ package("vcpkg")
     set_license("MIT")
 
     add_urls("https://github.com/microsoft/vcpkg/archive/refs/tags/$(version).tar.gz")
+    add_versions("2026.04.27", "d16031ddc44ca990052a6cee0e76aa240fa01397930dbc5eb054852d1816d860")
     add_versions("2026.03.18", "96bd7fa4745c8b42c16f585c47ddf09d5eef3fc35714654f755de379294f5245")
     add_versions("2026.01.16", "3949aef319ca0dce2eee7ea147733a7c225d6211e35f0558c7058730d2b78971")
     add_versions("2025.12.12", "fd3aedfae4d80fc9af5b2c4598ccc697586c7fda52e77c9a993f2ec2b4622d98")


### PR DESCRIPTION
New version of vcpkg detected (package version: 2026.03.18, last github version: 2026.04.27)