### PR TITLE
Auto-update samurai to v0.30.1

### DIFF
--- a/packages/s/samurai/xmake.lua
+++ b/packages/s/samurai/xmake.lua
@@ -7,6 +7,7 @@ package("samurai")
     add_urls("https://github.com/hpc-maths/samurai/archive/refs/tags/$(version).tar.gz",
              "https://github.com/hpc-maths/samurai.git")
 
+    add_versions("v0.30.1", "551c92fd86617b1ffaaa10face33c20b0cf5738a52105be810e243e4cea2b076")
     add_versions("v0.29.2", "7816f4269b6b93410d2d89ab65ada793317d5fa08b5f5b8a0e6e83e109d564a0")
     add_versions("v0.28.0", "94a50fc30714b652157e27ac7870dc8487e1045289d87cb83b28d2c7f6834b94")
     add_versions("v0.27.1", "5cb1ffb87a6a3defbde45037bd80e8277c31d577e20559c6cb2853b82bc989ba")


### PR DESCRIPTION
New version of samurai detected (package version: v0.29.2, last github version: v0.30.1)