### PR TITLE
Auto-update openjph to 0.30.1

### DIFF
--- a/packages/o/openjph/xmake.lua
+++ b/packages/o/openjph/xmake.lua
@@ -34,7 +34,7 @@ package("openjph")
         end)
     end
 
-    on_install(function (package)
+    on_install("!mingw or mingw|!i386", function (package)
         local ojph_header_path
         if package:version():lt("0.26.0") then
             ojph_header_path = "src/core/common"

--- a/packages/o/openjph/xmake.lua
+++ b/packages/o/openjph/xmake.lua
@@ -6,6 +6,7 @@ package("openjph")
     add_urls("https://github.com/aous72/OpenJPH/archive/refs/tags/$(version).tar.gz",
              "https://github.com/aous72/OpenJPH.git")
 
+    add_versions("0.30.1", "fb3ccf71af838ed2a42c6ea669308a2adaba115ae9d5862dfb1e2865b43eb5b8")
     add_versions("0.29.0", "1302a296308996af4c023b7f104133f0d48e89e18b86da999973c476b5e8b584")
     add_versions("0.28.1", "89629a3c0f61d474073076bb6195e9bb1d63fafb2e1c57ab46aee53a62f21819")
     add_versions("0.27.4", "4bd6c75cc74721b1a40c3e07206621d0c953d0b21e9f63c9982a8ecb4a6f326d")


### PR DESCRIPTION
New version of openjph detected (package version: 0.29.0, last github version: 0.30.1)