### PR TITLE
Auto-update pdfhummus to v4.9.0

### DIFF
--- a/packages/p/pdfhummus/xmake.lua
+++ b/packages/p/pdfhummus/xmake.lua
@@ -5,6 +5,7 @@ package("pdfhummus")
 
     add_urls("https://github.com/galkahana/PDF-Writer/archive/refs/tags/$(version).tar.gz",
              "https://github.com/galkahana/PDF-Writer.git")
+    add_versions("v4.9.0", "1d03fb6191bad40e8f2f218a2a2b7a8b6a679569f3f69bf6015ad82165feeb98")
     add_versions("v4.8.1", "9b96c040cb04ca116450c0ed53462b6aa66b299c555401bf498b14db847f0898")
     add_versions("v4.6.8", "129706e0336e00deb6b2e80c4e92e1b30e3504ae9f8d5e5225b512fbd17a991a")
     add_versions("v4.6.7", "735c65d4685c5156f0876635f3bc1565700d0f648fbb1f384e46d186796c8bae")


### PR DESCRIPTION
New version of pdfhummus detected (package version: v4.8.1, last github version: v4.9.0)