### PR TITLE
Auto-update gdcm to v3.2.7

### DIFF
--- a/packages/g/gdcm/xmake.lua
+++ b/packages/g/gdcm/xmake.lua
@@ -5,6 +5,7 @@ package("gdcm")
 
     add_urls("https://github.com/malaterre/GDCM/archive/refs/tags/$(version).tar.gz",
              "https://github.com/malaterre/GDCM.git")
+    add_versions("v3.2.7", "b7b17b70c009677cf244cc7837b88386441e097f8861fdeee83aa27d1bc1b090")
     add_versions("v3.2.5", "1763d94228ef31babe68a2b5f3b0d4fc66bc0afae641d9a4c38ea5269e06ba5d")
     add_versions("v3.2.1", "63d4fbbb487d450bc8004542892a45349bdc9f4400f7010c07170c127ef0f9e3")
     add_versions("v3.0.24", "d88519a094797c645ca34797a24a14efc10965829c4c3352c8ef33782a556336")


### PR DESCRIPTION
New version of gdcm detected (package version: v3.2.5, last github version: v3.2.7)