### PR TITLE
Auto-update harfbuzz to 14.2.1

### DIFF
--- a/packages/h/harfbuzz/xmake.lua
+++ b/packages/h/harfbuzz/xmake.lua
@@ -6,6 +6,7 @@ package("harfbuzz")
     add_urls("https://github.com/harfbuzz/harfbuzz/archive/refs/tags/$(version).tar.gz", {excludes = "**/README", "**/test"})
     add_urls("https://github.com/harfbuzz/harfbuzz.git")
 
+    add_versions("14.2.1", "3c2a9006a7e1bf58737e557014d7882c554c628fb379a9f00008f5ea53dbbdfb")
     add_versions("13.1.1", "8497968914f415d633c7ff885f58862667c40b79d2f04031951a5d04e91d1090")
     add_versions("11.3.3", "5563e1eeea7399c37dc7f0f92a89bbc79d8741bbdd134d22d2885ddb95944314")
     add_versions("11.2.1", "057d5754c3ac0c499bbf4d729d52acf134c7bb4ba8868ba22e84ae96bc272816")


### PR DESCRIPTION
New version of harfbuzz detected (package version: 13.1.1, last github version: 14.2.1)