### PR TITLE
Auto-update aws-crt-cpp to v0.42.1

### DIFF
--- a/packages/a/aws-crt-cpp/xmake.lua
+++ b/packages/a/aws-crt-cpp/xmake.lua
@@ -6,6 +6,7 @@ package("aws-crt-cpp")
     add_urls("https://github.com/awslabs/aws-crt-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-crt-cpp.git")
 
+    add_versions("v0.42.1", "bf24fdba415842654f26d36978061812e38d3485e8505d2fabf0a548fcf735c4")
     add_versions("v0.40.1", "697a8fb25167e12e704827e360b4f6b1af8ded48e11ef4d185b9cd72e17479c9")
     add_versions("v0.40.0", "bc81a9e97d004b354fcff5085567254ca837c2566973dfbaff67419ab6e2a57b")
     add_versions("v0.39.1", "e8f2a47737915ec36aaab68ec7bdf783f7a903f68322d3c0888d30951483b948")


### PR DESCRIPTION
New version of aws-crt-cpp detected (package version: v0.40.1, last github version: v0.42.1)