### PR TITLE
Auto-update sqlpp11 to 0.66

### DIFF
--- a/packages/s/sqlpp11/xmake.lua
+++ b/packages/s/sqlpp11/xmake.lua
@@ -6,6 +6,7 @@ package("sqlpp11")
 
     add_urls("https://github.com/rbock/sqlpp11/archive/refs/tags/$(version).tar.gz",
              "https://github.com/rbock/sqlpp11.git")
+    add_versions("0.66", "f0692bc223c3787e1c60cba5341f0b4420292535620b93ca99b1a054f6ca0726")
     add_versions("0.65", "aebdfc2d323f9020c75f67e443e92321a6a275f4324b5cf5a629c40651853f62")
     add_versions("0.64", "72e6d37c716cc45b38c3cf4541604f16224aaa3b511d1f1d0be0c49176c3be86")
     add_versions("0.61", "d5a95e28ae93930f7701f517b1342ac14bcf33a9b1c5b5f0dff6aea5e315bb50")


### PR DESCRIPTION
New version of sqlpp11 detected (package version: 0.65, last github version: 0.66)