### PR TITLE
Auto-update catch2 to v3.15.2

### DIFF
--- a/packages/c/catch2/xmake.lua
+++ b/packages/c/catch2/xmake.lua
@@ -5,6 +5,7 @@ package("catch2")
 
     add_urls("https://github.com/catchorg/Catch2/archive/refs/tags/$(version).zip",
              "https://github.com/catchorg/Catch2.git")
+    add_versions("v3.15.2", "a74af66888c17b14efa80544e56b2deef450ad210ddd239451c2222f109c5e51")
     add_versions("v3.15.1", "4be2f2625776fe50b419acad9d28a8f6d3e030fc8c6b9df200bb0fb1ac998d52")
     add_versions("v3.15.0", "27c53b2b03f17eb38c7565a8f80cfddaed2b0488d10206893f68776fac45694c")
     add_versions("v3.14.0", "33c9dfd4de6979fe127d5c43eb883818994f723938ce5aec0945410c8d6ebea2")


### PR DESCRIPTION
New version of catch2 detected (package version: v3.15.1, last github version: v3.15.2)