### PR TITLE
Auto-update libavif to v1.4.2

### DIFF
--- a/packages/l/libavif/xmake.lua
+++ b/packages/l/libavif/xmake.lua
@@ -6,6 +6,7 @@ package("libavif")
     add_urls("https://github.com/AOMediaCodec/libavif/archive/refs/tags/$(version).tar.gz",
              "https://github.com/AOMediaCodec/libavif.git")
 
+    add_versions("v1.4.2", "2b645287340ba5a631d268b551dc2d72bd73ac33335962dd36dcdb6d8366921d")
     add_versions("v1.4.1", "d4aea31a4becb3273ba7968221be2e48148ba05eb8a68d14e671963e17785648")
     add_versions("v1.3.0", "0a545e953cc049bf5bcf4ee467306a2f113a75110edf59e61248873101cd26c1")
     add_versions("v1.2.1", "9c859c7c12ccb0f407511bfe303e6a7247f5f6738f54852662c6df8048daddf4")


### PR DESCRIPTION
New version of libavif detected (package version: v1.4.1, last github version: v1.4.2)