### PR TITLE
Auto-update litehtml to v0.10

### DIFF
--- a/packages/l/litehtml/xmake.lua
+++ b/packages/l/litehtml/xmake.lua
@@ -6,6 +6,7 @@ package("litehtml")
     add_urls("https://github.com/litehtml/litehtml/archive/refs/tags/$(version).tar.gz",
              "https://github.com/litehtml/litehtml.git")
 
+    add_versions("v0.10", "7700eced92847d34ad9846b138cf195a9c974b519be70de58797880ae9da649e")
     add_versions("v0.9", "ef957307da15b1258a70961942840bcf54225a8d75315dcbc156186eba35b1a7")
 
     add_deps("cmake")

--- a/packages/l/litehtml/xmake.lua
+++ b/packages/l/litehtml/xmake.lua
@@ -25,13 +25,14 @@ package("litehtml")
     end)
 
     on_test(function (package)
+        local languages = package:version() and package:version():ge("0.10") and "c++17" or "c++11"
         assert(package:check_cxxsnippets({test = [[
             #include <string>
             #include <litehtml.h>
             using namespace litehtml;
             void test() {
-                css_element_selector selector;
-                selector.parse(".class");
+                style css;
+                css.add_property(_background_color_, "#ffffff");
             }
-        ]]}, {configs = {languages = "c++11"}}))
+        ]]}, {configs = {languages = languages}}))
     end)


### PR DESCRIPTION
New version of litehtml detected (package version: v0.9, last github version: v0.10)