### PR TITLE
Auto-update magic_enum to v0.9.8

### DIFF
--- a/packages/m/magic_enum/xmake.lua
+++ b/packages/m/magic_enum/xmake.lua
@@ -7,6 +7,7 @@ package("magic_enum")
     add_urls("https://github.com/Neargye/magic_enum/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Neargye/magic_enum.git")
 
+    add_versions("v0.9.8", "1e54959a3f3cb675938d858603ad69d0f3f7c82439fc2bf86d7232daec2bd10e")
     add_versions("v0.7.3", "b8d0cd848546fee136dc1fa4bb021a1e4dc8fe98e44d8c119faa3ef387636bf7")
     add_versions("v0.8.0", "5e7680e877dd4cf68d9d0c0e3c2a683b432a9ba84fc1993c4da3de70db894c3c")
     add_versions("v0.8.1", "6b948d1680f02542d651fc82154a9e136b341ce55c5bf300736b157e23f9df11")


### PR DESCRIPTION
New version of magic_enum detected (package version: v0.9.7, last github version: v0.9.8)