### PR TITLE
Auto-update libffi to 3.6.0

### DIFF
--- a/packages/l/libffi/xmake.lua
+++ b/packages/l/libffi/xmake.lua
@@ -5,6 +5,7 @@ package("libffi")
 
     set_urls("https://github.com/libffi/libffi/releases/download/v$(version)/libffi-$(version).tar.gz",
              "https://github.com/libffi/libffi.git")
+    add_versions("3.6.0", "31ff1fe32deaebfbb388727f32677bb254bf2a41382c51464c0b1837c9ee9828")
     add_versions("3.4.8", "bc9842a18898bfacb0ed1252c4febcc7e78fa139fd27fdc7a3e30d9d9356119b")
     add_versions("3.4.7", "138607dee268bdecf374adf9144c00e839e38541f75f24a1fcf18b78fda48b2d")
     add_versions("3.2.1", "d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37")


### PR DESCRIPTION
New version of libffi detected (package version: 3.4.8, last github version: 3.6.0)