### PR TITLE
Auto-update librealsense to v2.58.1

### DIFF
--- a/packages/l/librealsense/xmake.lua
+++ b/packages/l/librealsense/xmake.lua
@@ -6,6 +6,7 @@ package("librealsense")
     add_urls("https://github.com/realsenseai/librealsense/archive/refs/tags/$(version).tar.gz",
              "https://github.com/realsenseai/librealsense.git", {submodules = false})
 
+    add_versions("v2.58.1", "14409c3b810bf1508b87f46d47608a89018743b8a73d5855ab5d1ad18763fd8c")
     add_versions("v2.57.7", "02eae8aa49d52d39ea5483836116fee2596e1146254274db6b76d7a62092d9e8")
     add_versions("v2.57.6", "4c5eeafe004422e564df4ba74cab0e89a4b32282d0e0d6c1e9b33382bb5ed767")
     add_versions("v2.57.5", "6fe337090becb668289178b20dfce07d553d4a71fd54ffbfee18b45847bcdee4")


### PR DESCRIPTION
New version of librealsense detected (package version: v2.57.7, last github version: v2.58.1)