### PR TITLE
feat: add crashcatch library package

### DIFF
--- a/packages/c/crashcatch/xmake.lua
+++ b/packages/c/crashcatch/xmake.lua
@@ -21,6 +21,12 @@ package("crashcatch")
         os.cp("include/*.hpp", package:installdir("include"))
     end)
 
-    on_test(function(package)
-        assert(package:has_cxxtypes("CrashCatch_Config", {configs = {languages = "cxx17"}, includes = "CrashCatchDLL.hpp"}))
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            #include <CrashCatchDLL.hpp>
+            int test() {
+                crashcatch_enable();
+                return 0;
+            }
+        ]]}, {configs = {languages = "cxx17"}}))
     end)

--- a/packages/c/crashcatch/xmake.lua
+++ b/packages/c/crashcatch/xmake.lua
@@ -8,9 +8,6 @@ package("crashcatch")
         "https://github.com/keithpotz/CrashCatch.git")
     add_versions("1.4.0", "b1b965626ee200c039cfacaa77cdf458074235014c65f1862101714ce6b1fdfc")
     add_versions("1.3.0", "9723153a76c3c840ded92f1c1e53fe5817d452bcc6d2309d5b0c2bd295de5ff0")
-    add_versions("1.2", "04e99b5627a8ceb2b62449f7be8b4b23ae98184284aab5c99d191dbb6d6fa188")
-    add_versions("1.1.0", "50907a8177cb600d22a93663e9ed6b0c4f404c9091f9d64a56121df1357b8bc8")
-    add_versions("1.0.0", "8bff2368892fbf7d7b3f976851005b35e36cda8f65cb481dcc042e189933e6a6")
 
     add_defines("CRASHCATCH_DLL_EXPORTS")
     if is_plat("linux") then
@@ -20,7 +17,7 @@ package("crashcatch")
         add_syslinks("dbghelp", "user32")
     end
 
-    on_install(function(package)
+    on_install("!macosx", function(package)
         os.cp("include/*.hpp", package:installdir("include"))
     end)
 

--- a/packages/c/crashcatch/xmake.lua
+++ b/packages/c/crashcatch/xmake.lua
@@ -1,0 +1,29 @@
+package("crashcatch")
+    set_kind("library", { headeronly = true })
+    set_homepage("https://github.com/keithpotz/CrashCatch")
+    set_description("A cross-platform, lightweight, single-header crash-reporting library for modern C++ applications.")
+    set_license("MIT")
+
+    add_urls("https://github.com/keithpotz/CrashCatch/archive/refs/tags/$(version).tar.gz",
+        "https://github.com/keithpotz/CrashCatch.git")
+    add_versions("v1.4.0", "b1b965626ee200c039cfacaa77cdf458074235014c65f1862101714ce6b1fdfc")
+    add_versions("v1.3.0", "9723153a76c3c840ded92f1c1e53fe5817d452bcc6d2309d5b0c2bd295de5ff0")
+    add_versions("v1.2", "04e99b5627a8ceb2b62449f7be8b4b23ae98184284aab5c99d191dbb6d6fa188")
+    add_versions("v1.1.0", "50907a8177cb600d22a93663e9ed6b0c4f404c9091f9d64a56121df1357b8bc8")
+    add_versions("v1.0.0", "8bff2368892fbf7d7b3f976851005b35e36cda8f65cb481dcc042e189933e6a6")
+
+    add_defines("CRASHCATCH_DLL_EXPORTS")
+    if is_plat("linux") then
+        add_syslinks("pthread")
+    elseif is_plat("windows") then
+        add_defines("_CRT_SECURE_NO_WARNINGS")
+        add_syslinks("dbghelp", "user32")
+    end
+
+    on_install(function(package)
+        os.cp("include/*.hpp", package:installdir("include"))
+    end)
+
+    on_test(function(package)
+        assert(package:has_cxxtypes("CrashCatch_Config", {configs = {languages = "cxx17"}, includes = "CrashCatchDLL.hpp"}))
+    end)

--- a/packages/c/crashcatch/xmake.lua
+++ b/packages/c/crashcatch/xmake.lua
@@ -17,7 +17,7 @@ package("crashcatch")
         add_syslinks("dbghelp", "user32")
     end
 
-    on_install("!macosx", function(package)
+    on_install("!android and !macosx", function(package)
         os.cp("include/*.hpp", package:installdir("include"))
     end)
 

--- a/packages/c/crashcatch/xmake.lua
+++ b/packages/c/crashcatch/xmake.lua
@@ -4,13 +4,13 @@ package("crashcatch")
     set_description("A cross-platform, lightweight, single-header crash-reporting library for modern C++ applications.")
     set_license("MIT")
 
-    add_urls("https://github.com/keithpotz/CrashCatch/archive/refs/tags/$(version).tar.gz",
+    add_urls("https://github.com/keithpotz/CrashCatch/archive/refs/tags/v$(version).tar.gz",
         "https://github.com/keithpotz/CrashCatch.git")
-    add_versions("v1.4.0", "b1b965626ee200c039cfacaa77cdf458074235014c65f1862101714ce6b1fdfc")
-    add_versions("v1.3.0", "9723153a76c3c840ded92f1c1e53fe5817d452bcc6d2309d5b0c2bd295de5ff0")
-    add_versions("v1.2", "04e99b5627a8ceb2b62449f7be8b4b23ae98184284aab5c99d191dbb6d6fa188")
-    add_versions("v1.1.0", "50907a8177cb600d22a93663e9ed6b0c4f404c9091f9d64a56121df1357b8bc8")
-    add_versions("v1.0.0", "8bff2368892fbf7d7b3f976851005b35e36cda8f65cb481dcc042e189933e6a6")
+    add_versions("1.4.0", "b1b965626ee200c039cfacaa77cdf458074235014c65f1862101714ce6b1fdfc")
+    add_versions("1.3.0", "9723153a76c3c840ded92f1c1e53fe5817d452bcc6d2309d5b0c2bd295de5ff0")
+    add_versions("1.2", "04e99b5627a8ceb2b62449f7be8b4b23ae98184284aab5c99d191dbb6d6fa188")
+    add_versions("1.1.0", "50907a8177cb600d22a93663e9ed6b0c4f404c9091f9d64a56121df1357b8bc8")
+    add_versions("1.0.0", "8bff2368892fbf7d7b3f976851005b35e36cda8f65cb481dcc042e189933e6a6")
 
     add_defines("CRASHCATCH_DLL_EXPORTS")
     if is_plat("linux") then


### PR DESCRIPTION
Add crashcatch package definition with xmake.lua configuration.
This includes a cross-platform, lightweight, single-header crash-reporting
library for modern C++ applications.

- Set up package metadata including homepage, description and license
- Add multiple version support (v1.0.0 to v1.4.0)
- Configure platform-specific dependencies (pthread for linux,
  dbghelp/user32 for windows)
- Implement install and test functions for the header-only library