### PR TITLE
fix(python): support non-standard OpenSSL layouts (Nix)

### DIFF
--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -178,7 +178,7 @@ package("python")
                     openssl_dir = path.directory(linkdir)
                     -- Check if includedirs is inside the same directory
                     for _, includedir in ipairs(openssl.sysincludedirs or openssl.includedirs or {}) do
-                        if includedir:startswith(openssl_dir .. "/") then
+                        if includedir:startswith(openssl_dir) and (openssl_dir == "/" or includedir:sub(openssl_dir:len() + 1, openssl_dir:len() + 1) == "/") then
                             openssl_has_standard_layout = true
                             break
                         end
@@ -186,7 +186,7 @@ package("python")
                 else
                     -- try to find if linkdir is root (brew has linkdir as root and includedirs inside)
                     for _, includedir in ipairs(openssl.sysincludedirs or openssl.includedirs or {}) do
-                        if includedir:startswith(linkdir) then
+                        if includedir:startswith(linkdir) and (linkdir == "/" or includedir:sub(linkdir:len() + 1, linkdir:len() + 1) == "/") then
                             openssl_dir = linkdir
                             openssl_has_standard_layout = true
                             break

--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -169,21 +169,31 @@ package("python")
 
         -- add openssl libs path
         local openssl = package:dep("openssl"):fetch()
+        local openssl_has_standard_layout = false
         if openssl then
+            -- Try to use --with-openssl for standard installs
             local openssl_dir
             for _, linkdir in ipairs(openssl.linkdirs) do
                 if path.filename(linkdir) == "lib" then
                     openssl_dir = path.directory(linkdir)
+                    -- Check if includedirs is inside the same directory
+                    for _, includedir in ipairs(openssl.sysincludedirs or openssl.includedirs or {}) do
+                        if includedir:startswith(openssl_dir .. "/") then
+                            openssl_has_standard_layout = true
+                            break
+                        end
+                    end
                 else
                     -- try to find if linkdir is root (brew has linkdir as root and includedirs inside)
-                    for _, includedir in ipairs(openssl.sysincludedirs or openssl.includedirs) do
+                    for _, includedir in ipairs(openssl.sysincludedirs or openssl.includedirs or {}) do
                         if includedir:startswith(linkdir) then
                             openssl_dir = linkdir
+                            openssl_has_standard_layout = true
                             break
                         end
                     end
                 end
-                if openssl_dir then
+                if openssl_has_standard_layout then
                     if version:ge("3.0") then
                         table.insert(configs, "--with-openssl=" .. openssl_dir)
                     else
@@ -243,8 +253,14 @@ package("python")
             table.insert(cppflags, "-fPIC")
         end
 
-        -- add external path for zlib and libffi
-        for _, libname in ipairs({"zlib", "libffi"}) do
+        -- add external path for zlib, libffi, and openssl (for non-standard layouts like Nix)
+        local external_libs = {"zlib", "libffi"}
+        -- Use the standard layout check result from above
+        if openssl and not openssl_has_standard_layout then
+            table.insert(external_libs, "openssl")
+        end
+
+        for _, libname in ipairs(external_libs) do
             local lib = package:dep(libname)
             if lib and not lib:is_system() then
                 local fetchinfo = lib:fetch({external = false})


### PR DESCRIPTION
## Problem

  Python package fails to build on NixOS with SSL module unavailable:

  ERROR: ssl module is not available

  ## Root Cause

  The python recipe assumes OpenSSL headers and libs are in the same root directory (standard layout like `/usr/local/ssl/`). It  uses `--with-openssl=/path` which expects both `include/` and `lib/` under the same directory.

  On Nix, OpenSSL components are in different store paths:
  - `libssl.so` in `/nix/store/xxx-openssl-3.6.1/lib`
  - Headers in `/nix/store/yyy-openssl-3.6.1-dev/include`

  This breaks `--with-openssl` detection.

  ## Solution

  1. Detect if OpenSSL has standard layout by checking if includedirs share prefix with linkdirs
  2. Use `--with-openssl` for standard layouts (Ubuntu, Homebrew, etc.)
  3. Fall back to `CPPFLAGS`/`LDFLAGS` for non-standard layouts (Nix)
  
  ## Testing

  Tested on NixOS with Nix flakes:
  - Python 3.14.3 builds successfully
  - SSL module works (`import ssl` OK)
  - pip installs correctly