### PR TITLE
Auto-update cutlass to v4.5.2

### DIFF
--- a/packages/c/cutlass/xmake.lua
+++ b/packages/c/cutlass/xmake.lua
@@ -7,6 +7,7 @@ package("cutlass")
     add_urls("https://github.com/NVIDIA/cutlass/archive/refs/tags/$(version).tar.gz",
              "https://github.com/NVIDIA/cutlass.git")
 
+    add_versions("v4.5.2", "7d3ffb03b2d767439189492ab2aa0785632e1b80ba0c5e5618d6c5265d44e008")
     add_versions("v4.5.0", "d1ce5d785ba45e2ec1bbfc0fad64b5542878b8329a7d7dfdbfa681a545d35295")
     add_versions("v4.4.2", "ef62816841b8cbcd0ed3ec45d3ab56cf67d569a0f39329b43eeeebea86f58473")
     add_versions("v4.4.1", "fb2edaab5d806c0e3773375caffbb337b02c8b742816a71ea4c57ea699d5fd0b")


### PR DESCRIPTION
New version of cutlass detected (package version: v4.5.0, last github version: v4.5.2)