### PR TITLE
Auto-update mariadb-connector-c to 3.4.9

### DIFF
--- a/packages/m/mariadb-connector-c/xmake.lua
+++ b/packages/m/mariadb-connector-c/xmake.lua
@@ -5,6 +5,7 @@ package("mariadb-connector-c")
 
     add_urls("https://github.com/mariadb-corporation/mariadb-connector-c/archive/refs/tags/v$(version).tar.gz")
 
+    add_versions("3.4.9", "2c70b74393d589df0bde9b3e17cb7b571d30a45aaf006eda7a273120fb660f3a")
     add_versions("3.4.8", "ced7e5063c91fe2bfafd9d63a759490fe53e81df80599a9abad01c570c202f0c")
     add_versions("3.4.7", "cf81cd1c71c3199da9d2125aee840cb6083d43e1ea4c60c4be5045bfc7824eba")
     add_versions("3.3.9", "062b9ec5c26cbb236a78f0ba26981272053f59bdfc113040bab904a9da36d31f")


### PR DESCRIPTION
New version of mariadb-connector-c detected (package version: 3.4.8, last github version: 3.4.9)