### PR TITLE
Auto-update utfcpp to v4.1.1

### DIFF
--- a/packages/u/utfcpp/xmake.lua
+++ b/packages/u/utfcpp/xmake.lua
@@ -6,6 +6,7 @@ package("utfcpp")
 
     add_urls("https://github.com/nemtrif/utfcpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nemtrif/utfcpp.git")
+    add_versions("v4.1.1", "1ca68016f0abc24172998e39ce0d8f8e2b7a26f7579a0ff85d4e1b9a7aea56f8")
     add_versions("v4.0.9", "0902218f606e942ccc10724df8a988fc993c12da4b3adeace28a7f0211970e08")
     add_versions("v4.0.8", "f808b26d8c3a59def27fea207182ece77a8930bd121a69f80d328ecf3cfef925")
     add_versions("v4.0.6", "6920a6a5d6a04b9a89b2a89af7132f8acefd46e0c2a7b190350539e9213816c0")


### PR DESCRIPTION
New version of utfcpp detected (package version: v4.0.9, last github version: v4.1.1)