### PR TITLE
Auto-update aws-sdk-cpp to 1.11.817

### DIFF
--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -5,6 +5,7 @@ package("aws-sdk-cpp")
 
     add_urls("https://github.com/aws/aws-sdk-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/aws/aws-sdk-cpp.git")
+    add_versions("1.11.817", "18f65613ff591e1ed67d8b6ff086726ceeb7a3696d982f60edfdf67a24168fd8")
     add_versions("1.11.813", "3253922af460435592d9d1fe7e89d9fbde891235fe0abbe9d2319bf1776e62cc")
     add_versions("1.11.808", "f82a6289e11506b15c61b74c43da4c8f609395e7fa302fa09ad922ac6cd0b116")
     add_versions("1.11.802", "bee8a44185dfcc83f1252d0a0005d5f76c798562450a41773153bc20ed64f7ec")


### PR DESCRIPTION
New version of aws-sdk-cpp detected (package version: 1.11.813, last github version: 1.11.817)