### PR TITLE
Auto-update ixwebsocket to v12.0.0

### DIFF
--- a/packages/i/ixwebsocket/xmake.lua
+++ b/packages/i/ixwebsocket/xmake.lua
@@ -6,6 +6,7 @@ package("ixwebsocket")
     add_urls("https://github.com/machinezone/IXWebSocket/archive/refs/tags/$(version).tar.gz",
              "https://github.com/machinezone/IXWebSocket.git")
 
+    add_versions("v12.0.0", "f193bc24e10c18ab8d31d6f31370fde8b31d3eaf1de32e1d8ab14d666659b8ad")
     add_versions("v11.4.6", "c024334f8e45980836c67008979a884d6dcc5ef067dd2eb1fa7241f4c17ddc32")
     add_versions("v11.4.5", "c5fc225edec32bf7d583e55347ef2c9c4940d005c13ef5e848354a85602f5fd6")
     add_versions("v11.4.4", "9ef7fba86a91ce18693451466ddc54b1e0c4a7dc4466c3028d888d6d55dde539")


### PR DESCRIPTION
New version of ixwebsocket detected (package version: v11.4.6, last github version: v12.0.0)