### PR TITLE
Auto-update aws-c-sdkutils to v0.2.7

### DIFF
--- a/packages/a/aws-c-sdkutils/xmake.lua
+++ b/packages/a/aws-c-sdkutils/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-sdkutils")
     add_urls("https://github.com/awslabs/aws-c-sdkutils/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-sdkutils.git")
 
+    add_versions("v0.2.7", "802b8c4169da2b4cf5c48f9598fb778faccd3e052e443a482089193411c2b7bb")
     add_versions("v0.2.6", "673e78e9d029f31213f74eea6fb90c3750063cdec73729906e9017b0f8c95f78")
     add_versions("v0.2.5", "13a03ea87aa67c7db414bf245fbcc623555c783a34d8ba1d7d701fd42717c366")
     add_versions("v0.2.4", "493cbed4fa57e0d4622fcff044e11305eb4fc12445f32c8861025597939175fc")


### PR DESCRIPTION
New version of aws-c-sdkutils detected (package version: v0.2.6, last github version: v0.2.7)