### PR TITLE
Update geo-utils-cpp to v1.2.0

### DIFF
--- a/packages/g/geo-utils-cpp/xmake.lua
+++ b/packages/g/geo-utils-cpp/xmake.lua
@@ -7,6 +7,7 @@ package("geo-utils-cpp")
     add_urls("https://github.com/gistrec/geo-utils-cpp/archive/refs/tags/v$(version).tar.gz",
              "https://github.com/gistrec/geo-utils-cpp.git")
 
+    add_versions("1.1.0", "fcf31dba71e9c9db265bb44b91d54f0f101feda54660b843e1a1a4c74e5d565c")
     add_versions("1.0.2", "be01e145e38341544ba283ebd7ca9896e9b488659167b72ce662960fe4d58bb4")
     add_versions("1.0.1", "2594b5dd736dab3ee99dc586dd326f699b90243b6074df582a32547f90b82a08")
 

--- a/packages/g/geo-utils-cpp/xmake.lua
+++ b/packages/g/geo-utils-cpp/xmake.lua
@@ -7,6 +7,7 @@ package("geo-utils-cpp")
     add_urls("https://github.com/gistrec/geo-utils-cpp/archive/refs/tags/v$(version).tar.gz",
              "https://github.com/gistrec/geo-utils-cpp.git")
 
+    add_versions("1.2.0", "129b2a966891a5a911884d4b7e8e46f0e8b41d1a79f166ed4e527592cdd84935")
     add_versions("1.1.0", "fcf31dba71e9c9db265bb44b91d54f0f101feda54660b843e1a1a4c74e5d565c")
     add_versions("1.0.2", "be01e145e38341544ba283ebd7ca9896e9b488659167b72ce662960fe4d58bb4")
     add_versions("1.0.1", "2594b5dd736dab3ee99dc586dd326f699b90243b6074df582a32547f90b82a08")


### PR DESCRIPTION
Follow-up to #10327 (merged minutes before upstream released [v1.2.0](https://github.com/gistrec/geo-utils-cpp/releases/tag/v1.2.0)): adds v1.2.0 on top of v1.1.0.

Verified locally on macOS arm64 with `xmake l scripts/test.lua -D -k geo-utils-cpp` — installs 1.2.0 and passes the snippet test.