### PR TITLE
Auto-update minio-cpp to v0.4.0

### DIFF
--- a/packages/c/curlpp/xmake.lua
+++ b/packages/c/curlpp/xmake.lua
@@ -4,6 +4,7 @@ package("curlpp")
     set_license("MIT")
 
     add_urls("https://github.com/jpbarrette/curlpp.git")
+    add_versions("2026.02.12", "ec1b66e699557cd9d608d322c013a1ebda16bd08")
     add_versions("2023.07.27", "1d8c7876cc81d7d125b663066282b207d9cbfe9a")
 
     add_deps("libcurl")

--- a/packages/m/minio-cpp/patches/0.4.0/cmake.patch
+++ b/packages/m/minio-cpp/patches/0.4.0/cmake.patch
@@ -1,0 +1,42 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d2897e7..8b6fcd9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -86,15 +86,16 @@ endif()
+ # ------------
+ 
+ find_package(OpenSSL REQUIRED)
+-find_package(unofficial-curlpp CONFIG REQUIRED)
+-find_package(unofficial-inih CONFIG REQUIRED)
++find_package(CURL REQUIRED)
++include(FindPkgConfig)
++pkg_search_module(curlpp REQUIRED IMPORTED_TARGET curlpp)
++pkg_search_module(inih REQUIRED IMPORTED_TARGET inih)
+ find_package(nlohmann_json CONFIG REQUIRED)
+ find_package(pugixml CONFIG REQUIRED)
+ find_package(ZLIB REQUIRED)
+ 
+ list(APPEND MINIO_CPP_LIBS
+-  unofficial::curlpp::curlpp
+-  unofficial::inih::inireader
++  PkgConfig::curlpp CURL::libcurl PkgConfig::inih
+   nlohmann_json::nlohmann_json
+   pugixml
+   OpenSSL::SSL OpenSSL::Crypto
+@@ -163,7 +164,7 @@ IF (BUILD_SHARED_LIBS)
+     add_library(miniocpp SHARED ${MINIO_CPP_SOURCES} ${MINIO_CPP_HEADERS})
+   ENDIF ()
+ ELSE ()
+-  add_library(miniocpp STATIC ${MINIO_CPP_SOURCES} ${MINIO_CPP_HEADERS})
++  add_library(miniocpp  ${MINIO_CPP_SOURCES} ${MINIO_CPP_HEADERS})
+ ENDIF ()
+ 
+ target_compile_options(miniocpp PRIVATE ${MINIO_CPP_CFLAGS})
+@@ -178,7 +179,6 @@ if (MINIO_CPP_ENABLE_RDMA)
+   target_compile_definitions(miniocpp PUBLIC MINIO_CPP_RDMA)
+ endif()
+ set_target_properties(miniocpp PROPERTIES VERSION "${MINIO_CPP_VERSION_STRING}")
+-set_target_properties(miniocpp PROPERTIES POSITION_INDEPENDENT_CODE ON)
+ 
+ # Add a cmake alias - this is how users should use minio-cpp in their cmake projects.
+ add_library(miniocpp::miniocpp ALIAS miniocpp)

--- a/packages/m/minio-cpp/xmake.lua
+++ b/packages/m/minio-cpp/xmake.lua
@@ -24,6 +24,17 @@ package("minio-cpp")
     add_deps("inih", {configs = {ini_parser = true}})
     add_deps("curlpp", "pugixml", "zlib")
 
+    if on_check then
+        on_check("mingw", function (package)
+            assert(package:version() and package:version():lt("0.4.0"), "package(minio-cpp >=0.4.0): unsupport mingw")
+        end)
+        on_check("windows", function (package)
+            if package:version() and package:version():ge("0.4.0") and package:config("shared") then
+                raise("package(minio-cpp >=0.4.0): unsupport windows shared")
+            end
+        end)
+    end
+
     on_load(function (package)
         -- xrepo package: curlpp -> libcurl -> openssl
         if package:is_plat("linux") then

--- a/packages/m/minio-cpp/xmake.lua
+++ b/packages/m/minio-cpp/xmake.lua
@@ -6,6 +6,7 @@ package("minio-cpp")
     add_urls("https://github.com/minio/minio-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/minio/minio-cpp.git")
 
+    add_versions("v0.4.0", "31cca03d32a3a27955d21764e3719097895f243f3b3add932f3c207758624eda")
     add_versions("v0.3.0", "da0f2f54bf169ad9e5e9368cc9143df4db056fc5c05bb55d8c1d9065e7211f7c")
 
     add_patches("0.3.0", "patches/0.3.0/cmake-pkgconfig-find-deps.patch", "53a0a5a300c896ad92dbaf3b96fa25556a2f555e84ce07deb7b7b1562ddac9e5")

--- a/packages/m/minio-cpp/xmake.lua
+++ b/packages/m/minio-cpp/xmake.lua
@@ -9,6 +9,7 @@ package("minio-cpp")
     add_versions("v0.4.0", "31cca03d32a3a27955d21764e3719097895f243f3b3add932f3c207758624eda")
     add_versions("v0.3.0", "da0f2f54bf169ad9e5e9368cc9143df4db056fc5c05bb55d8c1d9065e7211f7c")
 
+    add_patches("0.4.0", "patches/0.4.0/cmake.patch", "09892d28a2c1a3a5cc5783128264fae83a4dec3faa0d8110ae93be24019ff4fb")
     add_patches("0.3.0", "patches/0.3.0/cmake-pkgconfig-find-deps.patch", "53a0a5a300c896ad92dbaf3b96fa25556a2f555e84ce07deb7b7b1562ddac9e5")
     add_patches("0.3.0", "patches/0.3.0/macos-unistd.patch", "cd50e5d3cb5ceda7d606dc15f90ab4764b34a61a96a3be83f02688329843ef1f")
 


### PR DESCRIPTION
New version of minio-cpp detected (package version: v0.3.0, last github version: v0.4.0)