### PR TITLE
Auto-update aws-c-io to v0.27.0

### DIFF
--- a/packages/a/aws-c-io/xmake.lua
+++ b/packages/a/aws-c-io/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-io")
     add_urls("https://github.com/awslabs/aws-c-io/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-io.git")
 
+    add_versions("v0.27.0", "e89a1f784e7c97e4197031ffdcf30f67d66d7c14f8a391edf5764f17dae982ee")
     add_versions("v0.26.3", "521fd0848fca661130bbb7278a414d7a38bdcb9bc8ffa89f6660d84e5838a303")
     add_versions("v0.26.1", "5481178b99f074314b23b39b35786715fb0c1bf9773023ff83efe0d62d6e0ce2")
     add_versions("v0.26.0", "27591a4d67b7401dc0b87f8fec91b1c93764decb32229086113c80d4d6d6d3c0")

--- a/packages/a/aws-c-io/xmake.lua
+++ b/packages/a/aws-c-io/xmake.lua
@@ -68,6 +68,10 @@ package("aws-c-io")
         if package:is_plat("windows") then
             table.insert(configs, "-DAWS_STATIC_MSVC_RUNTIME_LIBRARY=" .. (package:runtimes():startswith("MT") and "ON" or "OFF"))
         end
+        if package:is_plat("macosx") then
+            --TODO: add an option to USE_S2N
+            table.insert(configs, "-DAWS_USE_SECITEM=ON")
+        end
         import("package.tools.cmake").install(package, configs)
 
         if package:is_plat("windows") and package:is_debug() then


### PR DESCRIPTION
New version of aws-c-io detected (package version: v0.26.3, last github version: v0.27.0)