### PR TITLE
Auto-update gyp-next to v0.22.2

### DIFF
--- a/packages/g/gyp-next/xmake.lua
+++ b/packages/g/gyp-next/xmake.lua
@@ -7,6 +7,7 @@ package("gyp-next")
 
     add_urls("https://github.com/nodejs/gyp-next/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nodejs/gyp-next.git")
+    add_versions("v0.22.2", "eec4d9ca36028a28bffa6313fb7db51d664f06f49387cb734369777a55730d4d")
     add_versions("v0.21.1", "d75d7a8365e823292d94d80ea2178aa37897272af275a71ce32493d931178caf")
     add_versions("v0.20.4", "c010591b853eb79d625a3f10277dadbdc0b69a1c3aaadb3be81d0c91cf97bfba")
     add_versions("v0.20.2", "7684f8b8758152485d5dff030e6e1502adaeb65c6f4da5791ca0c5192c373f43")


### PR DESCRIPTION
New version of gyp-next detected (package version: v0.21.1, last github version: v0.22.2)