### PR TITLE
Auto-update pugixml to v1.16

### DIFF
--- a/packages/p/pugixml/xmake.lua
+++ b/packages/p/pugixml/xmake.lua
@@ -6,6 +6,7 @@ package("pugixml")
     add_urls("https://github.com/zeux/pugixml/archive/refs/tags/$(version).tar.gz",
              "https://github.com/zeux/pugixml.git")
 
+    add_versions("v1.16", "357bcab8877dc9943f355d3a72daba1b053238ba955f50fa81586afb65090219")
     add_versions("v1.11.4", "017139251c122dbff400a507cddc4cb74120a431a50c6c524f30edcc5b331ade")
     add_versions("v1.13", "5c5ad5d7caeb791420408042a7d88c2c6180781bf218feca259fd9d840a888e1")
     add_versions("v1.14", "610f98375424b5614754a6f34a491adbddaaec074e9044577d965160ec103d2e")


### PR DESCRIPTION
New version of pugixml detected (package version: v1.15, last github version: v1.16)