### PR TITLE
Auto-update assimp to v6.0.5

### DIFF
--- a/packages/a/assimp/xmake.lua
+++ b/packages/a/assimp/xmake.lua
@@ -6,6 +6,7 @@ package("assimp")
     set_urls("https://github.com/assimp/assimp/archive/refs/tags/$(version).zip",
              "https://github.com/assimp/assimp.git")
 
+    add_versions("v6.0.5", "89e477e89df739ecc7dd21874897ac2e70c8944eb1074fbdbbdbf4dd2de6a403")
     add_versions("v6.0.4", "1eeb63f3e6f6c9d820cc52f7d44fa6b6557256330f45ddaa903aa658c47fece5")
     add_versions("v6.0.3", "e9b3208513aa4566955a45cc085e031f7053e28f2e6a0e33d1657450bd0519c5")
     add_versions("v6.0.2", "699b455b92ce2b6b39aa06a957e59f9d83e8652c8b51364e811660a4acb9ee49")


### PR DESCRIPTION
New version of assimp detected (package version: v6.0.4, last github version: v6.0.5)