### PR TITLE
cmake: update to 4.3.4

### DIFF
--- a/packages/c/cmake/schemes/binary.lua
+++ b/packages/c/cmake/schemes/binary.lua
@@ -31,6 +31,7 @@ function add_urls(package, scheme_name)
         scheme:add("versions", "4.1.4",  "7fc64e989af34201acff6d16628d6a8d1f72cfb74d5bd9342ab332c8c00e69ab")
         scheme:add("versions", "4.2.1",  "0bb18f295e52d7e9309980e361e79e76a1d8da67a1587255cbe3696ea998f597")
         scheme:add("versions", "4.2.3",  "c2302d3e9c48daabee5ea7c4db4b2b93b989bcc89dae8b760880e00120641b5b")
+        scheme:add("versions", "4.3.4",  "bf6647c78ac295c54dbe0a094d4428f495be93c1f810fd8bde57374e8b548523")
         return true
     elseif is_host("linux") and linuxos.name() ~= "alpine" then
         if os.arch():find("arm64.*") then
@@ -54,6 +55,7 @@ function add_urls(package, scheme_name)
             scheme:add("versions", "4.1.4",  "efe4dfc830fbf4d897af8e210f5a0632ad2b93c015a37c9305d40a57b0e4c538")
             scheme:add("versions", "4.2.1",  "3e178207a2c42af4cd4883127f8800b6faf99f3f5187dccc68bfb2cc7808f5f7")
             scheme:add("versions", "4.2.3",  "e529c75f18f27ba27c52b329efe7b1f98dc32ccc0c6d193c7ab343f888962672")
+            scheme:add("versions", "4.3.4",  "56a8014a8f28b8ff9cbe2c6fa8beebc028ac5b1987195d122b847fb486dc5282")
             return true
         else
             scheme:add("urls", "https://cmake.org/files/v$(version)-x86_64.tar.gz", {version = function (version)
@@ -82,6 +84,7 @@ function add_urls(package, scheme_name)
             scheme:add("versions", "4.1.4",  "af5c72ce7ce61607d70ff80445130f6278204aa46c45127edc0dc36e26a687b2")
             scheme:add("versions", "4.2.1",  "c059bff1e97a2b6b5b0c0872263627486345ad0ed083298cb21cff2eda883980")
             scheme:add("versions", "4.2.3",  "5bb505d5e0cca0480a330f7f27ccf52c2b8b5214c5bba97df08899f5ef650c23")
+            scheme:add("versions", "4.3.4",  "ca6f08ccbd5e6b0a9068d33317d0d1aff7278d08cccaed4529b8fbead7942a68")
             return true
         end
     elseif is_host("windows") then
@@ -112,6 +115,7 @@ function add_urls(package, scheme_name)
             scheme:add("versions", "4.1.4",  "8c31aabdf2223a7bb5759209ada56a9a72c6a1c605c221f23967130d1989e171")
             scheme:add("versions", "4.2.1",  "dfc2b2afac257555e3b9ce375b12b2883964283a366c17fec96cf4d17e4f1677")
             scheme:add("versions", "4.2.3",  "eb4ebf5155dbb05436d675706b2a08189430df58904257ae5e91bcba4c86933c")
+            scheme:add("versions", "4.3.4",  "86e5fcafb38bdf58346a78b187c7b6b4f252ae5242cffe24c463a92bbd2e77d1")
             return true
         elseif os.arch() == "x86" then
             scheme:add("urls", "https://cmake.org/files/v$(version).zip", {excludes = {"*/doc/*"}, version = function (version)
@@ -140,6 +144,7 @@ function add_urls(package, scheme_name)
             scheme:add("versions", "4.1.4",  "661f09c60febe401a73de7abd5030332973d44a6d163e22bba0866a7d90116c9")
             scheme:add("versions", "4.2.1",  "696129556482da90293f9d64c1fa68dbe06b0ede80331d7da9aaa03aada6aecf")
             scheme:add("versions", "4.2.3",  "ad46d82c99a818a2cdd694fe82bec99f0cb557d864dc5fff5d54d347c7cdd98f")
+            scheme:add("versions", "4.3.4",  "d41f361d4f06e4eac4ad6220109155b7af9ae114229a6102c58d96e1a9590e36")
             return true
         elseif os.arch() == "arm64" then
             scheme:add("urls", "https://cmake.org/files/v$(version).zip", {excludes = {"*/doc/*"}, version = function (version)
@@ -160,6 +165,7 @@ function add_urls(package, scheme_name)
             scheme:add("versions", "4.1.4",  "82967cb4f33bd56c0d3dbceb13aa887156deac31f5b3a3db07bdfa96b11a7229")
             scheme:add("versions", "4.2.1",  "96b097ca3a019cd62839d4805958ad0163dd1adedcfbe578730d57c098aaf667")
             scheme:add("versions", "4.2.3",  "751b206b1cf65151b72c525d26267c1d9beebf8fafc365ae00286571d9fd3ed9")
+            scheme:add("versions", "4.3.4",  "91a59ca6ffbcec18e1fb05431fa22f538ab615b6e525d1bfd0b8dd67a4d45685")
             return true
         end
     end

--- a/packages/c/cmake/schemes/source.lua
+++ b/packages/c/cmake/schemes/source.lua
@@ -25,6 +25,7 @@ function add_urls(package, scheme_name)
     scheme:add("versions", "4.1.4",  "a728a8ae5846aecbe3f4fea1405d809a6455ac7d1ed1f80c1fcf82f48d071ee1")
     scheme:add("versions", "4.2.1",  "414aacfac54ba0e78e64a018720b64ed6bfca14b587047b8b3489f407a14a070")
     scheme:add("versions", "4.2.3",  "7efaccde8c5a6b2968bad6ce0fe60e19b6e10701a12fce948c2bf79bac8a11e9")
+    scheme:add("versions", "4.3.4",  "fdeff897b9eb49d764539f2b1edc6eb7e1440df325678a97c1978499e931adda")
 end
 
 function install(package)


### PR DESCRIPTION
I think we need update it to silence warning for emscripten shared library build support.

```
CMake Warning at /usr/lib/emscripten/cmake/Modules/Platform/Emscripten.cmake:26 (message):
  This version of cmake (4.2.3) does not support emscripten shared libraries.
  Use cmake < 4.2.0 or cmake > 4.3.3 if you need shared library support
Call Stack (most recent call first):
  /home/lin/.xmake/cache/packages/2607/d/dbus/1.16.2/source/build_72b7763a/CMakeFiles/4.2.3/CMakeSystem.cmake:6 (include)
  /home/lin/.xmake/cache/packages/2607/d/dbus/1.16.2/source/build_72b7763a/CMakeFiles/CMakeScratch/TryCompile-npcBOr/CMakeLists.txt:5 (project)
```
