### PR TITLE
Auto-update node-addon-api to v8.8.0

### DIFF
--- a/packages/n/node-addon-api/xmake.lua
+++ b/packages/n/node-addon-api/xmake.lua
@@ -11,6 +11,7 @@ package("node-addon-api")
     set_urls("https://github.com/nodejs/node-addon-api/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nodejs/node-addon-api.git")
 
+    add_versions("v8.8.0", "5c87d586de7204fbe7ebc87e6ceb2d49fc9a6ead02803a263ebea8ff9b7d2060")
     add_versions("v8.7.0", "c0dace4e1d4ae280acca09cea8bbe7af20683ac226844d834b5f34a0abd78a89")
     add_versions("v8.6.0", "04da1219b6a03fb7ebdabf7e7f023f7434692f3e839fca8624f8a925563f36fe")
     add_versions("v8.5.0", "8097466a416a6766639bd2cffedbcade924a54ea65679298b860807c6a192c67")

--- a/packages/n/node-addon-api/xmake.lua
+++ b/packages/n/node-addon-api/xmake.lua
@@ -47,5 +47,6 @@ package("node-addon-api")
     end)
 
     on_test(function (package)
-        assert(package:has_cxxfuncs("Napi::Just(0)", {configs = {languages = "c++11"}, includes = "napi.h"}))
+        local languages = package:version() and package:version():ge("8.8.0") and "c++17" or "c++11"
+        assert(package:has_cxxfuncs("Napi::Just(0)", {configs = {languages = languages}, includes = "napi.h"}))
     end)

--- a/packages/n/node-api-headers/xmake.lua
+++ b/packages/n/node-api-headers/xmake.lua
@@ -6,6 +6,7 @@ package("node-api-headers")
 
     set_urls("https://github.com/nodejs/node-api-headers/archive/refs/tags/$(version).tar.gz",
              "https://github.com/nodejs/node-api-headers.git")
+    add_versions("v1.9.0", "071f773bd10479f865f6828b86fe8232d63e255290d9bbb7a0ec487c57310231")
     add_versions("v1.8.0", "e2337d314fbff54ddc3923893704596944ea922b141ac550803526e552a62193")
     add_versions("v1.7.0", "2f964cac4f90b4379ea6db4ac9635b39cd29ba63a0a1f892b0075871ff6d0216")
     add_versions("v1.6.0", "199b465efd4276b85f6b6132745aba1804c2372c848247aca3a5a6895799d9ae")
@@ -20,5 +21,6 @@ package("node-api-headers")
     end)
 
     on_test(function (package)
-        assert(package:has_cfuncs("napi_async_init", {includes = "node_api.h"}))
+        local languages = package:version() and package:version():ge("1.9.0") and "c++17" or "c++11"
+        assert(package:has_cfuncs("napi_async_init", {configs = {languages = languages}, includes = "node_api.h"}))
     end)


### PR DESCRIPTION
New version of node-addon-api detected (package version: v8.7.0, last github version: v8.8.0)