### PR TITLE
Auto-update hpx to v1.11.0

### DIFF
--- a/packages/h/hpx/xmake.lua
+++ b/packages/h/hpx/xmake.lua
@@ -6,6 +6,7 @@ package("hpx")
     add_urls("https://github.com/STEllAR-GROUP/hpx/archive/refs/tags/$(version).tar.gz",
              "https://github.com/STEllAR-GROUP/hpx.git")
 
+    add_versions("v1.11.0", "01ec47228a2253b41e318bb09c83325a75021eb6ef3262400fbda30ac7389279")
     add_versions("v1.10.0", "5720ed7d2460fa0b57bd8cb74fa4f70593fe8675463897678160340526ec3c19")
     add_versions("v1.9.1", "1adae9d408388a723277290ddb33c699aa9ea72defadf3f12d4acc913a0ff22d")
 

--- a/packages/h/hpx/xmake.lua
+++ b/packages/h/hpx/xmake.lua
@@ -23,6 +23,11 @@ package("hpx")
         add_syslinks("pthread")
     end
 
+    if is_plat("windows") then
+        -- HPX overrides CMake's Ninja job pools, conflicting with --linkjobs.
+        set_policy("package.cmake_generator.ninja", false)
+    end
+
     add_deps("cmake", "hwloc", "asio >=1.12.0")
 
     on_load("windows|x64", "linux|x86_64", "macosx|x86_64", function (package)

--- a/packages/h/hpx/xmake.lua
+++ b/packages/h/hpx/xmake.lua
@@ -28,7 +28,7 @@ package("hpx")
         set_policy("package.cmake_generator.ninja", false)
     end
 
-    add_deps("cmake", "hwloc", "asio >=1.12.0")
+    add_deps("cmake", "hwloc", "asio >=1.12.0 <=1.21.0")
 
     on_load("windows|x64", "linux|x86_64", "macosx|x86_64", function (package)
         local malloc = package:config("malloc")
@@ -36,9 +36,9 @@ package("hpx")
             package:add("deps", malloc)
         end
         if package:config("context") then
-            package:add("deps", "boost >=1.71.0", {configs = {context = true}})
+            package:add("deps", "boost >=1.71.0", {configs = {context = true, spirit = true}})
         else
-            package:add("deps", "boost >=1.71.0")
+            package:add("deps", "boost >=1.71.0", {configs = {spirit = true}})
         end
     end)
 
@@ -46,6 +46,7 @@ package("hpx")
         local configs = {"-DHPX_WITH_EXAMPLES=OFF", "-DHPX_WITH_TESTS=OFF", "-DHPX_WITH_UNITY_BUILD=OFF"}
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:is_debug() and "Debug" or "Release"))
         table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        table.insert(configs, "-DHPX_WITH_STATIC_LINKING=" .. (package:config("shared") and "OFF" or "ON"))
         table.insert(configs, "-DHPX_WITH_MALLOC=" .. package:config("malloc"))
         table.insert(configs, "-DHPX_WITH_CUDA=" .. (package:config("cuda") and "ON" or "OFF"))
         table.insert(configs, "-DHPX_WITH_PARCELPORT_MPI=" .. (package:config("mpi") and "ON" or "OFF"))

--- a/packages/h/hpx/xmake.lua
+++ b/packages/h/hpx/xmake.lua
@@ -36,9 +36,9 @@ package("hpx")
             package:add("deps", malloc)
         end
         if package:config("context") then
-            package:add("deps", "boost >=1.71.0", {configs = {context = true, spirit = true}})
+            package:add("deps", "boost >=1.71.0", {configs = {context = true, serialization = true, spirit = true}})
         else
-            package:add("deps", "boost >=1.71.0", {configs = {spirit = true}})
+            package:add("deps", "boost >=1.71.0", {configs = {serialization = true, spirit = true}})
         end
     end)
 

--- a/packages/h/hpx/xmake.lua
+++ b/packages/h/hpx/xmake.lua
@@ -36,9 +36,9 @@ package("hpx")
             package:add("deps", malloc)
         end
         if package:config("context") then
-            package:add("deps", "boost >=1.71.0", {configs = {context = true, serialization = true, spirit = true}})
+            package:add("deps", "boost >=1.71.0", {configs = {context = true, iostreams = true, serialization = true, spirit = true}})
         else
-            package:add("deps", "boost >=1.71.0", {configs = {serialization = true, spirit = true}})
+            package:add("deps", "boost >=1.71.0", {configs = {iostreams = true, serialization = true, spirit = true}})
         end
     end)
 

--- a/packages/h/hpx/xmake.lua
+++ b/packages/h/hpx/xmake.lua
@@ -24,6 +24,7 @@ package("hpx")
     end
 
     if is_plat("windows") then
+        add_syslinks("dbghelp", "psapi", "shlwapi", "ws2_32", "mswsock")
         -- HPX overrides CMake's Ninja job pools, conflicting with --linkjobs.
         set_policy("package.cmake_generator.ninja", false)
     end


### PR DESCRIPTION
New version of hpx detected (package version: v1.10.0, last github version: v1.11.0)