### PR TITLE
Auto-update ittapi to v3.28.0

### DIFF
--- a/packages/i/ittapi/xmake.lua
+++ b/packages/i/ittapi/xmake.lua
@@ -6,6 +6,7 @@ package("ittapi")
     add_urls("https://github.com/intel/ittapi/archive/refs/tags/$(version).tar.gz",
              "https://github.com/intel/ittapi.git")
 
+    add_versions("v3.28.0", "39d47cf33bfc4101dcca61c00f9ace9a0ee50ccd98bb7905291f2f0679f5b6df")
     add_versions("v3.26.4", "22e62bc1e0bae9ca001d6ae7447d26b7bcfe5d955724d74e6bd1e3e2102b48b1")
     add_versions("v3.26.3", "435bfd99a8d9a7b7b2b4fde33132d7aea125e612decc9138bff6895ed0144e95")
     add_versions("v3.26.2", "e4dd9c78c17efa4ab79290d6a1c66c686208382ae1a689554d18d640761d0316")


### PR DESCRIPTION
New version of ittapi detected (package version: v3.26.4, last github version: v3.28.0)