### PR TITLE
fix: use 'python' instead of 'python3' on Windows

### DIFF
--- a/packages/d/depot_tools/xmake.lua
+++ b/packages/d/depot_tools/xmake.lua
@@ -60,7 +60,11 @@ package("depot_tools")
 
     on_test(function (package)
         import("core.base.global")
-        os.vrun("python3 --version")
+        if is_host("windows") then
+            os.vrun("python --version")
+        else
+            os.vrun("python3 --version")
+        end
         os.vrun("ninja --version")
         local envs = {}
         local proxy = global.get("proxy")


### PR DESCRIPTION
`Windows`上通常不会有`python3`，感觉改成`python`比较好。