### PR TITLE
kcp: update to 2.1.1

### DIFF
--- a/packages/k/kcp/xmake.lua
+++ b/packages/k/kcp/xmake.lua
@@ -1,52 +1,42 @@
 package("kcp")
-
     set_homepage("https://github.com/skywind3000/kcp")
     set_description("A Fast and Reliable ARQ Protocol.")
     set_license("MIT")
 
-    add_urls("https://github.com/skywind3000/kcp/archive/$(version).tar.gz",
+    add_urls("https://github.com/skywind3000/kcp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/skywind3000/kcp.git")
-    add_versions("1.7", "b4d26994d95599ab0c44e1f93002f9fda275094a879d66c192d79d596529199e")
 
+    add_versions("2.1.1", "54d3c80928d206529f67cba6f96f2c98007182b46e3112819b200d914f96e425")
+    add_versions("1.7", "b4d26994d95599ab0c44e1f93002f9fda275094a879d66c192d79d596529199e")
 
     on_install(function (package)
         io.writefile("xmake.lua", [[
             add_rules("mode.debug", "mode.release")
             target("kcp")
                 set_kind("$(kind)")
-                if is_kind("shared") and is_plat("windows") then
-                    local funcs = {"ikcp_allocator",
-                                   "ikcp_check",
-                                   "ikcp_create",
-                                   "ikcp_flush",
-                                   "ikcp_getconv",
-                                   "ikcp_input",
-                                   "ikcp_interval",
-                                   "ikcp_log",
-                                   "ikcp_nodelay",
-                                   "ikcp_parse_data",
-                                   "ikcp_peeksize",
-                                   "ikcp_qprint",
-                                   "ikcp_recv",
-                                   "ikcp_release",
-                                   "ikcp_send",
-                                   "ikcp_setmtu",
-                                   "ikcp_setoutput",
-                                   "ikcp_update",
-                                   "ikcp_waitsnd",
-                                   "ikcp_wndsize"}
-                    for _, func in ipairs(funcs) do
-                        add_shflags("/export:" .. func)
-                    end
-                end
+                add_rules("utils.symbols.export_list", {symbols = {
+                    "ikcp_create",
+                    "ikcp_release",
+                    "ikcp_setoutput",
+                    "ikcp_recv",
+                    "ikcp_send",
+                    "ikcp_update",
+                    "ikcp_check",
+                    "ikcp_input",
+                    "ikcp_flush",
+                    "ikcp_peeksize",
+                    "ikcp_setmtu",
+                    "ikcp_wndsize",
+                    "ikcp_waitsnd",
+                    "ikcp_nodelay",
+                    "ikcp_log",
+                    "ikcp_allocator",
+                    "ikcp_getconv"
+                }})
                 add_files("ikcp.c")
                 add_headerfiles("ikcp.h")
         ]])
-        local configs = {}
-        if package:config("shared") then
-            configs.kind = "shared"
-        end
-        import("package.tools.xmake").install(package, configs)
+        import("package.tools.xmake").install(package)
     end)
 
     on_test(function (package)

--- a/packages/k/kcp/xmake.lua
+++ b/packages/k/kcp/xmake.lua
@@ -14,25 +14,27 @@ package("kcp")
             add_rules("mode.debug", "mode.release")
             target("kcp")
                 set_kind("$(kind)")
-                add_rules("utils.symbols.export_list", {symbols = {
-                    "ikcp_create",
-                    "ikcp_release",
-                    "ikcp_setoutput",
-                    "ikcp_recv",
-                    "ikcp_send",
-                    "ikcp_update",
-                    "ikcp_check",
-                    "ikcp_input",
-                    "ikcp_flush",
-                    "ikcp_peeksize",
-                    "ikcp_setmtu",
-                    "ikcp_wndsize",
-                    "ikcp_waitsnd",
-                    "ikcp_nodelay",
-                    "ikcp_log",
-                    "ikcp_allocator",
-                    "ikcp_getconv"
-                }})
+                if is_plat("windows", "mingw") and is_kind("shared") then
+                    add_rules("utils.symbols.export_list", {symbols = {
+                        "ikcp_create",
+                        "ikcp_release",
+                        "ikcp_setoutput",
+                        "ikcp_recv",
+                        "ikcp_send",
+                        "ikcp_update",
+                        "ikcp_check",
+                        "ikcp_input",
+                        "ikcp_flush",
+                        "ikcp_peeksize",
+                        "ikcp_setmtu",
+                        "ikcp_wndsize",
+                        "ikcp_waitsnd",
+                        "ikcp_nodelay",
+                        "ikcp_log",
+                        "ikcp_allocator",
+                        "ikcp_getconv"
+                    }})
+                end
                 add_files("ikcp.c")
                 add_headerfiles("ikcp.h")
         ]])


### PR DESCRIPTION
At 1.7 there was not defined export surface, that's why all symbols were exported.