### PR TITLE
Update libintl and glib; patch jack2, liblo and pthreads4w

### DIFF
--- a/packages/g/glib/xmake.lua
+++ b/packages/g/glib/xmake.lua
@@ -14,6 +14,7 @@ package("glib")
     add_versions("home:2.85.0", "97cfb0466ae41fca4fa2a57a15440bee15b54ae76a12fb3cbff11df947240e48")
     add_versions("home:2.88.1", "51ab804c56f6eab3e5045c774d1290ac5e4c923d4f9a3d8e33123bee45c1840e")
     add_versions("home:2.89.1", "74447129c31afe141810f995626e8b99ab677413dae76ee3cf5a9cc6e75a486e")
+    add_versions("home:2.89.2", "894fd527e305041f7723071297d79a78af4719dbd0d8fb77f6b1a85c9f5475b9")
 
     add_patches("2.71.0", path.join(os.scriptdir(), "patches", "2.71.0", "macosx.patch"), "a0c928643e40f3a3dfdce52950486c7f5e6f6e9cfbd76b20c7c5b43de51d6399")
 
@@ -145,7 +146,7 @@ package("glib")
         for _, depname in ipairs({"libintl", "libiconv"}) do
             if package:dep(depname) and not package:dep(depname):is_system() then
                 for _, pc in ipairs(pcs) do
-                    add_to_pc(path.join(pc_dir, pc), "Requires.private", depname)
+                    add_to_pc(path.join(pc_dir, pc), "Requires", depname)
                 end
             end
         end

--- a/packages/j/jack2/xmake.lua
+++ b/packages/j/jack2/xmake.lua
@@ -13,7 +13,7 @@ package("jack2")
         io.writefile("xmake.lua", [[
             add_rules("mode.release", "mode.debug")
             add_languages("c11")
-            add_rules("utils.install.pkgconfig_importfiles")
+            add_rules("utils.install.pkgconfig_importfiles", {filename = "jack.pc"})
 
             option("version", {description = "Set the version"})
             set_version(get_config("version"))

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -167,6 +167,8 @@ void test() {
 ]])
 if is_plat("windows", "mingw") then
     set_configvar("WOE32DLL", is_kind("shared") and 1 or 0)
+else
+    set_configvar("WOE32DLL", 0)
 end
 set_configvar("SETLOCALE_NULL_ALL_MTSAFE", is_plat("windows", "linux") and 1 or 0)
 set_configvar("SETLOCALE_NULL_ONE_MTSAFE", 1)
@@ -279,7 +281,7 @@ target("intl")
         remove_files("gettext-runtime/intl/gnulib-lib/windows-*.c")
     end
     before_build(function (target)
-        -- Generate config.h from config.h.in
+        -- Generate config.h from config.h.in, with extra patches
         local src = path.join(os.projectdir(), "gettext-runtime/intl/config.h.in")
         local dst = path.join(target:configdir(), "config.h")
         local cvars = target:get("configvar") or {}
@@ -330,6 +332,12 @@ target("intl")
         end
         if not content:find("\\n#define locale_t", 1, true) then
             content = content .. "\n#ifndef locale_t\n#define locale_t _locale_t\n#endif\n"
+        end
+        if not content:find("\\nextern wchar_t", 1, true) and is_plat("mingw") then
+            content = content .. [[
+#include <stddef.h>
+extern wchar_t *wgetcwd (wchar_t *, size_t);
+]]
         end
         if not content:find("\\n#define streq", 1, true) then
             content = content .. [[

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -1,0 +1,371 @@
+set_project("libintl")
+
+add_rules("mode.debug", "mode.release")
+
+set_configvar("PACKAGE", "gettext-runtime")
+set_configvar("PACKAGE_NAME", "gettext-runtime")
+set_configvar("PACKAGE_TARNAME", "gettext-runtime")
+set_configvar("PACKAGE_BUGREPORT", "bug-gettext@gnu.org")
+set_configvar("PACKAGE_URL", "")
+
+option("installprefix")
+    set_default("")
+    set_showmenu(true)
+option_end()
+set_configvar("INSTALLPREFIX", get_config("installprefix"))
+if has_config("installprefix") then
+    add_defines("LOCALEDIR=\"" .. get_config("installprefix") .. "/locale\"")
+    add_defines("LOCALE_ALIAS_PATH=\"" .. get_config("installprefix") .. "/locale\"")
+end
+
+option("vers")
+    set_default("")
+    set_showmenu(true)
+option_end()
+if has_config("vers") then
+    set_version(get_config("vers"))
+    set_configvar("VERSION", get_config("vers"))
+    set_configvar("PACKAGE_VERSION", get_config("vers"))
+    set_configvar("PACKAGE_STRING", "gettext-runtime " .. get_config("vers"))
+end
+
+option("relocatable")
+    set_default(true)
+    set_showmenu(true)
+option_end()
+if has_config("relocatable") then
+    add_defines("ENABLE_RELOCATABLE=1")
+    set_configvar("ENABLE_RELOCATABLE", 1)
+end
+
+includes("@builtin/check")
+
+-- Helper: func checks
+local function check_funcs(...)
+    for _, t in ipairs({...}) do
+        local var, fn, inc = t[1], t[2], t[3]
+        if inc then
+            configvar_check_cfuncs(var, fn, {includes = inc})
+        else
+            configvar_check_cfuncs(var, fn)
+        end
+    end
+end
+
+-- Used autoconf variables
+set_configvar("_GNU_SOURCE", 1)
+set_configvar("__USE_MINGW_ANSI_STDIO", 1)
+configvar_check_cincludes("ENABLE_NLS", "libintl.h", {default = 0})	
+check_funcs(
+    {"HAVE_GETCWD", "getcwd", "unistd.h"},
+    {"HAVE_MBRTOWC", "mbrtowc", "wchar.h"},
+    {"HAVE_WCRTOMB", "wcrtomb", "wchar.h"},
+    {"HAVE_WCSLEN", "wcslen", "wchar.h"},
+    {"HAVE_WCWIDTH", "wcwidth", "wchar.h"},
+    {"HAVE_WCSNLEN", "wcsnlen", "wchar.h"},
+    {"HAVE_STPCPY", "stpcpy", "string.h"},
+    {"HAVE_MEMPCPY", "mempcpy", "string.h"},
+    {"HAVE_MMAP", "mmap", "sys/mman.h"},
+    {"HAVE_MUNMAP", "munmap", "sys/mman.h"}
+)
+configvar_check_ctypes("HAVE_WINT_T", "wint_t", {includes = "wchar.h"})
+configvar_check_csnippets("HAVE_VISIBILITY", [[
+extern __attribute__((__visibility__("hidden"))) int hiddenvar;
+extern __attribute__((__visibility__("default"))) int exportedvar;
+extern __attribute__((__visibility__("hidden"))) int hiddenfunc(void);
+extern __attribute__((__visibility__("default"))) int exportedfunc(void);]], {default = 0})
+configvar_check_csnippets("GNULIB_SIGPIPE", [[#include <signal.h>
+#ifndef SIGPIPE
+#error SIGPIPE not defined
+#endif]])
+configvar_check_csnippets("HAVE_LANGINFO_CODESET", [[#include <langinfo.h>
+int test() { char* cs = nl_langinfo(CODESET); return !cs; }]])
+
+-- config.h variables
+if is_plat("windows", "mingw") then
+    set_configvar("USE_WINDOWS_THREADS", 1)
+elseif is_plat("bsd") then
+    set_configvar("USE_POSIX_THREADS", 1)
+else
+    option("USE_ISOC_THREADS")
+        add_cfuncs("thrd_create")
+        add_cincludes("threads.h")
+    option_end()
+    if has_config("USE_ISOC_THREADS") then
+        set_configvar("USE_ISOC_THREADS", 1)
+        set_configvar("USE_ISOC_AND_POSIX_THREADS", 1)
+        set_configvar("USE_POSIX_THREADS", 1)
+    else
+        set_configvar("USE_POSIX_THREADS", 1)
+    end
+end
+configvar_check_ctypes("HAVE_STDINT_H_WITH_UINTMAX", "uintmax_t", {includes = "stdint.h"})
+if is_plat("android") then
+    configvar_check_cfuncs("HAVE_PTHREAD_API", "pthread_create", {includes = "pthread.h"})
+else
+    configvar_check_links("HAVE_PTHREAD_API", "pthread")
+end
+configvar_check_ctypes("HAVE_PTHREAD_RWLOCK", "pthread_rwlock_t", {includes = "pthread.h"})
+if not is_plat("windows", "mingw") then
+    configvar_check_csnippets("HAVE_PTHREAD_MUTEX_RECURSIVE", [[#include <pthread.h>
+int test() { int x = PTHREAD_MUTEX_RECURSIVE; return !x; }]])
+    configvar_check_csnippets("HAVE_WEAK_SYMBOLS", [[__attribute__((__weak__)) void *f(void);]], {default = 0})
+    configvar_check_cincludes("HAVE_THREADS_H", "threads.h")
+    configvar_check_cincludes("HAVE_SYS_SINGLE_THREADED_H", "sys/single_threaded.h")
+end
+configvar_check_csnippets("HAVE_ALLOCA", [[
+#ifdef __GNUC__
+# define alloca __builtin_alloca
+#elif defined _MSC_VER
+# include <malloc.h>
+# define alloca _alloca
+#else
+# include <alloca.h>
+#endif
+void test() { char *p = (char *)alloca(1); }
+]])
+set_configvar("HAVE_ALLOCA_H", 0)
+configvar_check_csnippets("HAVE_SAME_LONG_DOUBLE_AS_DOUBLE", [[
+#include <float.h>
+int test() {
+  int same = sizeof(long double) == sizeof(double)
+    && LDBL_MANT_DIG == DBL_MANT_DIG
+    && LDBL_MAX_EXP == DBL_MAX_EXP
+    && LDBL_MIN_EXP == DBL_MIN_EXP;
+  return same;
+}]])
+configvar_check_csnippets("HAVE_FREE_POSIX", [[
+#if !(__GLIBC__ >= 2 || defined __OpenBSD__ || defined __sun)
+#error not a known-good platform
+#endif
+void test() {}]])	
+configvar_check_csnippets("FLEXIBLE_ARRAY_MEMBER=/**/", [[
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+struct m { struct m *next, **list; char name[]; };
+struct s { struct s *p; struct m *m; int n; double d[]; };
+int test() {
+  int m = getchar();
+  size_t nbytes = offsetof(struct s, d) + m * sizeof(double);
+  nbytes += sizeof(struct s) - 1;
+  nbytes -= nbytes % sizeof(struct s);
+  struct s *p = malloc(nbytes);
+  p->p = p;
+  p->m = NULL;
+  p->d[0] = 0.0;
+  return p->d != (double *)NULL;
+}
+]], {default = 1, quote = false})
+configvar_check_csnippets("HAVE_WORKING_USELOCALE", [[
+#include <locale.h>
+locale_t loc1;
+void test() {
+  uselocale(NULL);
+  setlocale(LC_ALL, "en_US.UTF-8");
+}
+]])
+if is_plat("windows", "mingw") then
+    set_configvar("WOE32DLL", is_kind("shared") and 1 or 0)
+end
+set_configvar("SETLOCALE_NULL_ALL_MTSAFE", is_plat("windows", "linux") and 1 or 0)
+set_configvar("SETLOCALE_NULL_ONE_MTSAFE", 1)
+configvar_check_cincludes("HAVE_SEARCH_H", "search.h")
+configvar_check_cincludes("HAVE_STDBOOL_H", "stdbool.h")
+
+-- search.h variables
+set_configvar("GUARD_PREFIX", "GL", {quote = false})
+set_configvar("PRAGMA_SYSTEM_HEADER", "", {quote = false})
+set_configvar("PRAGMA_COLUMNS", "", {quote = false})
+if is_plat("windows", "mingw") then
+    set_configvar("INCLUDE_NEXT", "include", {quote = false})
+    set_configvar("NEXT_SEARCH_H", "<search.h>", {quote = false})
+else
+    set_configvar("INCLUDE_NEXT", "include_next", {quote = false})
+    set_configvar("NEXT_SEARCH_H", "<search.h>", {quote = false})
+end
+set_configvar("GNULIB_MDA_LFIND", 1)
+set_configvar("GNULIB_MDA_LSEARCH", 1)
+configvar_check_ctypes("HAVE_TYPE_VISIT", "VISIT", {includes = "search.h", default = 0})
+option("HAVE_TSEARCH")
+    add_cfuncs("tsearch")
+    add_cincludes("search.h")
+option_end()
+option("HAVE_TWALK")
+    add_cfuncs("twalk")
+    add_cincludes("search.h")
+option_end()
+if has_config("HAVE_TSEARCH") and has_config("HAVE_TWALK") then
+    set_configvar("HAVE_TSEARCH", 1)
+    set_configvar("HAVE_TWALK", 1)
+    set_configvar("REPLACE_TSEARCH", 0)
+    set_configvar("REPLACE_TWALK", 0)
+    set_configvar("GNULIB_TSEARCH", 0)
+else
+    set_configvar("tsearch", "_libintl_tsearch", {quote = false})
+    set_configvar("tfind", "_libintl_tfind", {quote = false})
+    set_configvar("tdelete", "_libintl_tdelete", {quote = false})
+    set_configvar("twalk", "_libintl_twalk", {quote = false})
+    set_configvar("rpl_tsearch", "_libintl_tsearch", {quote = false})
+    set_configvar("rpl_tfind", "_libintl_tfind", {quote = false})
+    set_configvar("rpl_tdelete", "_libintl_tdelete", {quote = false})
+    set_configvar("rpl_twalk", "_libintl_twalk", {quote = false})
+    set_configvar("HAVE_TSEARCH", 0)
+    set_configvar("HAVE_TWALK", 0)
+    set_configvar("REPLACE_TSEARCH", 1)
+    set_configvar("REPLACE_TWALK", 1)
+    set_configvar("GNULIB_TSEARCH", 1)
+end
+
+-- libgnuintl.h variables
+set_configvar("HAVE_NAMELESS_LOCALES", 0)
+set_configvar("ENHANCE_LOCALE_FUNCS", 0)
+configvar_check_cfuncs("HAVE_NEWLOCALE", "newlocale", {includes = (is_plat("macosx", "bsd") and "xlocale.h" or "locale.h"), default = 0})
+configvar_check_cfuncs("HAVE_POSIX_PRINTF", "printf", {includes = "stdio.h", default = 0})
+configvar_check_cfuncs("HAVE_WPRINTF", "wprintf", {includes = "wchar.h", default = 0})
+configvar_check_cfuncs("HAVE_SNPRINTF", "snprintf", {includes = "stdio.h", default = 0})
+configvar_check_cfuncs("HAVE_ASPRINTF", "asprintf", {includes = "stdio.h", default = 0})
+
+target("intl")
+    set_kind("$(kind)")
+    add_defines("HAVE_CONFIG_H", "NO_XMALLOC", "IN_LIBRARY", "BUILDING_LIBRARY", "IN_LIBINTL")
+    if is_kind("shared") then
+        add_defines("BUILDING_LIBINTL", "BUILDING_DLL")
+        if is_plat("windows", "mingw") then
+            add_defines("DLL_EXPORT")
+        end
+    end
+    if is_plat("windows", "mingw") then
+        add_syslinks("advapi32")
+    elseif is_plat("bsd") then
+        add_syslinks("pthread")
+    end
+    set_configvar("HAVE_ICONV", 0)
+    set_configvar("HAVE_ICONV_H", 0)
+    add_defines("DEPENDS_ON_LIBICONV=0")
+    set_configdir("gettext-runtime/intl")
+    add_configfiles("gettext-runtime/intl/(libgnuintl.in.h)", {filename = "libgnuintl.h", pattern = "@(.-)@"})
+    add_configfiles("gettext-runtime/intl/(export.h)", {filename = "export.h", pattern = "@(.-)@"})
+    add_configfiles("gettext-runtime/intl/(gnulib-lib/search.in.h)", {filename = "tsearch.h", pattern = "@(.-)@"})
+    add_configfiles("gettext-runtime/intl/gnulib-lib/(alloca.in.h)", {filename = "alloca.h", pattern = "@(.-)@"})
+    add_includedirs("gettext-runtime/intl", "gettext-runtime/intl/gnulib-lib")
+    add_files("gettext-runtime/intl/*.c")
+    add_files("gettext-runtime/intl/gnulib-lib/*.c")
+    add_files("gettext-runtime/intl/gnulib-lib/glthread/*.c")
+
+    remove_files("gettext-runtime/intl/os2compat.c")
+    remove_files("gettext-runtime/intl/intl-exports.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/c32*.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/frexp*.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/getcwd-lgpl.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/getlocalename_l-unsafe.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/pthread-once.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/unistd.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/localeconv.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/memchr.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/strncpy.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/wmemcpy.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/wmemset.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/iswblank.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/iswdigit.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/iswpunct.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/iswxdigit.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/mbsinit.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/stdio-consolesafe.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/wcwidth.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/mbrtoc32.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/isnan.c")
+    if not is_plat("windows", "mingw") then
+        remove_files("gettext-runtime/intl/gnulib-lib/windows-*.c")
+    end
+    before_build(function (target)
+        -- Generate config.h from config.h.in
+        local src = path.join(os.projectdir(), "gettext-runtime/intl/config.h.in")
+        local dst = path.join(target:configdir(), "config.h")
+        local cvars = target:get("configvar") or {}
+        for _, opt in ipairs(target:orderopts()) do
+            for k, v in pairs(opt:get("configvar") or {}) do
+                if cvars[k] == nil then cvars[k] = v end
+            end
+        end
+        local content = io.readfile(src)
+        content = content:gsub("@(.-)@", function(name)
+            local v = cvars[name]
+            if v == nil then return "@"..name.."@" end
+            return (type(v) == "number" and tostring(v)) or
+                   (type(v) == "boolean" and (v and "1" or "0")) or v
+        end)
+        content = content:gsub("#undef%s+([%w_]+)", function(name)
+            local v = cvars[name]
+            if v == nil or (type(v) == "boolean" and not v) then
+                return "/* #undef "..name.." */"
+            end
+            local val = (type(v) == "number" and tostring(v)) or
+                        (type(v) == "boolean" and "1") or v
+            if type(v) == "string" then
+                local extra = target:extraconf("configvar." .. name, v)
+                if not extra or extra.quote ~= false then
+                    val = '"' .. val .. '"'
+                end
+            end
+            return "#define "..name.." "..val
+        end)
+        content = content:gsub("%$%{define ([%w_]+)}", function(name)
+            local v = cvars[name]
+            if v == nil or (type(v) == "boolean" and not v) then
+                return "/* #undef " .. name .. " */"
+            end
+            local val = (type(v) == "number" and tostring(v)) or
+                        (type(v) == "boolean" and "1") or v
+            if type(v) == "string" then
+                local extra = target:extraconf("configvar." .. name, v)
+                if not extra or extra.quote ~= false then
+                    val = '"' .. val .. '"'
+                end
+            end
+            return "#define " .. name .. " " .. val
+        end)
+        if not content:find("SETLOCALE_NULL_ALL_MAX", 1, true) then
+            content = content .. "\n\n#ifndef SETLOCALE_NULL_ALL_MAX\n#define SETLOCALE_NULL_ALL_MAX (148+12*256+1)\n#define SETLOCALE_NULL_MAX (256+1)\n#endif\n"
+        end
+        if not content:find("\\n#define locale_t", 1, true) then
+            content = content .. "\n#ifndef locale_t\n#define locale_t _locale_t\n#endif\n"
+        end
+        if not content:find("\\n#define streq", 1, true) then
+            content = content .. [[
+#ifndef streq
+#define streq(s1, s2) (strcmp((s1), (s2)) == 0)
+#endif
+#ifndef memeq
+#define memeq(s1, s2, n) (memcmp((s1), (s2), (n)) == 0)
+#endif
+#ifndef mbszero
+#include <string.h>
+#define mbszero(ps) memset((ps), 0, sizeof(mbstate_t))
+#endif
+]]
+        end
+        content = content:gsub("#define mbszero%s+_libintl_mbszero\n",
+            "#define mbszero(ps) memset((ps), 0, sizeof(mbstate_t))\n")
+        io.writefile(dst, content)
+
+        io.gsub("gettext-runtime/intl/gnulib-lib/tsearch.h", "(definitions of _GL_FUNCDECL_RPL etc.-)\n", "%1\n#include <c++defs.h>\n")
+        io.gsub("gettext-runtime/intl/gnulib-lib/tsearch.h", "(definition of _GL_ARG_NONNULL.-)\n", "%1\n#include <arg-nonnull.h>\n")
+        io.gsub("gettext-runtime/intl/gnulib-lib/tsearch.h", "(definition of _GL_WARN_ON_USE.-)\n", "%1\n#include <warn-on-use.h>\n")
+        io.replace("gettext-runtime/intl/gnulib-lib/tsearch.c", "#include <search.h>", "#include <tsearch.h>", {plain = true})
+        os.cp("gettext-runtime/intl/libgnuintl.h", "gettext-runtime/intl/libintl.h")
+
+        local lines = io.readfile("gettext-runtime/intl/export.h")
+        lines = lines:gsub("@WOE32DLL@", is_plat("windows", "mingw") and "1" or "0")
+        lines = lines:gsub("@HAVE_VISIBILITY@", "0")
+        io.replace("gettext-runtime/intl/libgnuintl.h", "#define _LIBINTL_H 1",
+            "#define _LIBINTL_H 1\n" .. lines, {plain = true})
+        io.replace("gettext-runtime/intl/libgnuintl.h", 'extern "C"', 'EXTERN_C', {plain = true})
+        io.replace("gettext-runtime/intl/libgnuintl.h", "extern", "extern LIBINTL_SHLIB_EXPORTED", {plain = true})
+        io.replace("gettext-runtime/intl/libgnuintl.h", 'EXTERN_C', 'extern "C"', {plain = true})
+    end)
+    after_install(function (target)
+        local dest = path.join(target:installdir(), "include", "libintl.h")
+        os.cp("gettext-runtime/intl/libintl.h", dest)
+    end)
+target_end()

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -174,6 +174,9 @@ set_configvar("SETLOCALE_NULL_ONE_MTSAFE", 1)
 configvar_check_cincludes("HAVE_SEARCH_H", "search.h")
 configvar_check_cincludes("HAVE_STDBOOL_H", "stdbool.h")
 configvar_check_cincludes("HAVE_UNISTD_H", "unistd.h")
+if is_plat("android") then
+    set_configvar("HAVE_MEMPCPY", 1)
+end
 
 -- search.h variables
 set_configvar("GUARD_PREFIX", "GL", {quote = false})
@@ -287,9 +290,7 @@ target("intl")
 
     remove_files("gettext-runtime/intl/os2compat.c")
     remove_files("gettext-runtime/intl/intl-exports.c")
-    if not is_plat("mingw", "macosx") then
-        remove_files("gettext-runtime/intl/gnulib-lib/c32*.c")
-    end
+    remove_files("gettext-runtime/intl/gnulib-lib/c32*.c")
     remove_files("gettext-runtime/intl/gnulib-lib/frexp*.c")
     remove_files("gettext-runtime/intl/gnulib-lib/getcwd-lgpl.c")
     remove_files("gettext-runtime/intl/gnulib-lib/getlocalename_l-unsafe.c")
@@ -394,8 +395,8 @@ extern wchar_t *wgetcwd (wchar_t *, size_t);
         io.gsub("gettext-runtime/intl/gnulib-lib/tsearch.h", "(definition of _GL_ARG_NONNULL.-)\n", "%1\n#include <arg-nonnull.h>\n")
         io.gsub("gettext-runtime/intl/gnulib-lib/tsearch.h", "(definition of _GL_WARN_ON_USE.-)\n", "%1\n#include <warn-on-use.h>\n")
         io.replace("gettext-runtime/intl/gnulib-lib/tsearch.c", "#include <search.h>", "#include <tsearch.h>", {plain = true})
-        -- For MinGW/macOS relating to uchar
-        if is_plat("mingw", "macosx") then
+        -- For MinGW/macOS relating to uchar/c32* symbols
+        if is_plat("macosx") then
             local uchar_src = path.join(os.projectdir(), "gettext-runtime/intl/gnulib-lib/uchar.in.h")
             local uchar_dst = path.join(os.projectdir(), "gettext-runtime/intl/gnulib-lib/uchar.h")
             local uchar = io.readfile(uchar_src)
@@ -409,6 +410,38 @@ extern wchar_t *wgetcwd (wchar_t *, size_t);
             io.gsub(uchar_dst, "(definitions of _GL_FUNCDECL_RPL etc.-)\n", "%1\n#include <c++defs.h>\n")
             io.gsub(uchar_dst, "(definition of _GL_ARG_NONNULL.-)\n", "%1\n#include <arg-nonnull.h>\n")
             io.gsub(uchar_dst, "(definition of _GL_WARN_ON_USE.-)\n", "%1\n#include <warn-on-use.h>\n")
+        end
+        if is_plat("mingw") then
+            io.writefile(path.join(os.projectdir(), "gettext-runtime/intl/gnulib-lib/uchar.h"), [[
+#ifndef _GL_UCHAR_H
+#define _GL_UCHAR_H
+
+#include_next <uchar.h>
+#include <wchar.h>
+#include <wctype.h>
+#include <stdint.h>
+
+/* Inline c32* functions missing from MinGW's <uchar.h> */
+/* wchar_t is 16-bit on MinGW; for values > 0xFFFF return safe defaults. */
+
+static inline int c32isalnum(char32_t wc) { return (wc <= 0xFFFF) ? iswalnum((wint_t)wc) : 0; }
+static inline int c32isalpha(char32_t wc) { return (wc <= 0xFFFF) ? iswalpha((wint_t)wc) : 0; }
+static inline int c32isblank(char32_t wc) { return (wc <= 0xFFFF) ? iswblank((wint_t)wc) : 0; }
+static inline int c32iscntrl(char32_t wc) { return (wc <= 0xFFFF) ? iswcntrl((wint_t)wc) : 0; }
+static inline int c32isdigit(char32_t wc) { return (wc <= 0xFFFF) ? iswdigit((wint_t)wc) : 0; }
+static inline int c32isgraph(char32_t wc) { return (wc <= 0xFFFF) ? iswgraph((wint_t)wc) : 0; }
+static inline int c32islower(char32_t wc) { return (wc <= 0xFFFF) ? iswlower((wint_t)wc) : 0; }
+static inline int c32isprint(char32_t wc) { return (wc <= 0xFFFF) ? iswprint((wint_t)wc) : 0; }
+static inline int c32ispunct(char32_t wc) { return (wc <= 0xFFFF) ? iswpunct((wint_t)wc) : 0; }
+static inline int c32isspace(char32_t wc) { return (wc <= 0xFFFF) ? iswspace((wint_t)wc) : 0; }
+static inline int c32isupper(char32_t wc) { return (wc <= 0xFFFF) ? iswupper((wint_t)wc) : 0; }
+static inline int c32isxdigit(char32_t wc) { return (wc <= 0xFFFF) ? iswxdigit((wint_t)wc) : 0; }
+static inline int c32width(char32_t wc) { return (wc <= 0xFFFF) ? wcwidth((wchar_t)wc) : 2; }
+static inline char32_t c32tolower(char32_t wc) { return (wc <= 0xFFFF) ? towlower((wint_t)wc) : wc; }
+static inline char32_t c32toupper(char32_t wc) { return (wc <= 0xFFFF) ? towupper((wint_t)wc) : wc; }
+
+#endif
+]])
         end
         os.cp("gettext-runtime/intl/libgnuintl.h", "gettext-runtime/intl/libintl.h")
 

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -258,7 +258,7 @@ target("intl")
     end
 
     if is_plat("mingw") and is_kind("shared") then
-      add_ldflags("-Wl,--export-all-symbols")
+        add_ldflags("-Wl,--export-all-symbols")
     end
 
     set_configvar("HAVE_ICONV", 0)

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -92,9 +92,7 @@ else
         add_cincludes("threads.h")
     option_end()
     if has_config("USE_ISOC_THREADS") then
-        set_configvar("USE_ISOC_THREADS", 1)
         set_configvar("USE_ISOC_AND_POSIX_THREADS", 1)
-        set_configvar("USE_POSIX_THREADS", 1)
     else
         set_configvar("USE_POSIX_THREADS", 1)
     end
@@ -174,6 +172,7 @@ set_configvar("SETLOCALE_NULL_ALL_MTSAFE", is_plat("windows", "linux") and 1 or 
 set_configvar("SETLOCALE_NULL_ONE_MTSAFE", 1)
 configvar_check_cincludes("HAVE_SEARCH_H", "search.h")
 configvar_check_cincludes("HAVE_STDBOOL_H", "stdbool.h")
+configvar_check_cincludes("HAVE_UNISTD_H", "unistd.h")
 
 -- search.h variables
 set_configvar("GUARD_PREFIX", "GL", {quote = false})
@@ -339,6 +338,7 @@ target("intl")
 extern wchar_t *wgetcwd (wchar_t *, size_t);
 ]]
         end
+        content = content .. "\n#include \"setlocale_null.h\"\n"
         if not content:find("\\n#define streq", 1, true) then
             content = content .. [[
 #ifndef streq

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -108,7 +108,9 @@ configvar_check_ctypes("HAVE_PTHREAD_RWLOCK", "pthread_rwlock_t", {includes = "p
 if not is_plat("windows", "mingw") then
     configvar_check_csnippets("HAVE_PTHREAD_MUTEX_RECURSIVE", [[#include <pthread.h>
 int test() { int x = PTHREAD_MUTEX_RECURSIVE; return !x; }]])
-    configvar_check_csnippets("HAVE_WEAK_SYMBOLS", [[__attribute__((__weak__)) void *f(void);]], {default = 0})
+    if not is_plat("macosx") then
+        configvar_check_csnippets("HAVE_WEAK_SYMBOLS", [[__attribute__((__weak__)) void *f(void);]], {default = 0})
+    end
     configvar_check_cincludes("HAVE_THREADS_H", "threads.h")
     configvar_check_cincludes("HAVE_SYS_SINGLE_THREADED_H", "sys/single_threaded.h")
 end
@@ -353,9 +355,9 @@ target("intl")
             content = content .. "\n\n#ifndef SETLOCALE_NULL_ALL_MAX\n#define SETLOCALE_NULL_ALL_MAX (148+12*256+1)\n#define SETLOCALE_NULL_MAX (256+1)\n#endif\n"
         end
         if not content:find("\\n#define locale_t", 1, true) then
-            if is_plat("windows", "mingw") then
+            if package:is_plat("windows", "mingw") then
                 content = content .. "\n#ifndef locale_t\n#define locale_t _locale_t\n#endif\n"
-            elseif is_plat("macosx") then
+            elseif package:is_plat("macosx") then
                 content = content .. "\n#include <xlocale.h>\n"
             end
         end

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -231,36 +231,6 @@ configvar_check_cfuncs("HAVE_WPRINTF", "wprintf", {includes = "wchar.h", default
 configvar_check_cfuncs("HAVE_SNPRINTF", "snprintf", {includes = "stdio.h", default = 0})
 configvar_check_cfuncs("HAVE_ASPRINTF", "asprintf", {includes = "stdio.h", default = 0})
 
-if is_plat("mingw", "macosx") then
-    configvar_check_cincludes("HAVE_UCHAR_H", "uchar.h")
-    set_configvar("CXX_HAVE_UCHAR_H", 0)
-    set_configvar("CXX_HAS_CHAR8_TYPE", 0)
-    set_configvar("CXX_HAS_UCHAR_TYPES", 0)
-    set_configvar("GNULIBHEADERS_OVERRIDE_CHAR8_T", 0)
-    set_configvar("GNULIBHEADERS_OVERRIDE_CHAR16_T", 0)
-    set_configvar("GNULIBHEADERS_OVERRIDE_CHAR32_T", 0)
-    set_configvar("SMALL_WCHAR_T", is_plat("mingw") and 1 or 0)
-    if is_plat("mingw") then
-        set_configvar("INCLUDE_NEXT", "include_next", {quote = false})
-        set_configvar("NEXT_UCHAR_H", "<uchar.h>", {quote = false})
-    end
-    set_configvar("GNULIB_C32ISALNUM", 1)
-    set_configvar("GNULIB_C32ISALPHA", 1)
-    set_configvar("GNULIB_C32ISBLANK", 1)
-    set_configvar("GNULIB_C32ISCNTRL", 1)
-    set_configvar("GNULIB_C32ISDIGIT", 1)
-    set_configvar("GNULIB_C32ISGRAPH", 1)
-    set_configvar("GNULIB_C32ISLOWER", 1)
-    set_configvar("GNULIB_C32ISPRINT", 1)
-    set_configvar("GNULIB_C32ISPUNCT", 1)
-    set_configvar("GNULIB_C32ISSPACE", 1)
-    set_configvar("GNULIB_C32ISUPPER", 1)
-    set_configvar("GNULIB_C32ISXDIGIT", 1)
-    set_configvar("GNULIB_C32TOLOWER", 1)
-    set_configvar("GNULIB_C32TOUPPER", 1)
-    set_configvar("GNULIB_C32WIDTH", 1)
-end
-
 target("intl")
     set_kind("$(kind)")
     add_defines("HAVE_CONFIG_H", "NO_XMALLOC", "IN_LIBRARY", "BUILDING_LIBRARY", "IN_LIBINTL")
@@ -310,6 +280,9 @@ target("intl")
     remove_files("gettext-runtime/intl/gnulib-lib/wcwidth.c")
     remove_files("gettext-runtime/intl/gnulib-lib/mbrtoc32.c")
     remove_files("gettext-runtime/intl/gnulib-lib/isnan.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/mbchar.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/mbiterf.c")
+    remove_files("gettext-runtime/intl/gnulib-lib/mbsnlen.c")
     if not is_plat("windows", "mingw") then
         remove_files("gettext-runtime/intl/gnulib-lib/windows-*.c")
     end
@@ -395,54 +368,6 @@ extern wchar_t *wgetcwd (wchar_t *, size_t);
         io.gsub("gettext-runtime/intl/gnulib-lib/tsearch.h", "(definition of _GL_ARG_NONNULL.-)\n", "%1\n#include <arg-nonnull.h>\n")
         io.gsub("gettext-runtime/intl/gnulib-lib/tsearch.h", "(definition of _GL_WARN_ON_USE.-)\n", "%1\n#include <warn-on-use.h>\n")
         io.replace("gettext-runtime/intl/gnulib-lib/tsearch.c", "#include <search.h>", "#include <tsearch.h>", {plain = true})
-        -- For MinGW/macOS relating to uchar/c32* symbols
-        if is_plat("macosx") then
-            local uchar_src = path.join(os.projectdir(), "gettext-runtime/intl/gnulib-lib/uchar.in.h")
-            local uchar_dst = path.join(os.projectdir(), "gettext-runtime/intl/gnulib-lib/uchar.h")
-            local uchar = io.readfile(uchar_src)
-            uchar = uchar:gsub("@(.-)@", function(name)
-                local v = cvars[name]
-                if v == nil then return "0" end
-                return (type(v) == "number" and tostring(v)) or
-                       (type(v) == "boolean" and (v and "1" or "0")) or v
-            end)
-            io.writefile(uchar_dst, uchar)
-            io.gsub(uchar_dst, "(definitions of _GL_FUNCDECL_RPL etc.-)\n", "%1\n#include <c++defs.h>\n")
-            io.gsub(uchar_dst, "(definition of _GL_ARG_NONNULL.-)\n", "%1\n#include <arg-nonnull.h>\n")
-            io.gsub(uchar_dst, "(definition of _GL_WARN_ON_USE.-)\n", "%1\n#include <warn-on-use.h>\n")
-        end
-        if is_plat("mingw") then
-            io.writefile(path.join(os.projectdir(), "gettext-runtime/intl/gnulib-lib/uchar.h"), [[
-#ifndef _GL_UCHAR_H
-#define _GL_UCHAR_H
-
-#include_next <uchar.h>
-#include <wchar.h>
-#include <wctype.h>
-#include <stdint.h>
-
-/* Inline c32* functions missing from MinGW's <uchar.h> */
-/* wchar_t is 16-bit on MinGW; for values > 0xFFFF return safe defaults. */
-
-static inline int c32isalnum(char32_t wc) { return (wc <= 0xFFFF) ? iswalnum((wint_t)wc) : 0; }
-static inline int c32isalpha(char32_t wc) { return (wc <= 0xFFFF) ? iswalpha((wint_t)wc) : 0; }
-static inline int c32isblank(char32_t wc) { return (wc <= 0xFFFF) ? iswblank((wint_t)wc) : 0; }
-static inline int c32iscntrl(char32_t wc) { return (wc <= 0xFFFF) ? iswcntrl((wint_t)wc) : 0; }
-static inline int c32isdigit(char32_t wc) { return (wc <= 0xFFFF) ? iswdigit((wint_t)wc) : 0; }
-static inline int c32isgraph(char32_t wc) { return (wc <= 0xFFFF) ? iswgraph((wint_t)wc) : 0; }
-static inline int c32islower(char32_t wc) { return (wc <= 0xFFFF) ? iswlower((wint_t)wc) : 0; }
-static inline int c32isprint(char32_t wc) { return (wc <= 0xFFFF) ? iswprint((wint_t)wc) : 0; }
-static inline int c32ispunct(char32_t wc) { return (wc <= 0xFFFF) ? iswpunct((wint_t)wc) : 0; }
-static inline int c32isspace(char32_t wc) { return (wc <= 0xFFFF) ? iswspace((wint_t)wc) : 0; }
-static inline int c32isupper(char32_t wc) { return (wc <= 0xFFFF) ? iswupper((wint_t)wc) : 0; }
-static inline int c32isxdigit(char32_t wc) { return (wc <= 0xFFFF) ? iswxdigit((wint_t)wc) : 0; }
-static inline int c32width(char32_t wc) { return (wc <= 0xFFFF) ? wcwidth((wchar_t)wc) : 2; }
-static inline char32_t c32tolower(char32_t wc) { return (wc <= 0xFFFF) ? towlower((wint_t)wc) : wc; }
-static inline char32_t c32toupper(char32_t wc) { return (wc <= 0xFFFF) ? towupper((wint_t)wc) : wc; }
-
-#endif
-]])
-        end
         os.cp("gettext-runtime/intl/libgnuintl.h", "gettext-runtime/intl/libintl.h")
 
         local lines = io.readfile("gettext-runtime/intl/export.h")

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -98,6 +98,7 @@ else
     end
 end
 configvar_check_ctypes("HAVE_STDINT_H_WITH_UINTMAX", "uintmax_t", {includes = "stdint.h"})
+configvar_check_cincludes("HAVE_STDINT_H", "stdint.h")
 if is_plat("android") then
     configvar_check_cfuncs("HAVE_PTHREAD_API", "pthread_create", {includes = "pthread.h"})
 else
@@ -227,6 +228,36 @@ configvar_check_cfuncs("HAVE_WPRINTF", "wprintf", {includes = "wchar.h", default
 configvar_check_cfuncs("HAVE_SNPRINTF", "snprintf", {includes = "stdio.h", default = 0})
 configvar_check_cfuncs("HAVE_ASPRINTF", "asprintf", {includes = "stdio.h", default = 0})
 
+if is_plat("mingw", "macosx") then
+    configvar_check_cincludes("HAVE_UCHAR_H", "uchar.h")
+    set_configvar("CXX_HAVE_UCHAR_H", 0)
+    set_configvar("CXX_HAS_CHAR8_TYPE", 0)
+    set_configvar("CXX_HAS_UCHAR_TYPES", 0)
+    set_configvar("GNULIBHEADERS_OVERRIDE_CHAR8_T", 0)
+    set_configvar("GNULIBHEADERS_OVERRIDE_CHAR16_T", 0)
+    set_configvar("GNULIBHEADERS_OVERRIDE_CHAR32_T", 0)
+    set_configvar("SMALL_WCHAR_T", is_plat("mingw") and 1 or 0)
+    if is_plat("mingw") then
+        set_configvar("INCLUDE_NEXT", "include_next", {quote = false})
+        set_configvar("NEXT_UCHAR_H", "<uchar.h>", {quote = false})
+    end
+    set_configvar("GNULIB_C32ISALNUM", 1)
+    set_configvar("GNULIB_C32ISALPHA", 1)
+    set_configvar("GNULIB_C32ISBLANK", 1)
+    set_configvar("GNULIB_C32ISCNTRL", 1)
+    set_configvar("GNULIB_C32ISDIGIT", 1)
+    set_configvar("GNULIB_C32ISGRAPH", 1)
+    set_configvar("GNULIB_C32ISLOWER", 1)
+    set_configvar("GNULIB_C32ISPRINT", 1)
+    set_configvar("GNULIB_C32ISPUNCT", 1)
+    set_configvar("GNULIB_C32ISSPACE", 1)
+    set_configvar("GNULIB_C32ISUPPER", 1)
+    set_configvar("GNULIB_C32ISXDIGIT", 1)
+    set_configvar("GNULIB_C32TOLOWER", 1)
+    set_configvar("GNULIB_C32TOUPPER", 1)
+    set_configvar("GNULIB_C32WIDTH", 1)
+end
+
 target("intl")
     set_kind("$(kind)")
     add_defines("HAVE_CONFIG_H", "NO_XMALLOC", "IN_LIBRARY", "BUILDING_LIBRARY", "IN_LIBINTL")
@@ -256,7 +287,9 @@ target("intl")
 
     remove_files("gettext-runtime/intl/os2compat.c")
     remove_files("gettext-runtime/intl/intl-exports.c")
-    remove_files("gettext-runtime/intl/gnulib-lib/c32*.c")
+    if not is_plat("mingw", "macosx") then
+        remove_files("gettext-runtime/intl/gnulib-lib/c32*.c")
+    end
     remove_files("gettext-runtime/intl/gnulib-lib/frexp*.c")
     remove_files("gettext-runtime/intl/gnulib-lib/getcwd-lgpl.c")
     remove_files("gettext-runtime/intl/gnulib-lib/getlocalename_l-unsafe.c")
@@ -361,6 +394,22 @@ extern wchar_t *wgetcwd (wchar_t *, size_t);
         io.gsub("gettext-runtime/intl/gnulib-lib/tsearch.h", "(definition of _GL_ARG_NONNULL.-)\n", "%1\n#include <arg-nonnull.h>\n")
         io.gsub("gettext-runtime/intl/gnulib-lib/tsearch.h", "(definition of _GL_WARN_ON_USE.-)\n", "%1\n#include <warn-on-use.h>\n")
         io.replace("gettext-runtime/intl/gnulib-lib/tsearch.c", "#include <search.h>", "#include <tsearch.h>", {plain = true})
+        -- For MinGW/macOS relating to uchar
+        if is_plat("mingw", "macosx") then
+            local uchar_src = path.join(os.projectdir(), "gettext-runtime/intl/gnulib-lib/uchar.in.h")
+            local uchar_dst = path.join(os.projectdir(), "gettext-runtime/intl/gnulib-lib/uchar.h")
+            local uchar = io.readfile(uchar_src)
+            uchar = uchar:gsub("@(.-)@", function(name)
+                local v = cvars[name]
+                if v == nil then return "0" end
+                return (type(v) == "number" and tostring(v)) or
+                       (type(v) == "boolean" and (v and "1" or "0")) or v
+            end)
+            io.writefile(uchar_dst, uchar)
+            io.gsub(uchar_dst, "(definitions of _GL_FUNCDECL_RPL etc.-)\n", "%1\n#include <c++defs.h>\n")
+            io.gsub(uchar_dst, "(definition of _GL_ARG_NONNULL.-)\n", "%1\n#include <arg-nonnull.h>\n")
+            io.gsub(uchar_dst, "(definition of _GL_WARN_ON_USE.-)\n", "%1\n#include <warn-on-use.h>\n")
+        end
         os.cp("gettext-runtime/intl/libgnuintl.h", "gettext-runtime/intl/libintl.h")
 
         local lines = io.readfile("gettext-runtime/intl/export.h")

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -174,9 +174,6 @@ set_configvar("SETLOCALE_NULL_ONE_MTSAFE", 1)
 configvar_check_cincludes("HAVE_SEARCH_H", "search.h")
 configvar_check_cincludes("HAVE_STDBOOL_H", "stdbool.h")
 configvar_check_cincludes("HAVE_UNISTD_H", "unistd.h")
-if is_plat("android") then
-    set_configvar("HAVE_MEMPCPY", 1)
-end
 
 -- search.h variables
 set_configvar("GUARD_PREFIX", "GL", {quote = false})
@@ -337,7 +334,9 @@ target("intl")
             content = content .. "\n\n#ifndef SETLOCALE_NULL_ALL_MAX\n#define SETLOCALE_NULL_ALL_MAX (148+12*256+1)\n#define SETLOCALE_NULL_MAX (256+1)\n#endif\n"
         end
         if not content:find("\\n#define locale_t", 1, true) then
-            content = content .. "\n#ifndef locale_t\n#define locale_t _locale_t\n#endif\n"
+            if is_plat("windows", "mingw") then
+                content = content .. "\n#ifndef locale_t\n#define locale_t _locale_t\n#endif\n"
+            end
         end
         if not content:find("\\nextern wchar_t", 1, true) and is_plat("mingw") then
             content = content .. [[

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -277,7 +277,6 @@ target("intl")
     remove_files("gettext-runtime/intl/gnulib-lib/c32*.c")
     remove_files("gettext-runtime/intl/gnulib-lib/frexp*.c")
     remove_files("gettext-runtime/intl/gnulib-lib/getcwd-lgpl.c")
-    remove_files("gettext-runtime/intl/gnulib-lib/getlocalename_l-unsafe.c")
     remove_files("gettext-runtime/intl/gnulib-lib/pthread-once.c")
     remove_files("gettext-runtime/intl/gnulib-lib/unistd.c")
     remove_files("gettext-runtime/intl/gnulib-lib/localeconv.c")
@@ -297,6 +296,9 @@ target("intl")
     remove_files("gettext-runtime/intl/gnulib-lib/mbchar.c")
     remove_files("gettext-runtime/intl/gnulib-lib/mbiterf.c")
     remove_files("gettext-runtime/intl/gnulib-lib/mbsnlen.c")
+    if not is_plat("macosx") then
+        remove_files("gettext-runtime/intl/gnulib-lib/getlocalename_l-unsafe.c")
+    end
     if not is_plat("windows", "mingw") then
         remove_files("gettext-runtime/intl/gnulib-lib/windows-*.c")
     end

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -355,9 +355,9 @@ target("intl")
             content = content .. "\n\n#ifndef SETLOCALE_NULL_ALL_MAX\n#define SETLOCALE_NULL_ALL_MAX (148+12*256+1)\n#define SETLOCALE_NULL_MAX (256+1)\n#endif\n"
         end
         if not content:find("\\n#define locale_t", 1, true) then
-            if package:is_plat("windows", "mingw") then
+            if is_plat("windows", "mingw") then
                 content = content .. "\n#ifndef locale_t\n#define locale_t _locale_t\n#endif\n"
-            elseif package:is_plat("macosx") then
+            elseif is_plat("macosx") then
                 content = content .. "\n#include <xlocale.h>\n"
             end
         end

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -254,6 +254,11 @@ target("intl")
     elseif is_plat("bsd") then
         add_syslinks("pthread")
     end
+
+    if is_plat("mingw") and is_kind("shared") then
+      add_ldflags("-Wl,--export-all-symbols")
+    end
+
     set_configvar("HAVE_ICONV", 0)
     set_configvar("HAVE_ICONV_H", 0)
     add_defines("DEPENDS_ON_LIBICONV=0")
@@ -348,6 +353,8 @@ target("intl")
         if not content:find("\\n#define locale_t", 1, true) then
             if is_plat("windows", "mingw") then
                 content = content .. "\n#ifndef locale_t\n#define locale_t _locale_t\n#endif\n"
+            elseif is_plat("macosx") then
+                content = content .. "\n#include <xlocale.h>\n"
             end
         end
         if not content:find("\\nextern wchar_t", 1, true) and is_plat("mingw") then

--- a/packages/l/libintl/port/1.0/xmake.lua
+++ b/packages/l/libintl/port/1.0/xmake.lua
@@ -174,6 +174,18 @@ set_configvar("SETLOCALE_NULL_ONE_MTSAFE", 1)
 configvar_check_cincludes("HAVE_SEARCH_H", "search.h")
 configvar_check_cincludes("HAVE_STDBOOL_H", "stdbool.h")
 configvar_check_cincludes("HAVE_UNISTD_H", "unistd.h")
+configvar_check_cincludes("HAVE_XLOCALE_H", "xlocale.h")
+
+if is_plat("macosx") then
+    set_configvar("HAVE_GOOD_USELOCALE", 1)
+end
+
+if is_plat("android") then
+    local ndk_sdkver = get_config("ndk_sdkver")
+    if ndk_sdkver and tonumber(ndk_sdkver) >= 23 then
+        set_configvar("HAVE_MEMPCPY", 1)
+    end
+end
 
 -- search.h variables
 set_configvar("GUARD_PREFIX", "GL", {quote = false})

--- a/packages/l/libintl/xmake.lua
+++ b/packages/l/libintl/xmake.lua
@@ -19,6 +19,10 @@ package("libintl")
         add_syslinks("pthread")
     end
 
+    if is_plat("mingw") and is_kind("shared") then
+        add_ldflags("-Wl,--export-all-symbols")
+    end
+
     on_fetch(function (package, opt)
         if opt.system then
             return package:find_package("system::intl", {includes = "libintl.h"})

--- a/packages/l/libintl/xmake.lua
+++ b/packages/l/libintl/xmake.lua
@@ -7,6 +7,7 @@ package("libintl")
              "https://ftp.gnu.org/gnu/gettext/gettext-$(version).tar.xz")
     add_versions("0.21", "d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192")
     add_versions("0.22.3", "b838228b3f8823a6c1eddf07297197c4db13f7e1b173b9ef93f3f945a63080b6")
+    add_versions("1.0", "71132a3fb71e68245b8f2ac4e9e97137d3e5c02f415636eb508ae607bc01add7")
 
     if is_plat("mingw") then
         add_patches("0.22.3", "patches/0.22.3/fix-mingw-build-wgetcwd.diff", "4db86b836cf332151558d5cd4553ed2e8a6dc88676b5d66dda486f55dcd6785c")

--- a/packages/l/libintl/xmake.lua
+++ b/packages/l/libintl/xmake.lua
@@ -32,16 +32,15 @@ package("libintl")
             io.replace(conffile, "$", "", {plain = true})
             io.replace(conffile, "# ?undef (.-)\n", "${define %1}\n")
         end
-        local opt = {}
-        if package:is_plat("mingw") and package:config("shared") then
-            opt.shflags = "-Wl,--export-all-symbols"
-        end
-        import("package.tools.xmake").install(package, {
-            opt,
+        local opt = {
             vers = package:version_str(),
             relocatable = true,
             installprefix = package:installdir():gsub("\\", "/")
-        })
+        }
+        if package:is_plat("mingw") and package:config("shared") then
+            opt.shflags = "-Wl,--export-all-symbols"
+        end
+        import("package.tools.xmake").install(package, opt)
     end)
 
     on_test(function (package)

--- a/packages/l/libintl/xmake.lua
+++ b/packages/l/libintl/xmake.lua
@@ -19,10 +19,6 @@ package("libintl")
         add_syslinks("pthread")
     end
 
-    if is_plat("mingw") and is_kind("shared") then
-        add_ldflags("-Wl,--export-all-symbols")
-    end
-
     on_fetch(function (package, opt)
         if opt.system then
             return package:find_package("system::intl", {includes = "libintl.h"})
@@ -36,7 +32,12 @@ package("libintl")
             io.replace(conffile, "$", "", {plain = true})
             io.replace(conffile, "# ?undef (.-)\n", "${define %1}\n")
         end
+        local opt = {}
+        if package:is_plat("mingw") and package:config("shared") then
+            opt.shflags = "-Wl,--export-all-symbols"
+        end
         import("package.tools.xmake").install(package, {
+            opt,
             vers = package:version_str(),
             relocatable = true,
             installprefix = package:installdir():gsub("\\", "/")

--- a/packages/l/liblo/xmake.lua
+++ b/packages/l/liblo/xmake.lua
@@ -45,6 +45,8 @@ package("liblo")
         set_target_properties(${LIBRARY_SHARED} PROPERTIES EXCLUDE_FROM_ALL 1)
     endif()]], {plain = true})
         import("package.tools.cmake").install(package, configs)
+        local pc = package:installdir("lib/pkgconfig/liblo.pc")
+        io.replace(pc, "-llo", "-lliblo", {plain = true})
     end)
 
     on_test(function (package)

--- a/packages/l/liblo/xmake.lua
+++ b/packages/l/liblo/xmake.lua
@@ -46,7 +46,9 @@ package("liblo")
     endif()]], {plain = true})
         import("package.tools.cmake").install(package, configs)
         local pc = package:installdir("lib/pkgconfig/liblo.pc")
-        io.replace(pc, "-llo", "-lliblo", {plain = true})
+        if package:is_plat("windows") then
+            io.replace(pc, "-llo", "-lliblo", {plain = true})
+        end
     end)
 
     on_test(function (package)

--- a/packages/p/pthreads4w/xmake.lua
+++ b/packages/p/pthreads4w/xmake.lua
@@ -9,8 +9,6 @@ package("pthreads4w")
 
     add_versions("3.0.0", "31f20963840c26d78fb20224577b7e677018b3eb3000c3570db88528043adc20")
 
-    add_includedirs("include/pthread")
-
     if is_host("linux", "macosx") and is_plat("mingw") then
         add_deps("autoconf", "automake")
     end

--- a/packages/p/pthreads4w/xmake.lua
+++ b/packages/p/pthreads4w/xmake.lua
@@ -56,6 +56,17 @@ package("pthreads4w")
             target = target .. "-debug"
         end
         os.vrunv("make", {"V=1", target})
+
+        os.cp("_ptw32.h", package:installdir("include"))
+        os.cp("pthread.h", package:installdir("include"))
+        os.cp("sched.h", package:installdir("include"))
+        os.cp("semaphore.h", package:installdir("include"))
+        os.cp("*.a", package:installdir("lib"))
+        if package:config("shared") then
+            os.cp("*.dll", package:installdir("bin"))
+            os.cp("*.dll.a", package:installdir("lib"))
+            package:addenv("PATH", "bin")
+        end
     end)
 
     on_test(function (package)

--- a/packages/p/pthreads4w/xmake.lua
+++ b/packages/p/pthreads4w/xmake.lua
@@ -61,11 +61,12 @@ package("pthreads4w")
         os.cp("pthread.h", package:installdir("include"))
         os.cp("sched.h", package:installdir("include"))
         os.cp("semaphore.h", package:installdir("include"))
-        os.cp("*.a", package:installdir("lib"))
         if package:config("shared") then
             os.cp("*.dll", package:installdir("bin"))
             os.cp("*.dll.a", package:installdir("lib"))
             package:addenv("PATH", "bin")
+        else
+            os.cp("*.a", package:installdir("lib"))
         end
     end)
 

--- a/packages/p/pthreads4w/xmake.lua
+++ b/packages/p/pthreads4w/xmake.lua
@@ -25,7 +25,10 @@ package("pthreads4w")
         end
         import("package.tools.nmake").build(package, {"-f", "Makefile", target})
         os.cp("*.lib", package:installdir("lib"))
-        os.cp("*.h", package:installdir("include/pthread"))
+        os.cp("_ptw32.h", package:installdir("include"))
+        os.cp("pthread.h", package:installdir("include"))
+        os.cp("sched.h", package:installdir("include"))
+        os.cp("semaphore.h", package:installdir("include"))
         if package:config("shared") then
             os.cp("*.dll", package:installdir("bin"))
             package:addenv("PATH", "bin")


### PR DESCRIPTION
Closes #10441 , #10373 , #10342 .
All tested locally (Windows/MSVC) except for pthreads4w, whose changes didn't seem to need local testing.

In case the switch for glib from Requires.private to Requires seems random, it mirrors vcpkg's Libs in the sense that it's not added to private.