### PR TITLE
Auto-update shaderc to v2026.2

### DIFF
--- a/packages/s/shaderc/xmake.lua
+++ b/packages/s/shaderc/xmake.lua
@@ -6,6 +6,7 @@ package("shaderc")
     add_urls("https://github.com/google/shaderc/archive/refs/tags/$(version).tar.gz",
              "https://github.com/google/shaderc.git")
 
+    add_versions("v2026.2", "f924178e75e3293082481b25ed64d5e48a795b479dac3bd3c83d23070855df42")
     add_versions("v2024.1", "eb3b5f0c16313d34f208d90c2fa1e588a23283eed63b101edd5422be6165d528")
     add_versions("v2024.0", "c761044e4e204be8e0b9a2d7494f08671ca35b92c4c791c7049594ca7514197f")
     add_versions("v2022.2", "517d36937c406858164673db696dc1d9c7be7ef0960fbf2965bfef768f46b8c0")


### PR DESCRIPTION
New version of shaderc detected (package version: v2024.1, last github version: v2026.2)