### PR TITLE
Auto-update stringzilla to v4.6.2

### DIFF
--- a/packages/s/stringzilla/xmake.lua
+++ b/packages/s/stringzilla/xmake.lua
@@ -10,6 +10,7 @@ package("stringzilla")
     add_configs("cpp", {description = "Enable C++ support.", default = true, type = "boolean"})
     add_configs("stringzillas", {description = "Enable advanced API support.", default = false, type = "boolean"})
 
+    add_versions("v4.6.2", "e950b95383858f643d85088e8eeb26bc0ef32f3c9b37a65b5c499ab3a6c51970")
     add_versions("v4.6.1", "13d92f35e17bfca8d1a657e1f52d7da1b4c5986de023de04afb546e64e7ec307")
     add_versions("v4.6.0", "cba35adab6f0b25d277451e0130798d1a8742e4c52d0ab29c5a5fca54242d0e3")
     add_versions("v4.5.1", "2b706dff69baa28911f7df445f62391b8cc4b6b599c542a015dd685e7ea01948")


### PR DESCRIPTION
New version of stringzilla detected (package version: v4.6.1, last github version: v4.6.2)