### PR TITLE
Auto-update nazarautils to v1.1.2

### DIFF
--- a/packages/n/nazarautils/xmake.lua
+++ b/packages/n/nazarautils/xmake.lua
@@ -7,6 +7,7 @@ package("nazarautils")
     add_urls("https://github.com/NazaraEngine/NazaraUtils/archive/refs/tags/$(version).tar.gz",
              "https://github.com/NazaraEngine/NazaraUtils.git")
 
+    add_versions("v1.1.2", "0d9e25df5b038add5ab95d7c71752735b9099385db1aa59bce15a543979c675c")
     add_versions("v1.1.1", "9febde2fe10dc46a40c5680f2f65432e60d994297c7846e7191afd2ac9aa2de9")
     add_versions("v1.0.0", "924ea35e99b163b4fd88b61fbc848d384be497e3b0dc36fa762cc5143312524a")
 


### PR DESCRIPTION
New version of nazarautils detected (package version: v1.1.1, last github version: v1.1.2)