### PR TITLE
Auto-update aws-crt-cpp to v0.40.0

### DIFF
--- a/packages/a/aws-c-auth/xmake.lua
+++ b/packages/a/aws-c-auth/xmake.lua
@@ -29,7 +29,7 @@ package("aws-c-auth")
     add_deps("cmake")
     add_deps("aws-c-io", "aws-c-sdkutils", "aws-c-http")
 
-    on_install("!wasm and (!mingw or mingw|!i386)", function (package)
+    on_install("windows", "linux", "bsd", "cross", "android", "mingw|!i386", "macosx|arm64", function (package)
         if package:is_plat("windows") and package:config("shared") then
             package:add("defines", "USE_WINDOWS_DLL_SEMANTICS", "AWS_AUTH_USE_IMPORT_EXPORT")
         end

--- a/packages/a/aws-c-event-stream/xmake.lua
+++ b/packages/a/aws-c-event-stream/xmake.lua
@@ -25,7 +25,7 @@ package("aws-c-event-stream")
 
     add_deps("cmake", "aws-c-common", "aws-c-io", "aws-checksums")
 
-    on_install("windows", "linux", "macosx", "bsd", "msys", "cross", function (package)
+    on_install("windows", "linux", "macosx|arm64", "bsd", "msys", "cross", function (package)
         local cmakedir = package:dep("aws-c-common"):installdir("lib", "cmake")
         if package:is_plat("windows") then
             cmakedir = cmakedir:gsub("\\", "/")

--- a/packages/a/aws-c-http/xmake.lua
+++ b/packages/a/aws-c-http/xmake.lua
@@ -39,7 +39,7 @@ package("aws-c-http")
         end
     end)
 
-    on_install("!wasm and (!mingw or mingw|!i386)", function (package)
+    on_install("windows", "linux", "bsd", "cross", "android", "mingw|!i386", "macosx|arm64", function (package)
         if package:is_plat("windows") and package:config("shared") then
             package:add("defines", "USE_WINDOWS_DLL_SEMANTICS", "AWS_HTTP_USE_IMPORT_EXPORT")
         end

--- a/packages/a/aws-c-io/xmake.lua
+++ b/packages/a/aws-c-io/xmake.lua
@@ -36,6 +36,8 @@ package("aws-c-io")
     add_versions("v0.14.5", "2700bcde062f7de1c1cbfd236b9fdfc9b24b4aa6dc0fb09bb156e16e07ebd0b6")
     add_versions("v0.13.32", "2a6b18c544d014ca4f55cb96002dbbc1e52a2120541c809fa974cb0838ea72cc")
 
+    add_configs("s2n", {description = "Use s2n-tls as TLS backend.", default = is_plat("macosx") or is_plat("linux"), type = "boolean"})
+
     if is_plat("wasm") then
         add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
     end
@@ -50,7 +52,13 @@ package("aws-c-io")
 
     add_deps("cmake", "aws-c-common", "aws-c-cal")
 
-    on_install("!wasm and (!mingw or mingw|!i386)", function (package)
+    on_load(function (package)
+        if package:config("s2n") then
+            package:add("deps", "s2n-tls")
+        end
+    end)
+
+    on_install("windows", "linux", "bsd", "cross", "android", "mingw|!i386", "macosx|arm64", function (package)
         if package:is_plat("windows") and package:config("shared") then
             package:add("defines", "USE_WINDOWS_DLL_SEMANTICS", "AWS_IO_USE_IMPORT_EXPORT")
         end
@@ -65,12 +73,14 @@ package("aws-c-io")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
         table.insert(configs, "-DENABLE_SANITIZERS=" .. (package:config("asan") and "ON" or "OFF"))
+        table.insert(configs, "-DUSE_S2N=" .. (package:config("s2n") and "ON" or "OFF"))
         if package:is_plat("windows") then
             table.insert(configs, "-DAWS_STATIC_MSVC_RUNTIME_LIBRARY=" .. (package:runtimes():startswith("MT") and "ON" or "OFF"))
         end
         if package:is_plat("macosx") then
-            --TODO: add an option to USE_S2N
-            table.insert(configs, "-DAWS_USE_SECITEM=ON")
+            if not package:config("s2n") then
+                table.insert(configs, "-DAWS_USE_SECITEM=ON")
+            end
         end
         import("package.tools.cmake").install(package, configs)
 

--- a/packages/a/aws-c-mqtt/xmake.lua
+++ b/packages/a/aws-c-mqtt/xmake.lua
@@ -24,7 +24,7 @@ package("aws-c-mqtt")
 
     add_deps("cmake", "aws-c-http", "aws-c-io", "aws-c-cal", "aws-c-common")
 
-    on_install("windows", "linux", "macosx", "bsd", "msys", "cross", function (package)
+    on_install("windows", "linux", "macosx|arm64", "bsd", "msys", "cross", function (package)
         local cmakedir = package:dep("aws-c-common"):installdir("lib", "cmake")
         if package:is_plat("windows") then
             cmakedir = cmakedir:gsub("\\", "/")

--- a/packages/a/aws-c-s3/xmake.lua
+++ b/packages/a/aws-c-s3/xmake.lua
@@ -39,7 +39,7 @@ package("aws-c-s3")
     add_deps("cmake")
     add_deps("aws-checksums", "aws-c-io", "aws-c-http", "aws-c-auth")
 
-    on_install("!wasm and (!mingw or mingw|!i386)", function (package)
+    on_install("windows", "linux", "bsd", "cross", "android", "mingw|!i386", "macosx|arm64", function (package)
         if package:is_plat("windows") and package:config("shared") then
             package:add("defines", "WIN32", "AWS_S3_USE_IMPORT_EXPORT")
         end

--- a/packages/a/aws-crt-cpp/xmake.lua
+++ b/packages/a/aws-crt-cpp/xmake.lua
@@ -36,7 +36,7 @@ package("aws-crt-cpp")
     add_deps("cmake", "aws-c-common", "aws-c-io", "aws-checksums", "aws-c-event-stream",
              "aws-c-http", "aws-c-mqtt", "aws-c-auth", "aws-c-s3")
 
-    on_install("windows", "linux", "cross", "macosx", "bsd", "msys", function (package)
+    on_install("windows", "linux", "cross", "macosx|arm64", "bsd", "msys", function (package)
         local cmakedir = package:dep("aws-c-common"):installdir("lib", "cmake")
         if package:is_plat("windows") then
             cmakedir = cmakedir:gsub("\\", "/")

--- a/packages/a/aws-crt-cpp/xmake.lua
+++ b/packages/a/aws-crt-cpp/xmake.lua
@@ -6,6 +6,7 @@ package("aws-crt-cpp")
     add_urls("https://github.com/awslabs/aws-crt-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-crt-cpp.git")
 
+    add_versions("v0.40.0", "bc81a9e97d004b354fcff5085567254ca837c2566973dfbaff67419ab6e2a57b")
     add_versions("v0.39.1", "e8f2a47737915ec36aaab68ec7bdf783f7a903f68322d3c0888d30951483b948")
     add_versions("v0.39.0", "6f1e629734dc4c1600f10e034624b6908dab3c596863a35b6364badcf662db74")
     add_versions("v0.38.7", "5d0010af3e072f1a2712d3ee6a94363a48e5e5f1d9c6f35c1f8d6cd4f53b50c6")

--- a/packages/s/s2n-tls/xmake.lua
+++ b/packages/s/s2n-tls/xmake.lua
@@ -6,6 +6,7 @@ package("s2n-tls")
     add_urls("https://github.com/aws/s2n-tls/archive/refs/tags/$(version).tar.gz",
              "https://github.com/aws/s2n-tls.git")
 
+    add_versions("v1.7.3", "9b7c52aa76b1773218ce9033875a35cb59f29fa7ce2d8de16132648bd75c2194")
     add_versions("v1.7.2", "3ca5361dabd2b041ba6d8c3fe73d1bc5a721dc5f62bbf71838010d1eddaa0cfd")
     add_versions("v1.7.0", "a6e8228e238239bb3c17b1eda3ed702bcbb2eaebc792eac4d754cc5619b0ea06")
     add_versions("v1.6.2", "b62c52ededd0b42e58fea660727141728cfb853c564083dbfc6fd027a1564582")
@@ -24,13 +25,6 @@ package("s2n-tls")
     add_versions("v1.5.5", "6316e1ad2c8ef5807519758bb159d314b9fef31d79ae27bc8f809104b978bb04")
     add_versions("v1.5.1", "d79710d6ef089097a3b84fc1e5cec2f08d1ec46e93b1d400df59fcfc859e15a3")
     add_versions("v1.5.0", "5e86d97d8f24653ef3dff3abe6165169f0ba59cdf52b5264987125bba070174d")
-    add_versions("v1.4.18", "a55b0b87eaaffc58bd44d90c5bf7903d11be816aa144296193e7d1a6bea5910e")
-    add_versions("v1.4.17", "5235cd2c926b89ae795b1e6b5158dce598c9e79120208b4bcd8d19ce04d86986")
-    add_versions("v1.4.16", "84fdbaa894c722bf13cac87b8579f494c1c2d66de642e5e6104638fddea76ad9")
-    add_versions("v1.4.14", "90cd0b7b1e5ebc7e40ba5f810cc24a4d604aa534fac7260dee19a35678e38659")
-    add_versions("v1.4.12", "d0769f27eb9e6b8fc98d3e8e3eb87ed71e10b08fade87893b293878d84faaceb")
-    add_versions("v1.4.3", "e42551bdf6595f718e232eb98c4f0e37c7a284f29bfcbc09fa9c0a2145754ab9")
-    add_versions("v1.3.51", "75c650493c42dddafd5dec6a42f2258ab52e501719ee5a337ec580cc958ea67a")
 
     add_configs("pq", {description = [[Enables all Post Quantum Crypto code. You likely want this
     for older compilers or uncommon platforms.]], default = false, type = "boolean"})
@@ -42,9 +36,9 @@ package("s2n-tls")
         add_syslinks("m", "pthread")
     end
 
-    add_deps("cmake", "openssl")
+    add_deps("cmake", "openssl3")
 
-    on_install("linux", "bsd", "cross", "android", function (package)
+    on_install("linux", "bsd", "cross", "android", "macosx|arm64", function (package)
         local configs = {
             "-DBUILD_TESTING=OFF",
             "-DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF",


### PR DESCRIPTION
New version of aws-crt-cpp detected (package version: v0.39.1, last github version: v0.40.0)