### PR TITLE
Add package randx 1.4.2

### DIFF
--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -1,0 +1,39 @@
+package("randx")
+    set_homepage("https://github.com/lidaixingchen/RandX")
+    set_description("Modern, fast, and header-only C++ pseudo-random number generator and distribution library (C++17/C++23).")
+    set_license("MIT")
+
+    add_urls("https://github.com/lidaixingchen/RandX/archive/refs/tags/v$(version).tar.gz")
+
+    add_versions("1.3.1", "f271bbcb26bea7747ee292646df895c2305b696bb0d58d69b54e84fe96fab3c1")
+
+    on_load(function (package)
+        package:set("kind", "library", {headeronly = true})
+
+        -- 跨平台 OS 熵源链接（ChaCha20 CSPRNG 需要）
+        -- Windows: BCryptGenRandom → bcrypt
+        -- macOS:   SecRandomCopyBytes → Security framework
+        -- Linux:   getrandom → libc 内置，无需额外链接
+        if package:is_plat("windows", "mingw") then
+            package:add("syslinks", "bcrypt")
+        elseif package:is_plat("macosx") then
+            package:add("syslinks", "Security")
+        end
+    end)
+
+    on_install(function (package)
+        -- 仅安装两个头文件到 include/
+        os.cp("RandX.hpp", package:installdir("include"))
+        os.cp("RandX_Cpp17.hpp", package:installdir("include"))
+    end)
+
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            #include <RandX.hpp>
+            #include <cstdint>
+            static void test() {
+                std::uint64_t v = RandX::RandInt<std::uint64_t>(0, 1000);
+                (void)v;
+            }
+        ]]}, {configs = {languages = "c++23"}}))
+    end)

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -5,6 +5,7 @@ package("randx")
 
     add_urls("https://github.com/lidaixingchen/RandX/archive/refs/tags/v$(version).tar.gz")
 
+    add_versions("1.4.0", "ecf611c6f340986df2abf3191def2222a3287f5e20ec4280c88996770a95eec7")
     add_versions("1.3.1", "f271bbcb26bea7747ee292646df895c2305b696bb0d58d69b54e84fe96fab3c1")
 
     on_load(function (package)

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -6,6 +6,7 @@ package("randx")
 
     add_urls("https://github.com/lidaixingchen/RandX/archive/refs/tags/v$(version).tar.gz")
 
+    add_versions("1.4.2", "dc816718ab8a42e3fa34a6e56444f580a1539b9b21b462713e434a0f88d16b5b")
     add_versions("1.4.0", "ecf611c6f340986df2abf3191def2222a3287f5e20ec4280c88996770a95eec7")
     add_versions("1.3.1", "f271bbcb26bea7747ee292646df895c2305b696bb0d58d69b54e84fe96fab3c1")
 

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -8,7 +8,6 @@ package("randx")
 
     add_versions("1.4.2", "25badb73e98b2e83456bea63bb60b1f335091576ec1d1c06ec2649ed92fc84bf")
     add_versions("1.4.0", "ecf611c6f340986df2abf3191def2222a3287f5e20ec4280c88996770a95eec7")
-    add_versions("1.3.1", "f271bbcb26bea7747ee292646df895c2305b696bb0d58d69b54e84fe96fab3c1")
 
     if is_plat("windows", "mingw") then
         add_syslinks("bcrypt")
@@ -19,6 +18,12 @@ package("randx")
     on_install(function (package)
         os.cp("RandX.hpp", package:installdir("include"))
         os.cp("RandX_Cpp17.hpp", package:installdir("include"))
+        -- Header-only: create empty archive so -lrandx resolves in find_package checks
+        if not package:is_plat("windows") then
+            local libfile = package:installdir("lib", "librandx.a")
+            os.mkdir(path.directory(libfile))
+            io.writefile(libfile, "!<arch>\n")
+        end
     end)
 
     on_test(function (package)

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -1,29 +1,21 @@
 package("randx")
+    set_kind("library", {headeronly = true})
     set_homepage("https://github.com/lidaixingchen/RandX")
-    set_description("Modern, fast, and header-only C++ pseudo-random number generator and distribution library (C++17/C++23).")
+    set_description("Modern, fast, with header-only C++ pseudo-random number generator and distribution library (C++17/C++23).")
     set_license("MIT")
 
     add_urls("https://github.com/lidaixingchen/RandX/archive/refs/tags/v$(version).tar.gz")
 
-    add_versions("1.4.0", "ecf611c6f340986df2abf3191def2222a3287f5e20ec4280c88996770a95eec7")
-    add_versions("1.3.1", "f271bbcb26bea7747ee292646df895c2305b696bb0d58d69b54e84fe96fab3c1")
+    add_versions("1.4.0", "ecf611c6f340986df2abf319adef2222a3287f5e20ec4280c88996770a95eec7")
+    add_versions("1.3.1", "f271bbcb26bea7747ee292646df89b696b0d5869b54e84fe96fab3c1")
 
-    on_load(function (package)
-        package:set("kind", "library", {headeronly = true})
-
-        -- 跨平台 OS 熵源链接（ChaCha20 CSPRNG 需要）
-        -- Windows: BCryptGenRandom → bcrypt
-        -- macOS:   SecRandomCopyBytes → Security framework
-        -- Linux:   getrandom → libc 内置，无需额外链接
-        if package:is_plat("windows", "mingw") then
-            package:add("syslinks", "bcrypt")
-        elseif package:is_plat("macosx") then
-            package:add("syslinks", "Security")
-        end
-    end)
+    if is_plat("windows", "mingw") then
+        add_syslinks("bcrypt")
+    elseif is_plat("macosx") then
+        add_syslinks("Security")
+    end
 
     on_install(function (package)
-        -- 仅安装两个头文件到 include/
         os.cp("RandX.hpp", package:installdir("include"))
         os.cp("RandX_Cpp17.hpp", package:installdir("include"))
     end)
@@ -36,5 +28,5 @@ package("randx")
                 std::uint64_t v = RandX::RandInt<std::uint64_t>(0, 1000);
                 (void)v;
             }
-        ]]}, {configs = {languages = "c++23"}}))
+         ]]}, {configs = {languages = "c++23"}}))
     end)

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -17,7 +17,7 @@ package("randx")
     end
 
     on_install(function (package)
-        io.replace("RandX_Cpp17.hpp", [[#	elif defined(__linux__) && __has_include(<sys/random.h>)]], [[#	elif defined(__linux__) && __has_include(<sys/random.h>)
+        io.replace("", [[# pragma once]], [[# pragma once
 #if defined(__ANDROID__) && __ANDROID_API__ < 28
 #  include <unistd.h>
 #  include <sys/syscall.h>

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -6,7 +6,7 @@ package("randx")
 
     add_urls("https://github.com/lidaixingchen/RandX/archive/refs/tags/v$(version).tar.gz")
 
-    add_versions("1.4.2", "dc816718ab8a42e3fa34a6e56444f580a1539b9b21b462713e434a0f88d16b5b")
+    add_versions("1.4.2", "25badb73e98b2e83456bea63bb60b1f335091576ec1d1c06ec2649ed92fc84bf")
     add_versions("1.4.0", "ecf611c6f340986df2abf3191def2222a3287f5e20ec4280c88996770a95eec7")
     add_versions("1.3.1", "f271bbcb26bea7747ee292646df895c2305b696bb0d58d69b54e84fe96fab3c1")
 

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -17,7 +17,7 @@ package("randx")
     end
 
     on_install(function (package)
-        io.replace("", [[# pragma once]], [[# pragma once
+        io.replace("RandX_Cpp17.hpp", [[# pragma once]], [[# pragma once
 #if defined(__ANDROID__) && __ANDROID_API__ < 28
 #  include <unistd.h>
 #  include <sys/syscall.h>

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -9,7 +9,6 @@ package("randx")
     add_versions("1.4.3", "2227db348490f72e0aa8aaff923b24b773dec268656ef60bec3fe997e2fbac61")
     add_versions("1.4.2", "25badb73e98b2e83456bea63bb60b1f335091576ec1d1c06ec2649ed92fc84bf")
     add_versions("1.4.0", "ecf611c6f340986df2abf3191def2222a3287f5e20ec4280c88996770a95eec7")
-    add_versions("1.3.1", "f271bbcb26bea7747ee292646df895c2305b696bb0d58d69b54e84fe96fab3c1")
 
     if is_plat("windows", "mingw") then
         add_syslinks("bcrypt")

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -17,6 +17,11 @@ package("randx")
     end
 
     on_install(function (package)
+        io.replace("RandX_Cpp17.hpp", [[#	elif defined(__linux__) && __has_include(<sys/random.h>)]], [[#	elif defined(__linux__) && __has_include(<sys/random.h>)
+#if defined(__ANDROID__) && __ANDROID_API__ < 28
+#  include <syscall.h>
+#  define getrandom(buf, buflen, flags) syscall(SYS_getrandom, buf, buflen, flags)
+#endif]], {plain = true})
         os.cp("RandX.hpp", package:installdir("include"))
         os.cp("RandX_Cpp17.hpp", package:installdir("include"))
     end)

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -1,18 +1,18 @@
 package("randx")
     set_kind("library", {headeronly = true})
     set_homepage("https://github.com/lidaixingchen/RandX")
-    set_description("Modern, fast, with header-only C++ pseudo-random number generator and distribution library (C++17/C++23).")
+    set_description("Modern, fast, and header-only C++ pseudo-random number generator and distribution library (C++17/C++23).")
     set_license("MIT")
 
     add_urls("https://github.com/lidaixingchen/RandX/archive/refs/tags/v$(version).tar.gz")
 
-    add_versions("1.4.0", "ecf611c6f340986df2abf319adef2222a3287f5e20ec4280c88996770a95eec7")
-    add_versions("1.3.1", "f271bbcb26bea7747ee292646df89b696b0d5869b54e84fe96fab3c1")
+    add_versions("1.4.0", "ecf611c6f340986df2abf3191def2222a3287f5e20ec4280c88996770a95eec7")
+    add_versions("1.3.1", "f271bbcb26bea7747ee292646df895c2305b696bb0d58d69b54e84fe96fab3c1")
 
     if is_plat("windows", "mingw") then
         add_syslinks("bcrypt")
     elseif is_plat("macosx") then
-        add_syslinks("Security")
+        add_frameworks("Security")
     end
 
     on_install(function (package)
@@ -22,11 +22,11 @@ package("randx")
 
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
-            #include <RandX.hpp>
+            #include <RandX_Cpp17.hpp>
             #include <cstdint>
             static void test() {
                 std::uint64_t v = RandX::RandInt<std::uint64_t>(0, 1000);
                 (void)v;
             }
-         ]]}, {configs = {languages = "c++23"}}))
+        ]]}, {configs = {languages = "c++17"}}))
     end)

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -19,7 +19,8 @@ package("randx")
     on_install(function (package)
         io.replace("RandX_Cpp17.hpp", [[#	elif defined(__linux__) && __has_include(<sys/random.h>)]], [[#	elif defined(__linux__) && __has_include(<sys/random.h>)
 #if defined(__ANDROID__) && __ANDROID_API__ < 28
-#  include <syscall.h>
+#  include <unistd.h>
+#  include <sys/syscall.h>
 #  define getrandom(buf, buflen, flags) syscall(SYS_getrandom, buf, buflen, flags)
 #endif]], {plain = true})
         os.cp("RandX.hpp", package:installdir("include"))

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -9,7 +9,7 @@ package("randx")
     add_versions("1.4.3", "2227db348490f72e0aa8aaff923b24b773dec268656ef60bec3fe997e2fbac61")
     add_versions("1.4.2", "25badb73e98b2e83456bea63bb60b1f335091576ec1d1c06ec2649ed92fc84bf")
     add_versions("1.4.0", "ecf611c6f340986df2abf3191def2222a3287f5e20ec4280c88996770a95eec7")
-    add_versions("1.3.1", "f271bbcb26bea7747ee292646df8966b0d5869b54e84fe96fab3c1")
+    add_versions("1.3.1", "f271bbcb26bea7747ee292646df895c2305b696bb0d58d69b54e84fe96fab3c1")
 
     if is_plat("windows", "mingw") then
         add_syslinks("bcrypt")

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -1,13 +1,15 @@
 package("randx")
     set_kind("library", {headeronly = true})
     set_homepage("https://github.com/lidaixingchen/RandX")
-    set_description("Modern, fast, and header-only C++ pseudo-random number generator and distribution library (C++17/C++23).")
+    set_description("Modern, fast, with header-only C++ pseudo-random number generator and distribution library (C++17/C++23).")
     set_license("MIT")
 
     add_urls("https://github.com/lidaixingchen/RandX/archive/refs/tags/v$(version).tar.gz")
 
+    add_versions("1.4.3", "2227db348490f72e0aa8aaff923b24b773dec268656ef60bec3fe997e2fbac61")
     add_versions("1.4.2", "25badb73e98b2e83456bea63bb60b1f335091576ec1d1c06ec2649ed92fc84bf")
     add_versions("1.4.0", "ecf611c6f340986df2abf3191def2222a3287f5e20ec4280c88996770a95eec7")
+    add_versions("1.3.1", "f271bbcb26bea7747ee292646df8966b0d5869b54e84fe96fab3c1")
 
     if is_plat("windows", "mingw") then
         add_syslinks("bcrypt")
@@ -18,21 +20,15 @@ package("randx")
     on_install(function (package)
         os.cp("RandX.hpp", package:installdir("include"))
         os.cp("RandX_Cpp17.hpp", package:installdir("include"))
-        -- Header-only: create empty archive so -lrandx resolves in find_package checks
-        if not package:is_plat("windows") then
-            local libfile = package:installdir("lib", "librandx.a")
-            os.mkdir(path.directory(libfile))
-            io.writefile(libfile, "!<arch>\n")
-        end
     end)
 
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
-            #include <RandX_Cpp17.hpp>
+            #include <RandX.hpp>
             #include <cstdint>
             static void test() {
                 std::uint64_t v = RandX::RandInt<std::uint64_t>(0, 1000);
                 (void)v;
             }
-        ]]}, {configs = {languages = "c++17"}}))
+        ]]}, {configs = {languages = "c++23"}}i)'
     end)

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -13,7 +13,7 @@ package("randx")
 
     if is_plat("windows", "mingw") then
         add_syslinks("bcrypt")
-    elseif is_plat("macosx") then
+    elseif is_plat("macosx", "iphoneos") then
         add_frameworks("Security")
     end
 
@@ -30,5 +30,5 @@ package("randx")
                 std::uint64_t v = RandX::RandInt<std::uint64_t>(0, 1000);
                 (void)v;
             }
-        ]]}, {configs = {languages = "c++23"}}i)'
+        ]]}, {configs = {languages = "c++23"}}))
     end)

--- a/packages/r/randx/xmake.lua
+++ b/packages/r/randx/xmake.lua
@@ -23,11 +23,11 @@ package("randx")
 
     on_test(function (package)
         assert(package:check_cxxsnippets({test = [[
-            #include <RandX.hpp>
+            #include <RandX_Cpp17.hpp>
             #include <cstdint>
             static void test() {
                 std::uint64_t v = RandX::RandInt<std::uint64_t>(0, 1000);
                 (void)v;
             }
-        ]]}, {configs = {languages = "c++23"}}))
+        ]]}, {configs = {languages = "c++17"}}))
     end)


### PR DESCRIPTION
## Summary
- Add new header-only C++ pseudo-random number generator library **RandX** (v1.3.1)
- Based on xoshiro/xoroshiro algorithm family, supports C++17 and C++23
- Cross-platform OS entropy linking (Windows bcrypt / macOS Security)

## Test
- [x] Local install verified: `xrepo install -y randx`
- [x] `on_test` C++23 compilation check passed
- [x] SHA256 matches GitHub archive tarball for tag v1.3.1