### PR TITLE
Auto-update libfiber to v1.1.0

### DIFF
--- a/packages/l/libfiber/xmake.lua
+++ b/packages/l/libfiber/xmake.lua
@@ -7,6 +7,7 @@ package("libfiber")
         return version:gsub("%+", ".")
     end})
     add_urls("https://github.com/iqiyi/libfiber.git")
+    add_versions("v1.1.0", "d9729a34b5a8438fab9387eaf9564cd0316673d142043f187f24cba9dc12d694")
     add_versions("v0.9.0+0", "9359a7ebc8d9c48cfaa4c7d1445b3a3e1c392a238574f1d4f7c1191ec8242af2")
 
     add_deps("cmake")


### PR DESCRIPTION
New version of libfiber detected (package version: v0.9.0+0, last github version: v1.1.0)