### PR TITLE
Auto-update fbgemm to v1.7.0

### DIFF
--- a/packages/f/fbgemm/xmake.lua
+++ b/packages/f/fbgemm/xmake.lua
@@ -6,6 +6,7 @@ package("fbgemm")
     add_urls("https://github.com/pytorch/FBGEMM/archive/refs/tags/$(version).tar.gz",
              "https://github.com/pytorch/FBGEMM.git", {submodules = false})
 
+    add_versions("v1.7.0", "ea56354b03b8ec0cbb66c1b3bd66487d84ecc59530137e5daed3c37529d76f47")
     add_versions("v1.2.0", "f679c3a9d0b0b1511122dca39c553b52d1fbf23c563f897d8218746a087f8bed")
     add_versions("v1.1.2", "15f89d724a00ce2f82ea7c1782e3fdc5c472d0ad37698498c0f419cc4924d8c8")
     add_versions("v1.1.0", "ca55019d6b75952a14c64aed0b6b90df06b21196a1152ab97c385964cc996a30")


### PR DESCRIPTION
New version of fbgemm detected (package version: v1.2.0, last github version: v1.7.0)