### PR TITLE
Auto-update ls-qpack to v2.6.5

### DIFF
--- a/packages/l/ls-qpack/xmake.lua
+++ b/packages/l/ls-qpack/xmake.lua
@@ -19,6 +19,10 @@ package("ls-qpack")
     add_patches(">=2.5.5 <=2.6.0", "patches/2.5.5/cmake.patch", "23fd785c3db2e1b43ead464b0ee8d12e9f290fbfdf818c3238cba316df295f08")
     add_patches("2.5.3", "patches/2.5.3/fix-cmake-install.patch", "7d819b620b5e2bd34ef58a91bf20d882883c7525def9f9f80313b64cba5e5239")
 
+    if is_plat("wasm") then
+        add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+    end
+
     add_deps("cmake")
     add_deps("xxhash")
 

--- a/packages/l/ls-qpack/xmake.lua
+++ b/packages/l/ls-qpack/xmake.lua
@@ -6,6 +6,7 @@ package("ls-qpack")
     add_urls("https://github.com/litespeedtech/ls-qpack/archive/refs/tags/$(version).tar.gz",
              "https://github.com/litespeedtech/ls-qpack.git")
 
+    add_versions("v2.6.5", "58241ce3d2971cc16f9bc6284c0a06e22e1793a50da7d38db9edc63b9af51191")
     add_versions("v2.6.4", "1bea5d42312b7004162421a10876799cf7587e1407e359f6301ac0e37b787a15")
     add_versions("v2.6.3", "822f60e118a82f79c8a550164a3dd8dd87409c8bae5bc226f4bdcba10f191418")
     add_versions("v2.6.2", "db1a83102bb7d2d946a910cb11a9d69c1c5b9fd9a40249c22c411fb9c429fe16")


### PR DESCRIPTION
New version of ls-qpack detected (package version: v2.6.4, last github version: v2.6.5)