### PR TITLE
Auto-update vmaf to v3.2.0

### DIFF
--- a/packages/v/vmaf/xmake.lua
+++ b/packages/v/vmaf/xmake.lua
@@ -6,6 +6,7 @@ package("vmaf")
     add_urls("https://github.com/Netflix/vmaf/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Netflix/vmaf.git")
 
+    add_versions("v3.2.0", "a28f93f3b4fa65601be324587072e32a6a704a304ba7b1aec9b70b3f709bc1dc")
     add_versions("v3.1.0", "80090e29d7fd0db472ddc663513f5be89bc936815e62b767e630c1d627279fe2")
     add_versions("v3.0.0", "7178c4833639e6b989ecae73131d02f70735fdb3fc2c7d84bc36c9c3461d93b1")
 


### PR DESCRIPTION
New version of vmaf detected (package version: v3.1.0, last github version: v3.2.0)