### PR TITLE
Auto-update aws-c-sdkutils to v0.2.5

### DIFF
--- a/packages/a/aws-c-sdkutils/xmake.lua
+++ b/packages/a/aws-c-sdkutils/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-sdkutils")
     add_urls("https://github.com/awslabs/aws-c-sdkutils/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-sdkutils.git")
 
+    add_versions("v0.2.5", "13a03ea87aa67c7db414bf245fbcc623555c783a34d8ba1d7d701fd42717c366")
     add_versions("v0.2.4", "493cbed4fa57e0d4622fcff044e11305eb4fc12445f32c8861025597939175fc")
     add_versions("v0.2.3", "5a0489d508341b84eea556e351717bc33524d3dfd6207ee3aba6068994ea6018")
     add_versions("v0.2.2", "75defbfd4d896b8bdc0790bd25d854218acae61b9409d1956d33832924b82045")


### PR DESCRIPTION
New version of aws-c-sdkutils detected (package version: v0.2.4, last github version: v0.2.5)