### PR TITLE
Auto-update pdfio to v1.6.4

### DIFF
--- a/packages/p/pdfio/xmake.lua
+++ b/packages/p/pdfio/xmake.lua
@@ -21,6 +21,10 @@ package("pdfio")
         add_syslinks("m")
     end
 
+    if is_plat("wasm") then
+        add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+    end
+
     add_deps("zlib")
 
     if on_check then

--- a/packages/p/pdfio/xmake.lua
+++ b/packages/p/pdfio/xmake.lua
@@ -6,6 +6,7 @@ package("pdfio")
     add_urls("https://github.com/michaelrsweet/pdfio/archive/refs/tags/$(version).tar.gz",
              "https://github.com/michaelrsweet/pdfio.git")
 
+    add_versions("v1.6.4", "1efa737a8f370b1d9e9a3084dd73479cae8c5e74eee75abc53f5e60b942f53e6")
     add_versions("v1.6.3", "5021c00208f37547d7b9d454df08d55a33a8e22537b716a74c2ca888d6c277ea")
     add_versions("v1.6.1", "de733aad5d5b2d8199667ca28efe01fce17e00743ba021f88303c8a81a5eaa67")
     add_versions("v1.5.0", "895cfa22a895d0afc69a18402f19057ddaf8f035cc0a69f3f2a4cbe55ead9662")


### PR DESCRIPTION
New version of pdfio detected (package version: v1.6.3, last github version: v1.6.4)