### PR TITLE
Update libhat to v0.10.0

### DIFF
--- a/packages/l/libhat/xmake.lua
+++ b/packages/l/libhat/xmake.lua
@@ -6,6 +6,7 @@ package("libhat")
     add_urls("https://github.com/BasedInc/libhat/archive/refs/tags/$(version).tar.gz",
              "https://github.com/BasedInc/libhat.git")
 
+    add_versions("v0.10.0", "6baa0856c5728c20b471751fcdd6cd69fb7385f822ee0592fdbdfafb8fb81e73")
     add_versions("v0.9.0", "b1e9e16e804d9f9bec7ccc4df4b8a1cdd281b6ec0c1377244ab28a7944a3e13a")
     add_versions("v0.7.0", "09c080be938d6e8901f1af8da74a66dc9d424393e071e1ada5ae13d86c2c9c9b")
     add_versions("v0.6.0", "9e25b898277d0bc248e1860ef11acd2dcd860d7fcdadb04d038588c60a850a4f")


### PR DESCRIPTION
Adds latest release (`v0.10.0`). No additional changes required.