### PR TITLE
Auto-update glaze to v7.7.1

### DIFF
--- a/packages/g/glaze/xmake.lua
+++ b/packages/g/glaze/xmake.lua
@@ -7,6 +7,7 @@ package("glaze")
     add_urls("https://github.com/stephenberry/glaze/archive/refs/tags/$(version).tar.gz",
              "https://github.com/stephenberry/glaze.git")
 
+    add_versions("v7.7.1", "c51217ca374f2a7d556c501a849d3a43dfffff47ba7711b6f0c22020e71ff63d")
     add_versions("v7.0.2", "febbec555648b310c2a1975ca750939cd00c4801dede8362fcf84cab7b3ae46f")
     add_versions("v7.0.0", "8a6c67d3b3320017100252ad7a84af4f7eb619421e011b3c860ad71f11f7fac9")
     add_versions("v6.1.0", "4ec01e893363701735d1ef3842fa77a74c4a664edaf08d6a1da0e744900d4125")


### PR DESCRIPTION
New version of glaze detected (package version: v7.0.2, last github version: v7.7.1)