### PR TITLE
glibmm: cap glib dependency version to <2.89.2

### DIFF
--- a/packages/g/glibmm/xmake.lua
+++ b/packages/g/glibmm/xmake.lua
@@ -25,11 +25,11 @@ package("glibmm")
 
         if package:version():lt("2.68") then
             package:add("deps", "libsigcplusplus <3.0.0")
-            package:add("deps", "glib >=2.61.2")
+            package:add("deps", "glib >=2.61.2 <2.89.2")
             package:add("languages", "c++11")
         else
             package:add("deps", "libsigcplusplus >=3.0.0")
-            package:add("deps", "glib >=2.87.3")
+            package:add("deps", "glib >=2.87.3 <2.89.2")
             package:add("languages", "c++17")
         end
 


### PR DESCRIPTION
#10470 .