### PR TITLE
Auto-update octree to v3.2.4

### DIFF
--- a/packages/o/octree/patches/v3.2.4/fix-cereal-bridge.patch
+++ b/packages/o/octree/patches/v3.2.4/fix-cereal-bridge.patch
@@ -1,0 +1,14 @@
+diff --git a/include/orthotree/serialization/nvp.h b/include/orthotree/serialization/nvp.h
+index 24c392d..35bcb47 100644
+--- a/include/orthotree/serialization/nvp.h
++++ b/include/orthotree/serialization/nvp.h
+@@ -214,7 +214,8 @@ namespace OrthoTree
+   {
+     if constexpr (detail::is_cereal_archive_v<TArchive>)
+     {
+-      std::size_t cerealSize = static_cast<std::size_t>(tag.value);
++      using CerealSize = std::conditional_t<detail::is_cereal_archive_v<TArchive>, std::size_t, T>;
++      CerealSize cerealSize = static_cast<CerealSize>(tag.value);
+       ar(::cereal::make_size_tag(cerealSize));
+       tag.value = static_cast<T>(cerealSize);
+     }

--- a/packages/o/octree/xmake.lua
+++ b/packages/o/octree/xmake.lua
@@ -10,6 +10,8 @@ package("octree")
     add_versions("v3.2.4", "eaec0b3c1f95e6aff2cb74635c59e676f6201678d9345477e79b23e375ed7b77")
     add_versions("v2.5", "86088cd000254aeddf4f9d75c0600b7f799e062340394124d69760829ed317fe")
 
+    add_patches(">=3.2.4", "patches/v3.2.4/fix-cereal-bridge.patch", "b320138eddba9cd598c38187409a9470f693f5b1b6a863222079f6239a0de233")
+
     on_check(function (package)
         if not package:is_arch("x64", "x86", "x86_64") then
             raise("package(octree) only support x86 arch")
@@ -27,15 +29,25 @@ package("octree")
     end)
 
     on_install(function (package)
-        os.cp("*.h", package:installdir("include"))
+        if package:version():ge("3.0.0") then
+            os.cp("include/orthotree", package:installdir("include"))
+        else
+            os.cp("*.h", package:installdir("include"))
+        end
     end)
 
     on_test(function (package)
-        assert(package:check_cxxsnippets({test = [[
+        local include = "octree.h"
+        local octree_type = "OctreePointC"
+        if package:version():ge("3.0.0") then
+            include = "orthotree/octree.h"
+            octree_type = "OctreePointM"
+        end
+        assert(package:check_cxxsnippets({test = ([[
             using namespace OrthoTree;
             void test() {
                 auto constexpr points = std::array{ Point3D{0,0,0}, Point3D{1,1,1}, Point3D{2,2,2} };
-                auto const octree = OctreePointC(points, 3 /*max depth*/);
+                auto const octree = %s(points, 3 /*max depth*/);
 
                 auto const searchBox = BoundingBox3D{ {0.5, 0.5, 0.5}, {2.5, 2.5, 2.5} };
                 auto const pointIDs = octree.RangeSearch(searchBox); //: { 1, 2 }
@@ -45,5 +57,5 @@ package("octree")
                     , neighborNo
                 ); //: { 1, 2 }
             }
-        ]]}, {configs = {languages = "c++20"}, includes = "octree.h"}))
+        ]]):format(octree_type)}, {configs = {languages = "c++20"}, includes = include}))
     end)

--- a/packages/o/octree/xmake.lua
+++ b/packages/o/octree/xmake.lua
@@ -7,6 +7,7 @@ package("octree")
     set_urls("https://github.com/attcs/Octree/archive/refs/tags/$(version).tar.gz",
              "https://github.com/attcs/Octree.git", {submodules = false})
 
+    add_versions("v3.2.4", "eaec0b3c1f95e6aff2cb74635c59e676f6201678d9345477e79b23e375ed7b77")
     add_versions("v2.5", "86088cd000254aeddf4f9d75c0600b7f799e062340394124d69760829ed317fe")
 
     on_check(function (package)


### PR DESCRIPTION
New version of octree detected (package version: v2.5, last github version: v3.2.4)