### PR TITLE
Auto-update flecs to v4.1.6

### DIFF
--- a/.github/workflows/wasm_ubuntu.yml
+++ b/.github/workflows/wasm_ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
-          xmake-version: branch@pic
+          xmake-version: branch@master
           actions-cache-folder: '.xmake-cache'
           actions-cache-key: 'wasm'
 

--- a/.github/workflows/wasm_ubuntu.yml
+++ b/.github/workflows/wasm_ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
-          xmake-version: branch@master
+          xmake-version: branch@pic
           actions-cache-folder: '.xmake-cache'
           actions-cache-key: 'wasm'
 

--- a/packages/f/flecs/xmake.lua
+++ b/packages/f/flecs/xmake.lua
@@ -6,6 +6,7 @@ package("flecs")
     add_urls("https://github.com/SanderMertens/flecs/archive/refs/tags/$(version).tar.gz",
              "https://github.com/SanderMertens/flecs.git")
 
+    add_versions("v4.1.6", "29ccf56961b7ffbd38cce2227a06c0722c7df464422e86619a65ee37bb31bae7")
     add_versions("v4.1.5", "8b94f56dfdda0b3c86110f651a4e0ec1c59030db43bb4810ae296a0630682ab9")
     add_versions("v4.1.4", "1ecd4b2b463388d1243c15a900dd62096b28cebba48ad76c204b562304945f0d")
     add_versions("v4.1.2", "9820e965339cca4659dc3b4547059d56889c707e9947e7cdae71847b00dafa9c")

--- a/packages/f/flecs/xmake.lua
+++ b/packages/f/flecs/xmake.lua
@@ -53,7 +53,7 @@ package("flecs")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DFLECS_STATIC=" .. (package:config("shared") and "OFF" or "ON"))
         table.insert(configs, "-DFLECS_SHARED=" .. (package:config("shared") and "ON" or "OFF"))
-        table.insert(configs, "-DFLECS_PIC=" .. ((package:is_plat("wasm") or package:config("pic")) and "ON" or "OFF"))
+        table.insert(configs, "-DFLECS_PIC=" .. (package:config("pic") and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)
 
         local pdb = path.join(package:buildir(), "flecs.pdb")

--- a/packages/f/flecs/xmake.lua
+++ b/packages/f/flecs/xmake.lua
@@ -53,7 +53,7 @@ package("flecs")
         table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
         table.insert(configs, "-DFLECS_STATIC=" .. (package:config("shared") and "OFF" or "ON"))
         table.insert(configs, "-DFLECS_SHARED=" .. (package:config("shared") and "ON" or "OFF"))
-        table.insert(configs, "-DFLECS_PIC=" .. (package:config("pic") and "ON" or "OFF"))
+        table.insert(configs, "-DFLECS_PIC=" .. ((package:is_plat("wasm") or package:config("pic")) and "ON" or "OFF"))
         import("package.tools.cmake").install(package, configs)
 
         local pdb = path.join(package:buildir(), "flecs.pdb")


### PR DESCRIPTION
New version of flecs detected (package version: v4.1.5, last github version: v4.1.6)