### PR TITLE
Auto-update c4core to 0.4.0

### DIFF
--- a/packages/c/c4core/xmake.lua
+++ b/packages/c/c4core/xmake.lua
@@ -6,6 +6,7 @@ package("c4core")
     add_urls("https://github.com/biojppm/c4core/releases/download/v$(version)/c4core-$(version)-src.zip",
              "https://github.com/biojppm/c4core.git")
 
+    add_versions("0.4.0", "e36336ab9ddddda8633a26df591f92796b7925a607c44df453210c9e4eff2f34")
     add_versions("0.3.0", "f144f771cff7282ffdb4684275b812dcb954d4a7f7be5a3b4096d2a5c7e93362")
     add_versions("0.2.11", "5f667922c299434a9eeb34fb7fcf5e74de86d890d7788dea849a423fc429b87a")
     add_versions("0.2.10", "8560011998c714a7faeafc1f4fea8d8b579bb6971cd9b38fddcc965a5bb4ae17")


### PR DESCRIPTION
New version of c4core detected (package version: 0.3.0, last github version: 0.4.0)