### PR TITLE
Auto-update libheif to 1.23.1

### DIFF
--- a/packages/l/libheif/xmake.lua
+++ b/packages/l/libheif/xmake.lua
@@ -6,6 +6,7 @@ package("libheif")
     add_urls("https://github.com/strukturag/libheif/releases/download/v$(version)/libheif-$(version).tar.gz",
             "https://github.com/strukturag/libheif.git")
 
+    add_versions("1.23.1", "0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a")
     add_versions("1.23.0", "4c9182b18897617182eed12ab5eb9f9d855b3aa3a736d6bdb31abc034ec7d393")
     add_versions("1.22.2", "eea48e4841f83fbe51d029337ffd2d14512d0203015dad40b90213d872958af3")
     add_versions("1.22.0", "8bd20cfa3201997b8f63266cddfabea2e1481467d7f992e6a2595e0bec691fc2")


### PR DESCRIPTION
New version of libheif detected (package version: 1.23.0, last github version: 1.23.1)