### PR TITLE
update rmlui c++ version from 14 to 17

### DIFF
--- a/packages/r/rmlui/xmake.lua
+++ b/packages/r/rmlui/xmake.lua
@@ -84,5 +84,5 @@ package("rmlui")
             void test() {
                 Rml::Context* context = Rml::CreateContext("default", Rml::Vector2i(640, 480));
             }
-        ]]}, {configs = {languages = "c++14"}}))
+        ]]}, {configs = {languages = "c++17"}}))
     end)

--- a/packages/r/rmlui/xmake.lua
+++ b/packages/r/rmlui/xmake.lua
@@ -55,7 +55,7 @@ package("rmlui")
             #include <cstdint>
             ]], {plain = true})
         end
-        
+
         local configs = {"-DBUILD_TESTING=OFF", "-DBUILD_SAMPLES=OFF"}
         if package:is_plat("macosx") and package:is_arch("arm64") then
             table.insert(configs, "-DCMAKE_OSX_ARCHITECTURES=arm64")
@@ -84,5 +84,5 @@ package("rmlui")
             void test() {
                 Rml::Context* context = Rml::CreateContext("default", Rml::Vector2i(640, 480));
             }
-        ]]}, {configs = {languages = "c++17"}}))
+        ]]}, {configs = {languages = (not package:version() or package:version():ge("6.2")) and "c++17" or "c++14"}}))
     end)


### PR DESCRIPTION
RmlUI has updated to C++17 from C++14 after 6.2 update so it's not possible to use master branch without this change.
The related commit from rmlui: https://github.com/mikke89/RmlUi/commit/5137c3677de3f9be19fa86b25ff71cb8718a2064