### PR TITLE
Update geo-utils-cpp to v1.2.0

### DIFF
--- a/packages/g/geo-utils-cpp/xmake.lua
+++ b/packages/g/geo-utils-cpp/xmake.lua
@@ -7,6 +7,7 @@ package("geo-utils-cpp")
     add_urls("https://github.com/gistrec/geo-utils-cpp/archive/refs/tags/v$(version).tar.gz",
              "https://github.com/gistrec/geo-utils-cpp.git")
 
+    add_versions("1.1.0", "fcf31dba71e9c9db265bb44b91d54f0f101feda54660b843e1a1a4c74e5d565c")
     add_versions("1.0.2", "be01e145e38341544ba283ebd7ca9896e9b488659167b72ce662960fe4d58bb4")
     add_versions("1.0.1", "2594b5dd736dab3ee99dc586dd326f699b90243b6074df582a32547f90b82a08")
 


### PR DESCRIPTION
Adds v1.1.0 of [geo-utils-cpp](https://github.com/gistrec/geo-utils-cpp) (header-only C++17 spherical lat/lng geometry).

Upstream release notes: https://github.com/gistrec/geo-utils-cpp/releases/tag/v1.1.0 — adds Encoded Polyline `encode`/`decode`, Douglas-Peucker `simplify`, `is_closed_polygon`, `LatLng::is_valid()`, and antimeridian/pole correctness fixes. Install logic and the test snippet are unchanged.

Verified locally on macOS arm64 with `xmake l scripts/test.lua -D -k geo-utils-cpp` — installs 1.1.0 and passes the snippet test.