### PR TITLE
Auto-update asbind20 to 2.0.1

### DIFF
--- a/packages/a/asbind20/xmake.lua
+++ b/packages/a/asbind20/xmake.lua
@@ -6,6 +6,7 @@ package("asbind20")
     add_urls("https://github.com/HenryAWE/asbind20/archive/refs/tags/$(version).tar.gz",
              "https://github.com/HenryAWE/asbind20.git")
 
+    add_versions("2.0.1", "4d48b81dbe6d9d8cde2e671b7fdc10e1a868926cbc637610ea7355140a4041ef")
     add_versions("1.8.0", "cbc4b68cfbd39c96225d2f1509d0f842678b98b0cafa682daef24dc773e5bbc9")
     add_versions("1.7.1", "076afaa81eb880440c8c83df1a54cff04c72d5b0633dbe93776882bdc02348e6")
     add_versions("1.7.0", "43d0cbb0edb64b35f4a847cf16dbb41bd94d13d2cb7cdc4187de2e1d03869652")


### PR DESCRIPTION
New version of asbind20 detected (package version: 1.8.0, last github version: 2.0.1)