### PR TITLE
Auto-update aws-c-common to v0.14.2

### DIFF
--- a/packages/a/aws-c-common/xmake.lua
+++ b/packages/a/aws-c-common/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-common")
     add_urls("https://github.com/awslabs/aws-c-common/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-common.git")
 
+    add_versions("v0.14.2", "da518accb60eb08e0d56f641f00c3ea856c36a0972394770c978e5ff3bfc3728")
     add_versions("v0.14.1", "85a05209b324ca330085b84fdada4faf6820592c34f252f0ceb61001f76bf04d")
     add_versions("v0.14.0", "3684076ec5da899074336722ba58a01f7166a1a2e5ad72f846f6fd468ecdf2ec")
     add_versions("v0.13.1", "a85bfd3a9939cc9a18dcd0cbd34c66ffbefec9b908c4b4dad2217b17e21b26ff")


### PR DESCRIPTION
New version of aws-c-common detected (package version: v0.14.1, last github version: v0.14.2)