### PR TITLE
Auto-update libfyaml to v0.9.6

### DIFF
--- a/packages/l/libfyaml/xmake.lua
+++ b/packages/l/libfyaml/xmake.lua
@@ -6,6 +6,7 @@ package("libfyaml")
     add_urls("https://github.com/pantoniou/libfyaml/archive/refs/tags/$(version).tar.gz",
              "https://github.com/pantoniou/libfyaml.git")
 
+    add_versions("v0.9.6", "2d016379a69f6cf6beaf06d12bcefe1ad1784bab28fbb41a6fa8d49d25f1bc0a")
     add_versions("v0.9.5", "bbb0ce413003e665b8bce1c167640f069ad10491a0c05937b41aa7a2c3f1d139")
     add_versions("v0.9.2", "979be4f6ba463c6d1a5b0d25c780486ae09c78477228e0af9368690e90a95698")
     add_versions("v0.9", "927306fc85c7566904751766d36178650766b34e59ce56882eaa5b60f791668c")


### PR DESCRIPTION
New version of libfyaml detected (package version: v0.9.5, last github version: v0.9.6)