### PR TITLE
Add structural_interface package

### DIFF
--- a/packages/s/structural_interface/xmake.lua
+++ b/packages/s/structural_interface/xmake.lua
@@ -1,0 +1,39 @@
+package("structural_interface")
+    set_policy("check.auto_ignore_flags", false)
+    set_kind("library", {headeronly = true})
+    set_homepage("https://github.com/Maltose0118/structural_interface")
+    set_description("Header-only C++26 library for structural interfaces and type erasure")
+    set_license("MIT")
+
+    add_urls("https://github.com/Maltose0118/structural_interface/archive/refs/tags/v$(version).tar.gz")
+    add_versions("0.1.0", "a71b07193d9fdfc1bf74b5898a057331ead982ee8896567ea51761af4ba184e1")
+
+    on_load(function(package)
+        package:add("cxxflags", "-std=c++26", "-freflection", {
+            tools = "gcc",
+            force = true
+        })
+    end)
+
+    on_install(function(package)
+        os.cp("include", package:installdir())
+    end)
+
+    on_test(function(package)
+        assert(package:check_cxxsnippets({test = [[
+            #include <structural_interface.hpp>
+
+            void test() {
+                struct Interface {
+                    void draw() const;
+                };
+
+                static_assert(si::satisfies<Interface, Interface>);
+            }
+        ]]}, {
+            configs = {
+                languages = "c++26",
+                cxflags = {"-freflection"}
+            }
+        }))
+    end)

--- a/packages/s/structural_interface/xmake.lua
+++ b/packages/s/structural_interface/xmake.lua
@@ -13,11 +13,6 @@ package("structural_interface")
         end
     end)
 
-    add_cxxflags("-std=c++26", "-freflection", {
-        tools = "gcc",
-        force = true
-    })
-
     on_install(function(package)
         os.cp("include", package:installdir())
     end)

--- a/packages/s/structural_interface/xmake.lua
+++ b/packages/s/structural_interface/xmake.lua
@@ -1,5 +1,4 @@
 package("structural_interface")
-    set_policy("check.auto_ignore_flags", false)
     set_kind("library", {headeronly = true})
     set_homepage("https://github.com/Maltose0118/structural_interface")
     set_description("Header-only C++26 library for structural interfaces and type erasure")
@@ -8,12 +7,16 @@ package("structural_interface")
     add_urls("https://github.com/Maltose0118/structural_interface/archive/refs/tags/v$(version).tar.gz")
     add_versions("0.1.0", "a71b07193d9fdfc1bf74b5898a057331ead982ee8896567ea51761af4ba184e1")
 
-    on_load(function(package)
-        package:add("cxxflags", "-std=c++26", "-freflection", {
-            tools = "gcc",
-            force = true
-        })
+    on_check(function(package)
+        if not package:has_tool("cxx", "gxx") then
+            raise("package(structural_interface): only gcc is supported")
+        end
     end)
+
+    add_cxxflags("-std=c++26", "-freflection", {
+        tools = "gcc",
+        force = true
+    })
 
     on_install(function(package)
         os.cp("include", package:installdir())
@@ -23,17 +26,27 @@ package("structural_interface")
         assert(package:check_cxxsnippets({test = [[
             #include <structural_interface.hpp>
 
-            void test() {
-                struct Interface {
-                    void draw() const;
-                };
+            struct Drawable {
+                void draw() const;
+            };
 
-                static_assert(si::satisfies<Interface, Interface>);
+            struct Circle {
+                void draw() const {}
+            };
+
+            static_assert(si::satisfies<Circle, Drawable>);
+
+            void test() {
+                si::existential<Drawable> drawable = Circle{};
+                drawable.draw();
             }
         ]]}, {
             configs = {
                 languages = "c++26",
-                cxflags = {"-freflection"}
+                cxflags = "-freflection",
+                force = {
+                    cxflags = "-freflection"
+                }
             }
         }))
     end)

--- a/packages/s/structural_interface/xmake.lua
+++ b/packages/s/structural_interface/xmake.lua
@@ -38,10 +38,7 @@ package("structural_interface")
         ]]}, {
             configs = {
                 languages = "c++26",
-                cxflags = "-freflection",
-                force = {
-                    cxflags = "-freflection"
-                }
+                cxflags = "-freflection"
             }
         }))
     end)


### PR DESCRIPTION
Add the structural_interface package for the C++26 header-only structural interface and type-erasure library.\n\nThe package was tested locally with xmake v3.0.9 and GCC 16.0.1 using the official package test script. The test requires GCC static reflection support and -freflection.