### PR TITLE
Auto-update cpp-httplib to v0.50.1

### DIFF
--- a/packages/c/cpp-httplib/xmake.lua
+++ b/packages/c/cpp-httplib/xmake.lua
@@ -7,6 +7,7 @@ package("cpp-httplib")
     set_urls("https://github.com/yhirose/cpp-httplib/archive/refs/tags/$(version).tar.gz",
              "https://github.com/yhirose/cpp-httplib.git")
 
+    add_versions("v0.50.1", "3c23acaf0e37bf63cf1b747813b358063e2e40590a7f6418955031fe5eb173c0")
     add_versions("v0.48.0", "d9ed142d319c6e19a961f477257e67f846909ce15288502188df2281941be84e")
     add_versions("v0.47.0", "f6676dd6539c1d05978aa8ecfae86d71e73c46f48c7766a04b991aa545c2f065")
     add_versions("v0.45.0", "03121ca28d210ac8014021c2f2deda4a181f215b1638c493c40a4c7e6056495f")


### PR DESCRIPTION
New version of cpp-httplib detected (package version: v0.48.0, last github version: v0.50.1)