### PR TITLE
Auto-update boost_sml to v1.2.0

### DIFF
--- a/packages/b/boost_sml/xmake.lua
+++ b/packages/b/boost_sml/xmake.lua
@@ -7,6 +7,7 @@ package("boost_sml")
     add_urls("https://github.com/boost-ext/sml/archive/refs/tags/$(version).tar.gz",
              "https://github.com/boost-ext/sml.git")
 
+    add_versions("v1.2.0", "d584375bc8b4b391f0d94d57bc126a7cbb0f8c2bf810f5602400206b62eaf280")
     add_versions("v1.1.13", "383b1d6868a29319694e5e2ed5934062de21c6e4920ad2ccb8e552f2892b922c")
     add_versions("v1.1.12", "65b53b3b839881512a5bf5bd443afd7dd64a406c706aab469f2e7cfd1d0a6012")
     add_versions("v1.1.11", "8773efd639ce9649dc449135c8c53232e1cb5f4037d44be02c1b9ccc343f246d")


### PR DESCRIPTION
New version of boost_sml detected (package version: v1.1.13, last github version: v1.2.0)