### PR TITLE
Auto-update ocilib to v4.9.0

### DIFF
--- a/packages/o/ocilib/xmake.lua
+++ b/packages/o/ocilib/xmake.lua
@@ -6,6 +6,7 @@ package("ocilib")
     add_urls("https://github.com/vrogier/ocilib/archive/refs/tags/$(version).tar.gz",
              "https://github.com/vrogier/ocilib.git")
 
+    add_versions("v4.9.0", "71a09e31932b02973cc83ccbfa9d890dcc559913dc18b91f2df6169caf3e9d23")
     add_versions("v4.8.0", "dcaffe0766d9517ae2234e285dd07cae604c792c4016a9834584674f00e9b2ca")
     add_versions("v4.7.7", "92822cc683048d3a2cddbbc7835062a02a9011ed2d7382da52a4c120e8c911ab")
     add_versions("v4.7.6", "43f5093cac645518ad5bc8d6f48f5b77e12372ef84dc87ddb3a54c40e425bd26")


### PR DESCRIPTION
New version of ocilib detected (package version: v4.8.0, last github version: v4.9.0)