### PR TITLE
Fix `gamenetworkingsockets` package `protobuf-cpp` dependency

### DIFF
--- a/packages/g/gamenetworkingsockets/xmake.lua
+++ b/packages/g/gamenetworkingsockets/xmake.lua
@@ -24,7 +24,7 @@ package("gamenetworkingsockets")
     on_load("windows", "linux", function(package)
         if not package:config("shared") then
             package:add("defines", "STEAMNETWORKINGSOCKETS_STATIC_LINK")
-            package:add("deps", "protobuf-cpp")
+            package:add("deps", "protobuf-cpp 29.3")
             if not package:is_plat("windows") then
                 package:add("deps", "openssl")
             end

--- a/packages/g/gamenetworkingsockets/xmake.lua
+++ b/packages/g/gamenetworkingsockets/xmake.lua
@@ -24,7 +24,7 @@ package("gamenetworkingsockets")
     on_load("windows", "linux", function(package)
         if not package:config("shared") then
             package:add("defines", "STEAMNETWORKINGSOCKETS_STATIC_LINK")
-            package:add("deps", "protobuf-cpp 29.3")
+            package:add("deps", "protobuf-cpp <30")
             if not package:is_plat("windows") then
                 package:add("deps", "openssl")
             end

--- a/packages/g/gamenetworkingsockets/xmake.lua
+++ b/packages/g/gamenetworkingsockets/xmake.lua
@@ -22,16 +22,18 @@ package("gamenetworkingsockets")
     add_configs("webrtc", {description = "Enable p2p.", default = false, type = "boolean"})
 
     on_load("windows", "linux", function(package)
-        if not package:config("shared") then
-            package:add("defines", "STEAMNETWORKINGSOCKETS_STATIC_LINK")
-            package:add("deps", "protobuf-cpp <30")
-            if not package:is_plat("windows") then
-                package:add("deps", "openssl")
-            end
-            if package:config("webrtc") then
-                package:add("deps", "abseil")
-            end
-        end
+       package:add("deps", "protobuf-cpp <30")
+       if not package:is_plat("windows") then
+           package:add("deps", "openssl")
+       end
+        
+       if package:config("webrtc") then
+          package:add("deps", "abseil")
+       end
+        
+       if not package:config("shared") then
+           package:add("defines", "STEAMNETWORKINGSOCKETS_STATIC_LINK")
+       end
     end)
 
     on_install("windows|x86", "windows|x64", "linux", function (package)


### PR DESCRIPTION
Pin protobuf-cpp to <30. Protobuf 30+ introduced API changes replacing several std::string return types with absl::string_view, which may cause compilation failures (and was causing compilation errors on my environment). 