### PR TITLE
Auto-update mlpack to 4.8.0

### DIFF
--- a/packages/m/mlpack/xmake.lua
+++ b/packages/m/mlpack/xmake.lua
@@ -7,6 +7,7 @@ package("mlpack")
     add_urls("https://github.com/mlpack/mlpack/archive/refs/tags/$(version).tar.gz",
              "https://github.com/mlpack/mlpack.git")
 
+    add_versions("4.8.0", "0ab06e5c506c7ed5f072faa4c04477c65624e4a1ff62eee8c0d996ef850ec51c")
     add_versions("4.7.0", "a3f0fb530e51d51f8d7eceb7998b4699906d628000b158ada80541465595324e")
     add_versions("4.3.0", "08cd54f711fde66fc3b6c9db89dc26776f9abf1a6256c77cfa3556e2a56f1a3d")
 


### PR DESCRIPTION
New version of mlpack detected (package version: 4.7.0, last github version: 4.8.0)