### PR TITLE
Auto-update netcdf-c to v4.10.0

### DIFF
--- a/packages/n/netcdf-c/xmake.lua
+++ b/packages/n/netcdf-c/xmake.lua
@@ -5,6 +5,7 @@ package("netcdf-c")
 
     add_urls("https://github.com/Unidata/netcdf-c/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Unidata/netcdf-c.git")
+    add_versions("v4.10.0", "ce160f9c1483b32d1ba8b7633d7984510259e4e439c48a218b95a023dc02fd4c")
     add_versions("v4.9.3", "990f46d49525d6ab5dc4249f8684c6deeaf54de6fec63a187e9fb382cc0ffdff")
     add_patches("v4.9.3", "patches/v4.9.3/deps.patch", "b66fdf04a6d0d220ef14e078ca17ca09d33491f19ef408dc971c5c1fac6e7d6d")
 


### PR DESCRIPTION
New version of netcdf-c detected (package version: v4.9.3, last github version: v4.10.0)