### PR TITLE
Auto-update libsolv to 0.7.39

### DIFF
--- a/packages/l/libsolv/xmake.lua
+++ b/packages/l/libsolv/xmake.lua
@@ -6,6 +6,7 @@ package("libsolv")
     add_urls("https://github.com/openSUSE/libsolv/archive/refs/tags/$(version).tar.gz",
              "https://github.com/openSUSE/libsolv.git")
 
+    add_versions("0.7.39", "2a74cbf1e49984cb01f75ac4b19a237f24de6ce199766858aeb9ab3aae2b95fa")
     add_versions("0.7.37", "ad6a38624dde26fc59c41427608536c443b76f90dcb6bb96c2e70b8e3ee20419")
     add_versions("0.7.36", "32b8a565b70b6ba81d9ad68070de4561dfc8462be12288725a267a90423c0fa6")
     add_versions("0.7.35", "e6ef552846f908beb3bbf6ca718b6dd431bd8a281086d82af9a6d2a3ba919be5")


### PR DESCRIPTION
New version of libsolv detected (package version: 0.7.37, last github version: 0.7.39)