### PR TITLE
fix(boost): avoid replacing gcc- in path components

### DIFF
--- a/packages/b/boost/b2/install.lua
+++ b/packages/b/boost/b2/install.lua
@@ -28,10 +28,17 @@ function _get_compiler(package, toolchain)
         -- from the latest installed msvc version.
         return format("using %s : %s : \"%s\" ;", win_toolset, msvc_ver, cxx:gsub("\\", "\\\\"))
     else
-        cxx = cxx:gsub("gcc$", "g++")
-        cxx = cxx:gsub("gcc%-", "g++-")
-        cxx = cxx:gsub("clang$", "clang++")
-        cxx = cxx:gsub("clang%-", "clang++-")
+        local basename = path.filename(cxx)
+        local dirname = path.directory(cxx)
+        basename = basename:gsub("gcc$", "g++")
+        basename = basename:gsub("gcc%-", "g++-")
+        basename = basename:gsub("clang$", "clang++")
+        basename = basename:gsub("clang%-", "clang++-")
+        if dirname == "." or #dirname == 0 then
+            cxx = basename
+        else
+            cxx = path.join(dirname, basename)
+        end
         if cxx and cxx:find("clang", 1, true) then
             return format("using clang : : \"%s\" ;", cxx:gsub("\\", "/"))
         else


### PR DESCRIPTION
On NixOS, the compiler path contains "gcc-wrapper" in the nix store path, e.g. /nix/store/xxx-gcc-wrapper-16.1.0/bin/g++

The original gsub("gcc%-", "g++-") would corrupt the path component to "g++-wrapper" which doesn't exist.

Fix by only applying the replacement in the filename portion, not in the directory path components.

