### PR TITLE
Auto-update libselinux to 3.11

### DIFF
--- a/packages/l/libselinux/xmake.lua
+++ b/packages/l/libselinux/xmake.lua
@@ -3,6 +3,7 @@ package("libselinux")
     set_description("SELinux library and simple utilities.")
 
     add_urls("https://github.com/SELinuxProject/selinux/releases/download/$(version)/libselinux-$(version).tar.gz")
+    add_versions("3.11", "73d419c6e20e874adaa4019372cbd097eecf4d276e13f27ec5e67d35c0bd203c")
     add_versions("3.10", "1ef216c5b56fb7e0a51cd2909787a175a17ee391e0467894807873539ebe766b")
     add_versions("3.9", "e7ee2c01dba64a0c35c9d7c9c0e06209d8186b325b0638a0d83f915cc3c101e8")
 


### PR DESCRIPTION
New version of libselinux detected (package version: 3.10, last github version: 3.11)