### PR TITLE
Auto-update libass to 0.17.5

### DIFF
--- a/packages/l/libass/port/xmake.lua
+++ b/packages/l/libass/port/xmake.lua
@@ -55,6 +55,9 @@ target("ass")
         elseif is_arch("arm64.*", "aarch64") then
             add_files("libass/aarch64/*.S")
             add_defines("ARCH_AARCH64")
+            if is_plat("macosx") then
+                add_defines("PREFIX")
+            end
         end
     end
     if has_config("system-font-provider") then

--- a/packages/l/libass/xmake.lua
+++ b/packages/l/libass/xmake.lua
@@ -6,6 +6,7 @@ package("libass")
     add_urls("https://github.com/libass/libass/releases/download/$(version)/libass-$(version).tar.gz",
              "https://github.com/libass/libass.git")
 
+    add_versions("0.17.5", "caab4b993dd7be6187c55623b789ed75dddefea6e65938af134637c732fe094a")
     add_versions("0.15.2", "1b2a54dda819ef84fa2dee3069cf99748a886363d2adb630fde87fe046e2d1d5")
     add_versions("0.16.0", "fea8019b1887cab9ab00c1e58614b4ec2b1cee339b3f7e446f5fab01b032d430")
     add_versions("0.17.0", "72b9ba5d9dd1ac6d30b5962f38cbe7aefb180174f71d8b65c5e3c3060dbc403f")

--- a/packages/l/libass/xmake.lua
+++ b/packages/l/libass/xmake.lua
@@ -28,6 +28,11 @@ package("libass")
             local ndk = package:toolchain("ndk"):config("ndkver")
             assert(ndk and tonumber(ndk) > 22, "package(libass) dep(harfbuzz) require ndk version > 22")
         end)
+        on_check("mingw", function (package)
+            if is_subhost("macosx") then
+                raise("package(libass): does not support mingw@macosx")
+            end
+        end)
     end
 
     on_install(function (package)

--- a/packages/l/libass/xmake.lua
+++ b/packages/l/libass/xmake.lua
@@ -18,6 +18,18 @@ package("libass")
         add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
     end
 
+    if on_check then
+        on_check("windows", function (package)
+            if package:is_arch("arm64") then
+                raise("package(libass): does not support windows|arm64 because MSVC cannot assemble its AArch64 sources")
+            end
+        end)
+        on_check("android", function (package)
+            local ndk = package:toolchain("ndk"):config("ndkver")
+            assert(ndk and tonumber(ndk) > 22, "package(libass) dep(harfbuzz) require ndk version > 22")
+        end)
+    end
+
     on_install(function (package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         os.cp(path.join(package:scriptdir(), "port", "config.h.in"), "config.h.in")


### PR DESCRIPTION
New version of libass detected (package version: 0.17.1, last github version: 0.17.5)