### PR TITLE
Auto-update llhttp to v9.4.2

### DIFF
--- a/packages/l/llhttp/xmake.lua
+++ b/packages/l/llhttp/xmake.lua
@@ -5,6 +5,7 @@ package("llhttp")
 
     add_urls("https://github.com/nodejs/llhttp/archive/refs/tags/release/$(version).tar.gz")
 
+    add_versions("v9.4.2", "ba717a2f99f340a0ee9796aaf2b1acca057e1e37682ffd2bc4def4d3b6bc4005")
     add_versions("v9.4.1", "86a8c16759fdcc7aa2c9841fbe8ba2e77ea98be7d5d45615f2604776d0ff78c7")
     add_versions("v9.3.1", "c14a93f287d3dbd6580d08af968294f8bcc61e1e1e3c34301549d00f3cf09365")
     add_versions("v9.3.0", "1a2b45cb8dda7082b307d336607023aa65549d6f060da1d246b1313da22b685a")

--- a/packages/l/llhttp/xmake.lua
+++ b/packages/l/llhttp/xmake.lua
@@ -13,6 +13,9 @@ package("llhttp")
     add_versions("v8.1.0", "9da0d23453e8e242cf3b2bc5d6fb70b1517b8a70520065fcbad6be787e86638e")
     add_versions("v3.0.0", "02931556e69f8d075edb5896127099e70a093c104a994a57b4d72c85b48d25b0")
 
+    if is_plat("wasm") then
+        add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+    end
 
     on_load(function (package)
         if package:version():ge("9.2.1") then


### PR DESCRIPTION
New version of llhttp detected (package version: v9.4.1, last github version: v9.4.2)