### PR TITLE
Fix Python package OpenSSL detection for non-standard layouts

### DIFF
--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -169,21 +169,31 @@ package("python")
 
         -- add openssl libs path
         local openssl = package:dep("openssl"):fetch()
+        local openssl_has_standard_layout = false
         if openssl then
+            -- Try to use --with-openssl for standard installs
             local openssl_dir
             for _, linkdir in ipairs(openssl.linkdirs) do
                 if path.filename(linkdir) == "lib" then
                     openssl_dir = path.directory(linkdir)
+                    -- Check if includedirs is inside the same directory
+                    for _, includedir in ipairs(openssl.sysincludedirs or openssl.includedirs or {}) do
+                        if includedir:startswith(openssl_dir) and (openssl_dir == "/" or includedir:sub(openssl_dir:len() + 1, openssl_dir:len() + 1) == "/") then
+                            openssl_has_standard_layout = true
+                            break
+                        end
+                    end
                 else
                     -- try to find if linkdir is root (brew has linkdir as root and includedirs inside)
-                    for _, includedir in ipairs(openssl.sysincludedirs or openssl.includedirs) do
-                        if includedir:startswith(linkdir) then
+                    for _, includedir in ipairs(openssl.sysincludedirs or openssl.includedirs or {}) do
+                        if includedir:startswith(linkdir) and (linkdir == "/" or includedir:sub(linkdir:len() + 1, linkdir:len() + 1) == "/") then
                             openssl_dir = linkdir
+                            openssl_has_standard_layout = true
                             break
                         end
                     end
                 end
-                if openssl_dir then
+                if openssl_has_standard_layout then
                     if version:ge("3.0") then
                         table.insert(configs, "--with-openssl=" .. openssl_dir)
                     else
@@ -243,8 +253,14 @@ package("python")
             table.insert(cppflags, "-fPIC")
         end
 
-        -- add external path for zlib and libffi
-        for _, libname in ipairs({"zlib", "libffi"}) do
+        -- add external path for zlib, libffi, and openssl (for non-standard layouts like Nix)
+        local external_libs = {"zlib", "libffi"}
+        -- Use the standard layout check result from above
+        if openssl and not openssl_has_standard_layout then
+            table.insert(external_libs, "openssl")
+        end
+
+        for _, libname in ipairs(external_libs) do
             local lib = package:dep(libname)
             if lib and not lib:is_system() then
                 local fetchinfo = lib:fetch({external = false})

--- a/packages/p/python/xmake.lua
+++ b/packages/p/python/xmake.lua
@@ -176,21 +176,15 @@ package("python")
             for _, linkdir in ipairs(openssl.linkdirs) do
                 if path.filename(linkdir) == "lib" then
                     openssl_dir = path.directory(linkdir)
-                    -- Check if includedirs is inside the same directory
-                    for _, includedir in ipairs(openssl.sysincludedirs or openssl.includedirs or {}) do
-                        if includedir:startswith(openssl_dir) and (openssl_dir == "/" or includedir:sub(openssl_dir:len() + 1, openssl_dir:len() + 1) == "/") then
-                            openssl_has_standard_layout = true
-                            break
-                        end
-                    end
-                else
-                    -- try to find if linkdir is root (brew has linkdir as root and includedirs inside)
-                    for _, includedir in ipairs(openssl.sysincludedirs or openssl.includedirs or {}) do
-                        if includedir:startswith(linkdir) and (linkdir == "/" or includedir:sub(linkdir:len() + 1, linkdir:len() + 1) == "/") then
-                            openssl_dir = linkdir
-                            openssl_has_standard_layout = true
-                            break
-                        end
+                else 
+                    -- brew has linkdir as root and includedirs inside
+                    openssl_dir = linkdir
+                end 
+                -- Check if openssl uses a standard prefix/include layout
+                for _, includedir in ipairs(openssl.sysincludedirs or openssl.includedirs or {}) do
+                    if openssl_dir == "/" or includedir:startswith(openssl_dir .. "/") then
+                        openssl_has_standard_layout = true
+                        break
                     end
                 end
                 if openssl_has_standard_layout then


### PR DESCRIPTION
This patch improves OpenSSL layout detection in the Python package.

Changes:

* Detect whether OpenSSL follows a standard include/lib directory layout
* Only use `--with-openssl` when the layout is standard
* Fallback to external include/lib flags for non-standard layouts (e.g. Nix)
* Avoid incorrect prefix detection caused by naive `startswith()` matching

This fixes Python builds with OpenSSL installations that do not follow the usual:

* `<prefix>/include`
* `<prefix>/lib`

directory structure.

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.


