### PR TITLE
Auto-update aws-lc to v5.1.0

### DIFF
--- a/packages/a/aws-lc/xmake.lua
+++ b/packages/a/aws-lc/xmake.lua
@@ -6,6 +6,7 @@ package("aws-lc")
     add_urls("https://github.com/aws/aws-lc/archive/refs/tags/$(version).tar.gz",
              "https://github.com/aws/aws-lc.git")
 
+    add_versions("v5.1.0", "a6bf6adfc5f9bba559d28554b7d3581b15f2813f03bc9f2ae19f0d915e97dadf")
     add_versions("v5.0.0", "b4e1ea639d526c54243b8fbd9d21e101360423965bca5cbd72b862e7c9efdb12")
     add_versions("v1.73.0", "e33ae89e7d09d7b23a900f68b62088d8813c260ac564b016e543ee3540ebcce3")
     add_versions("v1.72.1", "7ea49769625a20b7e21230be3692286877473cc075f214ce28231d427e2e757e")


### PR DESCRIPTION
New version of aws-lc detected (package version: v5.0.0, last github version: v5.1.0)