### PR TITLE
Auto-update sqlcipher to 4.16.0

### DIFF
--- a/packages/s/sqlcipher/xmake.lua
+++ b/packages/s/sqlcipher/xmake.lua
@@ -13,7 +13,7 @@ package("sqlcipher")
 
     if not is_plat("windows") then
         -- only for GCC 15
-        add_patches(">=4.12.0", path.join(os.scriptdir(), "patches", "4.12.0", "stdint.patch"), "608ea7c41855b26029f114ac5b0c9abf35656dec559b86939909813da6bb78ae")
+        add_patches(">=4.12.0 <4.16.0", path.join(os.scriptdir(), "patches", "4.12.0", "stdint.patch"), "608ea7c41855b26029f114ac5b0c9abf35656dec559b86939909813da6bb78ae")
     end
 
     add_configs("encrypt",  { description = "enable encrypt", default = true, type = "boolean"})

--- a/packages/s/sqlcipher/xmake.lua
+++ b/packages/s/sqlcipher/xmake.lua
@@ -4,6 +4,7 @@ package("sqlcipher")
     set_license("BSD-3-Clause")
 
     set_urls("https://github.com/sqlcipher/sqlcipher/archive/refs/tags/v$(version).tar.gz")
+    add_versions("4.16.0", "d687bf981199ac019c6c87b11f92a5900aec777855e7ba5b30e5e1192933ce8a")
     add_versions("4.14.0", "67fb27e967a4a6968c0905691c89c908e7250dddc581b887c19ef981c737e473")
     add_versions("4.13.0", "7ca5c11f70e460d6537844185621d5b3d683a001e6bad223d15bdf8eff322efa")
     add_versions("4.12.0", "151a1c618c7ae175dfd0f862a8d52e8abd4c5808d548072290e8656032bb0f12")


### PR DESCRIPTION
New version of sqlcipher detected (package version: 4.14.0, last github version: 4.16.0)