### PR TITLE
Fix error for pango not building on windows (and possibly mingw)

### DIFF
--- a/packages/p/pango/xmake.lua
+++ b/packages/p/pango/xmake.lua
@@ -83,10 +83,13 @@ package("pango")
             envs.LDFLAGS = string.gsub(envs.LDFLAGS, "%-libpath:", "/libpath:")
         end
 
-        local cxflags
+        -- Force the Cairo static-build define into the compiler environment
+        -- so Meson's dependency/feature checks pick it up during configuration.
         if package:is_plat("windows", "mingw") and not package:dep("cairo"):config("shared") then
-            cxflags = "-DCAIRO_WIN32_STATIC_BUILD=1"
+            envs.CFLAGS   = (envs.CFLAGS or "")   .. " -DCAIRO_WIN32_STATIC_BUILD=1"
+            envs.CXXFLAGS = (envs.CXXFLAGS or "") .. " -DCAIRO_WIN32_STATIC_BUILD=1"
         end
+
         meson.install(package, configs, {envs = envs, cxflags = cxflags})
     end)
 

--- a/packages/p/pango/xmake.lua
+++ b/packages/p/pango/xmake.lua
@@ -85,12 +85,12 @@ package("pango")
 
         -- Force the Cairo static-build define into the compiler environment
         -- so Meson's dependency/feature checks pick it up during configuration.
-        if package:is_plat("windows", "mingw") and not package:dep("cairo"):config("shared") then
+        if package:is_plat("windows", "mingw") and package:dep("cairo") and not package:dep("cairo"):config("shared") then
             envs.CFLAGS   = (envs.CFLAGS or "")   .. " -DCAIRO_WIN32_STATIC_BUILD=1"
             envs.CXXFLAGS = (envs.CXXFLAGS or "") .. " -DCAIRO_WIN32_STATIC_BUILD=1"
         end
 
-        meson.install(package, configs, {envs = envs, cxflags = cxflags})
+        meson.install(package, configs, {envs = envs})
     end)
 
     on_test(function (package)


### PR DESCRIPTION
Despite the earlier code passing tests when submitting a new version of pango, pango was still failing being built for me on windows due to the same error encountered during submitting the new version (something relating to the cairo-ft check).

I tested the edit, it successfully built.

Why the CI passed in the previous commit but the local build failed for me, I'm not sure.