### PR TITLE
Auto-update aws-sdk-cpp to 1.11.829

### DIFF
--- a/packages/a/aws-sdk-cpp/xmake.lua
+++ b/packages/a/aws-sdk-cpp/xmake.lua
@@ -5,6 +5,7 @@ package("aws-sdk-cpp")
 
     add_urls("https://github.com/aws/aws-sdk-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/aws/aws-sdk-cpp.git")
+    add_versions("1.11.829", "6cd42090442adce6c620b0c52dd7a264d2bdc738d309a53f155fbe29f3cbed26")
     add_versions("1.11.828", "a34b2ad9d304052aa46c4f1535f89cc6db502eb57bc0f8c329affc9e99360183")
     add_versions("1.11.817", "18f65613ff591e1ed67d8b6ff086726ceeb7a3696d982f60edfdf67a24168fd8")
     add_versions("1.11.813", "3253922af460435592d9d1fe7e89d9fbde891235fe0abbe9d2319bf1776e62cc")


### PR DESCRIPTION
New version of aws-sdk-cpp detected (package version: 1.11.828, last github version: 1.11.829)