### PR TITLE
tbox: verify v1.7.6 is broken for `wasm`

### DIFF
--- a/packages/t/tbox/patches/v1.7.6/fix-uninitialized-const-pointer.patch
+++ b/packages/t/tbox/patches/v1.7.6/fix-uninitialized-const-pointer.patch
@@ -1,0 +1,51 @@
+--- a/src/tbox/libm/isqrti.c
++++ b/src/tbox/libm/isqrti.c
+@@ -206,7 +206,7 @@
+         // analyze isqrti
+         tb_hong_t                   t1 = tb_uclock();
+         __tb_volatile__ tb_size_t   n1 = 200;
+-        __tb_volatile__ tb_uint32_t v1; tb_used(&v1);
++        __tb_volatile__ tb_uint32_t v1 = 0; tb_used(&v1);
+         while (n1--)
+         {
+             v1 = tb_isqrti_impl((1 << 4) + 3);
+@@ -219,7 +219,7 @@
+         // analyze sqrt
+         tb_hong_t                   t2 = tb_uclock();
+         __tb_volatile__ tb_size_t   n2 = 200;
+-        __tb_volatile__ tb_uint32_t v2; tb_used(&v2);
++        __tb_volatile__ tb_uint32_t v2 = 0; tb_used(&v2);
+         while (n2--)
+         {
+             v2 = tb_isqrti_impl_using_sqrt((1 << 4) + 3);
+--- a/src/tbox/libm/isqrti64.c
++++ b/src/tbox/libm/isqrti64.c
+@@ -82,7 +82,7 @@
+         // analyze isqrti64
+         tb_hong_t                   t1 = tb_uclock();
+         __tb_volatile__ tb_size_t   n1 = 100;
+-        __tb_volatile__ tb_uint32_t v1; tb_used(&v1);
++        __tb_volatile__ tb_uint32_t v1 = 0; tb_used(&v1);
+         while (n1--)
+         {
+             v1 = tb_isqrti64_impl((1 << 4) + 3);
+@@ -100,7 +100,7 @@
+         // analyze sqrt
+         tb_hong_t                   t2 = tb_uclock();
+         __tb_volatile__ tb_size_t   n2 = 100;
+-        __tb_volatile__ tb_uint32_t v2; tb_used(&v2);
++        __tb_volatile__ tb_uint32_t v2 = 0; tb_used(&v2);
+         while (n2--)
+         {
+             v2 = tb_isqrti64_impl_using_sqrt((1 << 4) + 3);
+--- a/src/tbox/platform/posix/thread_local.c
++++ b/src/tbox/platform/posix/thread_local.c
+@@ -141,7 +141,7 @@
+         /* mark exists and we use dummy variable to silence glibc 2.34 warnings
+          * https://github.com/SELinuxProject/selinux/issues/311
+          */
+-        tb_int_t dummy;
++        tb_int_t dummy = 0;
+         ok = pthread_setspecific(((pthread_key_t*)local->priv)[1], &dummy) == 0;
+     }
+     return ok;

--- a/packages/t/tbox/xmake.lua
+++ b/packages/t/tbox/xmake.lua
@@ -84,5 +84,9 @@ package("tbox")
     end)
 
     on_test(function (package)
-        assert(package:has_cfuncs("tb_exit", {includes = "tbox/tbox.h", configs = {languages = "c99"}}))
+        local configs = {languages = "c99"}
+        if package:is_plat("wasm") and package:config("pic") ~= false then
+            configs.cxflags = "-fPIC"
+        end
+        assert(package:has_cfuncs("tb_exit", {includes = "tbox/tbox.h", configs = configs}))
     end)

--- a/packages/t/tbox/xmake.lua
+++ b/packages/t/tbox/xmake.lua
@@ -1,5 +1,4 @@
 package("tbox")
-
     set_homepage("https://tboox.org")
     set_description("A glib-like multi-platform c library")
 

--- a/packages/t/tbox/xmake.lua
+++ b/packages/t/tbox/xmake.lua
@@ -19,6 +19,8 @@ package("tbox")
     add_versions("v1.7.5", "6382cf7d6110cbe6f29e8346d0e4eb078dd2cbf7e62913b96065848e351eb15e")
     add_versions("v1.7.6", "2622de5473b8f2e94b800b86ff6ef4a535bc138c61c940c3ab84737bb94a126a")
 
+    add_patches("v1.7.6", "patches/v1.7.6/fix-uninitialized-const-pointer.patch", "4430c2c01aa2c42a4e89a443356bece20ae2d0dde0602f0ad16cd44edf56c561")
+
     add_configs("micro",      {description = "Compile micro core library for the embed system.", default = false, type = "boolean"})
     add_configs("float",      {description = "Enable or disable the float type.", default = true, type = "boolean"})
     add_configs("force-utf8", {description = "Forcely regard all tb_char* as utf-8.", default = false, type = "boolean"})


### PR DESCRIPTION
Well similar patch would be required for 1.8.0 I think.
