### PR TITLE
Auto-update microsoft-gsl to v4.2.2

### DIFF
--- a/packages/m/microsoft-gsl/xmake.lua
+++ b/packages/m/microsoft-gsl/xmake.lua
@@ -7,6 +7,7 @@ package("microsoft-gsl")
     add_urls("https://github.com/microsoft/GSL/archive/refs/tags/$(version).tar.gz",
              "https://github.com/microsoft/GSL.git")
 
+    add_versions("v4.2.2", "59e2a0a0ea22e8bcf9db2dc4d4bd21212ac6595748295fc27a7e02cf75eac4b5")
     add_versions("v4.2.1", "d959f1cb8bbb9c94f033ae5db60eaf5f416be1baa744493c32585adca066fe1f")
     add_versions("v4.2.0", "2c717545a073649126cb99ebd493fa2ae23120077968795d2c69cbab821e4ac6")
     add_versions("v4.1.0", "0a227fc9c8e0bf25115f401b9a46c2a68cd28f299d24ab195284eb3f1d7794bd")


### PR DESCRIPTION
New version of microsoft-gsl detected (package version: v4.2.1, last github version: v4.2.2)