### PR TITLE
Add liblsl and brainflow

### DIFF
--- a/packages/b/brainflow/xmake.lua
+++ b/packages/b/brainflow/xmake.lua
@@ -41,7 +41,8 @@ package("brainflow")
             "-DBUILD_SYNCHRONI_SDK=OFF",
             "-DUSE_LIBFTDI=OFF",
             "-DUSE_OPENMP=OFF",
-            "-DWARNINGS_AS_ERRORS=OFF"
+            "-DWARNINGS_AS_ERRORS=OFF",
+            "-DBUILD_SHARED_LIBS=OFF"
         }
 
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))

--- a/packages/b/brainflow/xmake.lua
+++ b/packages/b/brainflow/xmake.lua
@@ -10,13 +10,11 @@ package("brainflow")
 
     add_deps("cmake")
 
-    on_load(function (package)
-        package:add("includedirs", "inc")
-        package:add("links", "Brainflow", "BoardController", "DataHandler", "MLModule")
-        if package:is_plat("linux") then
-            package:add("syslinks", "pthread", "dl")
-        end
-    end)
+    add_includedirs("inc")
+    add_links("Brainflow", "BoardController", "DataHandler", "MLModule")
+    if is_plat("linux") then
+        add_syslinks("pthread", "dl")
+    end
 
     -- Windows (MSVC) is intentionally omitted: BrainFlow only supports an MSVC
     -- build with the Windows 8.1 SDK (https://github.com/brainflow-dev/brainflow/blob/master/.github/workflows/run_windows.yml)

--- a/packages/b/brainflow/xmake.lua
+++ b/packages/b/brainflow/xmake.lua
@@ -54,6 +54,8 @@ package("brainflow")
         local opt = {}
         if package:is_plat("windows") then
             opt.cxflags = {"-DUNICODE", "-D_UNICODE"}
+            io.replace("third_party/DSPFilters/include/DspFilters/Common.h",
+                "namespace tr1 = std::tr1;", "namespace tr1 = std;", {plain = true})
         end
 
         import("package.tools.cmake").install(package, configs, opt)

--- a/packages/b/brainflow/xmake.lua
+++ b/packages/b/brainflow/xmake.lua
@@ -12,25 +12,17 @@ package("brainflow")
 
     on_load(function (package)
         package:add("includedirs", "inc")
-
-        local is_windows = package:is_plat("windows")
-        local is_32bit = is_windows and package:is_arch("x86", "i386")
-        local suffix = is_32bit and "32" or ""
-
-        package:add("links",
-            "Brainflow" .. suffix,
-            "BoardController" .. suffix,
-            "DataHandler" .. suffix,
-            "MLModule" .. suffix)
+        package:add("links", "Brainflow", "BoardController", "DataHandler", "MLModule")
 
         if package:is_plat("linux", "bsd") then
             package:add("syslinks", "pthread", "dl")
-        elseif is_windows then
-            package:add("syslinks", "ws2_32", "iphlpapi")
         end
     end)
 
-    on_install("linux", "macosx", "windows", "bsd", function (package)
+    -- Windows (MSVC) is intentionally omitted: BrainFlow only supports an MSVC
+    -- build with the Windows 8.1 SDK (https://github.com/brainflow-dev/brainflow/blob/master/.github/workflows/run_windows.yml)
+    -- and does not target Windows on ARM at all, so it does not compile against a recent MSVC/SDK.
+    on_install("linux", "macosx", "bsd", function (package)
         local configs = {
             "-DBUILD_TESTS=OFF",
             "-DBUILD_BLUETOOTH=OFF",
@@ -51,14 +43,7 @@ package("brainflow")
             table.insert(configs, "-DBRAINFLOW_VERSION=" .. tostring(version))
         end
 
-        local opt = {}
-        if package:is_plat("windows") then
-            opt.cxflags = {"-DUNICODE", "-D_UNICODE"}
-            io.replace("third_party/DSPFilters/include/DspFilters/Common.h",
-                "namespace tr1 = std::tr1;", "namespace tr1 = std;", {plain = true})
-        end
-
-        import("package.tools.cmake").install(package, configs, opt)
+        import("package.tools.cmake").install(package, configs)
     end)
 
     on_test(function (package)

--- a/packages/b/brainflow/xmake.lua
+++ b/packages/b/brainflow/xmake.lua
@@ -1,6 +1,6 @@
 package("brainflow")
     set_homepage("https://github.com/brainflow-dev/brainflow")
-    set_description("BrainFlow SDK for EEG and biosensors")
+    set_description("BrainFlow is a library intended to obtain, parse and analyze EEG, EMG, ECG and other kinds of data from biosensors.")
     set_license("MIT")
 
     add_urls("https://github.com/brainflow-dev/brainflow/archive/refs/tags/$(version).tar.gz",

--- a/packages/b/brainflow/xmake.lua
+++ b/packages/b/brainflow/xmake.lua
@@ -13,8 +13,7 @@ package("brainflow")
     on_load(function (package)
         package:add("includedirs", "inc")
         package:add("links", "Brainflow", "BoardController", "DataHandler", "MLModule")
-
-        if package:is_plat("linux", "bsd") then
+        if package:is_plat("linux") then
             package:add("syslinks", "pthread", "dl")
         end
     end)
@@ -22,7 +21,7 @@ package("brainflow")
     -- Windows (MSVC) is intentionally omitted: BrainFlow only supports an MSVC
     -- build with the Windows 8.1 SDK (https://github.com/brainflow-dev/brainflow/blob/master/.github/workflows/run_windows.yml)
     -- and does not target Windows on ARM at all, so it does not compile against a recent MSVC/SDK.
-    on_install("linux", "macosx", "bsd", function (package)
+    on_install("linux", "macosx", function (package)
         local configs = {
             "-DBUILD_TESTS=OFF",
             "-DBUILD_BLUETOOTH=OFF",

--- a/packages/b/brainflow/xmake.lua
+++ b/packages/b/brainflow/xmake.lua
@@ -51,7 +51,12 @@ package("brainflow")
             table.insert(configs, "-DBRAINFLOW_VERSION=" .. tostring(version))
         end
 
-        import("package.tools.cmake").install(package, configs)
+        local opt = {}
+        if package:is_plat("windows") then
+            opt.cxflags = {"-DUNICODE", "-D_UNICODE"}
+        end
+
+        import("package.tools.cmake").install(package, configs, opt)
     end)
 
     on_test(function (package)

--- a/packages/b/brainflow/xmake.lua
+++ b/packages/b/brainflow/xmake.lua
@@ -1,0 +1,63 @@
+package("brainflow")
+    set_homepage("https://github.com/brainflow-dev/brainflow")
+    set_description("BrainFlow SDK for EEG and biosensors")
+    set_license("MIT")
+
+    add_urls("https://github.com/brainflow-dev/brainflow/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/brainflow-dev/brainflow.git")
+    add_versions("5.20.1", "0f01f00025c67ce52745be26ebc049d1ba68d398c3fe5a6df6c766c3bf6d40ce")
+
+    add_deps("cmake")
+
+    on_load(function (package)
+        package:add("includedirs", "inc")
+
+        local is_windows = package:is_plat("windows")
+        local is_32bit = is_windows and package:is_arch("x86", "i386")
+        local suffix = is_32bit and "32" or ""
+
+        package:add("links",
+            "Brainflow" .. suffix,
+            "BoardController" .. suffix,
+            "DataHandler" .. suffix,
+            "MLModule" .. suffix)
+
+        if package:is_plat("linux", "bsd") then
+            package:add("syslinks", "pthread", "dl")
+        elseif is_windows then
+            package:add("syslinks", "ws2_32", "iphlpapi")
+        end
+    end)
+
+    on_install("linux", "macosx", "windows", "bsd", function (package)
+        local configs = {
+            "-DBUILD_TESTS=OFF",
+            "-DBUILD_BLUETOOTH=OFF",
+            "-DBUILD_BLE=OFF",
+            "-DBUILD_ONNX=OFF",
+            "-DBUILD_PERIPHERY=OFF",
+            "-DBUILD_OYMOTION_SDK=OFF",
+            "-DBUILD_SYNCHRONI_SDK=OFF",
+            "-DUSE_LIBFTDI=OFF",
+            "-DUSE_OPENMP=OFF",
+            "-DWARNINGS_AS_ERRORS=OFF"
+        }
+
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
+        local version = package:version()
+        if version then
+            table.insert(configs, "-DBRAINFLOW_VERSION=" .. tostring(version))
+        end
+
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            #include "board_shim.h"
+            int main() {
+                auto version = BoardShim::get_version();
+                return version.empty();
+            }
+        ]]}, {configs = {languages = "c++11"}}))
+    end)

--- a/packages/b/brainflow/xmake.lua
+++ b/packages/b/brainflow/xmake.lua
@@ -5,6 +5,7 @@ package("brainflow")
 
     add_urls("https://github.com/brainflow-dev/brainflow/archive/refs/tags/$(version).tar.gz",
              "https://github.com/brainflow-dev/brainflow.git")
+    add_versions("5.22.2", "a7e21b1b9d086370496282a5198c904cb25199cacd9c6a809b9adce544fcbe36")
     add_versions("5.20.1", "0f01f00025c67ce52745be26ebc049d1ba68d398c3fe5a6df6c766c3bf6d40ce")
 
     add_deps("cmake")

--- a/packages/l/liblsl/xmake.lua
+++ b/packages/l/liblsl/xmake.lua
@@ -14,7 +14,7 @@ package("liblsl")
         if package:is_plat("linux", "bsd") then
             package:add("syslinks", "pthread")
         elseif package:is_plat("windows") then
-            package:add("syslinks", "ws2_32")
+            package:add("syslinks", "ws2_32", "iphlpapi", "winmm", "mswsock")
         end
 
         if not package:config("shared") then

--- a/packages/l/liblsl/xmake.lua
+++ b/packages/l/liblsl/xmake.lua
@@ -26,6 +26,7 @@ package("liblsl")
         local configs = {
             "-DLSL_UNITTESTS=OFF",
             "-DLSL_TOOLS=OFF",
+            "-DLSL_OPTIMIZATIONS=OFF",
             "-DLSL_INSTALL=ON",
             "-DLSL_BUNDLED_BOOST=ON",
             "-DLSL_BUNDLED_PUGIXML=ON",

--- a/packages/l/liblsl/xmake.lua
+++ b/packages/l/liblsl/xmake.lua
@@ -5,6 +5,7 @@ package("liblsl")
 
     add_urls("https://github.com/sccn/liblsl/archive/refs/tags/$(version).tar.gz",
              "https://github.com/sccn/liblsl.git")
+    add_versions("v1.17.7", "19604fb1b30c753457e8bf1430341d84012834c0cf8d2ca921e8151d31220df9")
     add_versions("v1.17.5", "6f1f5a3fc4c4a162c86ced19c75d13a81d8ebe1f819c50caf257b1ee0b401d1a")
 
     add_deps("cmake")

--- a/packages/l/liblsl/xmake.lua
+++ b/packages/l/liblsl/xmake.lua
@@ -10,13 +10,13 @@ package("liblsl")
 
     add_deps("cmake")
 
-    on_load(function (package)
-        if package:is_plat("linux", "bsd") then
-            package:add("syslinks", "pthread")
-        elseif package:is_plat("windows") then
-            package:add("syslinks", "ws2_32", "iphlpapi", "winmm", "mswsock")
-        end
+    if is_plat("linux", "bsd") then
+        add_syslinks("pthread")
+    elseif is_plat("windows") then
+        add_syslinks("ws2_32", "iphlpapi", "winmm", "mswsock")
+    end
 
+    on_load(function (package)
         if not package:config("shared") then
             package:add("defines", "LIBLSL_STATIC")
         end

--- a/packages/l/liblsl/xmake.lua
+++ b/packages/l/liblsl/xmake.lua
@@ -1,0 +1,43 @@
+package("liblsl")
+    set_homepage("https://github.com/sccn/liblsl")
+    set_description("Lab Streaming Layer C/C++ library")
+    set_license("MIT")
+
+    add_urls("https://github.com/sccn/liblsl/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/sccn/liblsl.git")
+    add_versions("v1.17.5", "6f1f5a3fc4c4a162c86ced19c75d13a81d8ebe1f819c50caf257b1ee0b401d1a")
+
+    add_deps("cmake")
+
+    on_load(function (package)
+        if package:is_plat("linux", "bsd") then
+            package:add("syslinks", "pthread")
+        elseif package:is_plat("windows") then
+            package:add("syslinks", "ws2_32")
+        end
+
+        if not package:config("shared") then
+            package:add("defines", "LIBLSL_STATIC")
+        end
+    end)
+
+    on_install("linux", "macosx", "windows", "bsd", function (package)
+        local configs = {
+            "-DLSL_UNITTESTS=OFF",
+            "-DLSL_TOOLS=OFF",
+            "-DLSL_INSTALL=ON",
+            "-DLSL_BUNDLED_BOOST=ON",
+            "-DLSL_BUNDLED_PUGIXML=ON",
+            "-DLSL_FRAMEWORK=OFF",
+            "-DLSL_BUILD_STATIC=" .. (package:config("shared") and "OFF" or "ON")
+        }
+
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("lsl_local_clock", {includes = "lsl_c.h"}))
+    end)

--- a/packages/l/liblsl/xmake.lua
+++ b/packages/l/liblsl/xmake.lua
@@ -1,6 +1,6 @@
 package("liblsl")
     set_homepage("https://github.com/sccn/liblsl")
-    set_description("Lab Streaming Layer C/C++ library")
+    set_description("C++ lsl library for multi-modal time-synched data transmission over the local network.")
     set_license("MIT")
 
     add_urls("https://github.com/sccn/liblsl/archive/refs/tags/$(version).tar.gz",


### PR DESCRIPTION
Two packages that aren't in the repo yet, used together for EEG/biosignal acquisition.

- **liblsl** (sccn/liblsl): the Lab Streaming Layer, for time-synchronised
  streaming of multi-channel data over a local network. Boost and pugixml are
  built bundled, so it needs no extra packages.
- **brainflow** (brainflow-dev/brainflow): a uniform API to pull and parse data
  from EEG/EMG/ECG boards. The optional heavy backends (Bluetooth, BLE, ONNX,
  OpenMP, libftdi) are off by default to keep the build self-contained.

Both carry an `on_test` and pass `scripts/test.lua` locally on Linux
(liblsl v1.17.7, brainflow 5.22.2).