### PR TITLE
Auto-update thrift to v0.24.0

### DIFF
--- a/packages/t/thrift/patches/0.24.0/cmake.patch
+++ b/packages/t/thrift/patches/0.24.0/cmake.patch
@@ -1,0 +1,90 @@
+diff --git a/build/cmake/DefineInstallationPaths.cmake b/build/cmake/DefineInstallationPaths.cmake
+index 0c3dd09..39ae0ca 100644
+--- a/build/cmake/DefineInstallationPaths.cmake
++++ b/build/cmake/DefineInstallationPaths.cmake
+@@ -22,11 +22,7 @@
+ set(BIN_INSTALL_DIR "bin" CACHE PATH "The binary install dir (default: bin)")
+ # For MSVC builds, install shared libs to bin/, while keeping the install
+ # dir for static libs as lib/.
+-if(MSVC AND BUILD_SHARED_LIBS)
+-    set(LIB_INSTALL_DIR "bin${LIB_SUFFIX}" CACHE PATH "The library install dir (default: bin${LIB_SUFFIX})")
+-else()
+-    set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE PATH "The library install dir (default: lib${LIB_SUFFIX})")
+-endif()
++set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE PATH "The library install dir (default: lib${LIB_SUFFIX})")
+ set(INCLUDE_INSTALL_DIR "include" CACHE PATH "The library install dir (default: include)")
+ set(CMAKE_INSTALL_DIR "lib/cmake" CACHE PATH "The subdirectory to install cmake config files (default: cmake)")
+ set(PKGCONFIG_INSTALL_DIR "lib/pkgconfig" CACHE PATH "The subdirectory to install pkgconfig config files (default: lib/pkgconfig)")
+diff --git a/build/cmake/DefineOptions.cmake b/build/cmake/DefineOptions.cmake
+index 7c1dddb..74d2fb7 100644
+--- a/build/cmake/DefineOptions.cmake
++++ b/build/cmake/DefineOptions.cmake
+@@ -39,11 +39,6 @@ option(BUILD_LIBRARIES "Build Thrift libraries" ON)
+ # and enables the library if all are found. This means the default is to build as
+ # much as possible but leaving out libraries if their dependencies are not met.
+ 
+-if (NOT Boost_USE_STATIC_LIBS)
+-    add_definitions(-DBOOST_ALL_DYN_LINK)
+-    add_definitions(-DBOOST_TEST_DYN_LINK)
+-endif()
+-
+ # C++
+ option(WITH_CPP "Build C++ Thrift library" ON)
+ if(WITH_CPP)
+diff --git a/lib/c_glib/CMakeLists.txt b/lib/c_glib/CMakeLists.txt
+index 3557123..ac6fc1d 100644
+--- a/lib/c_glib/CMakeLists.txt
++++ b/lib/c_glib/CMakeLists.txt
+@@ -71,7 +71,8 @@ set(thrift_c_glib_zlib_SOURCES
+ )
+ 
+ # If OpenSSL is not found just ignore the OpenSSL stuff
+-if(OPENSSL_FOUND AND WITH_OPENSSL)
++if(WITH_OPENSSL)
++    find_package(OpenSSL REQUIRED)
+     list(APPEND thrift_c_glib_SOURCES
+ 	    src/thrift/c_glib/transport/thrift_ssl_socket.c
+     )
+@@ -83,8 +84,7 @@ if(OPENSSL_FOUND AND WITH_OPENSSL)
+             list(APPEND SYSLIBS OpenSSL::Crypto)
+         endif()
+     else()
+-        include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
+-        list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
++        list(APPEND SYSLIBS OpenSSL::SSL OpenSSL::Crypto)
+     endif()
+ endif()
+ 
+diff --git a/lib/cpp/CMakeLists.txt b/lib/cpp/CMakeLists.txt
+index d189922..c532cca 100644
+--- a/lib/cpp/CMakeLists.txt
++++ b/lib/cpp/CMakeLists.txt
+@@ -97,7 +97,8 @@ else()
+ endif()
+ 
+ # If OpenSSL is not found or disabled just ignore the OpenSSL stuff
+-if(OPENSSL_FOUND AND WITH_OPENSSL)
++if(WITH_OPENSSL)
++    find_package(OpenSSL REQUIRED)
+     list(APPEND thriftcpp_SOURCES
+        src/thrift/transport/TSSLSocket.cpp
+        src/thrift/transport/TSSLServerSocket.cpp
+@@ -112,8 +113,7 @@ if(OPENSSL_FOUND AND WITH_OPENSSL)
+             list(APPEND SYSLIBS OpenSSL::Crypto)
+         endif()
+     else()
+-        include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
+-        list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
++        list(APPEND SYSLIBS OpenSSL::SSL OpenSSL::Crypto)
+     endif()
+ endif()
+ 
+@@ -174,7 +174,7 @@ if(WITH_LIBEVENT)
+     target_link_libraries(thriftnb PUBLIC thrift)
+     if(TARGET libevent::core AND TARGET libevent::extra)
+         # libevent was found via its cmake config, use modern style targets
+-        target_link_libraries(thriftnb PUBLIC libevent::core libevent::extra)
++    target_link_libraries(thriftnb PUBLIC libevent::core libevent::extra)
+     else()
+         target_link_libraries(thriftnb PUBLIC ${LIBEVENT_LIBRARIES})
+     endif()

--- a/packages/t/thrift/xmake.lua
+++ b/packages/t/thrift/xmake.lua
@@ -6,6 +6,7 @@ package("thrift")
     add_urls("https://github.com/apache/thrift/archive/refs/tags/$(version).tar.gz",
              "https://github.com/apache/thrift.git")
 
+    add_versions("v0.24.0", "d3a60676b1df3fb9850f6ce1e8a3df9a0efac036ceb4bce8ce46ee3eca735d2d")
     add_versions("v0.23.0", "087ba9517063c8252e9e7fb4e3891a9fd85e20af80e0309e2276eff16791d75c")
     add_versions("v0.22.0", "c4649c5879dd56c88f1e7a1c03e0fbfcc3b2a2872fb81616bffba5aa8a225a37")
     add_versions("v0.21.0", "31e46de96a7b36b8b8a457cecd2ee8266f81a83f8e238a9d324d8c6f42a717bc")

--- a/packages/t/thrift/xmake.lua
+++ b/packages/t/thrift/xmake.lua
@@ -17,7 +17,8 @@ package("thrift")
     add_versions("v0.17.0", "f5888bcd3b8de40c2c2ab86896867ad9b18510deb412cba3e5da76fb4c604c29")
     add_versions("v0.16.0", "df2931de646a366c2e5962af679018bca2395d586e00ba82d09c0379f14f8e7b")
 
-    add_patches(">=0.21.0", "patches/0.21.0/cmake.patch", "506f7f70d76e092a62e87ada5290410a203241a08ba362eb82afa6200fae0881")
+    add_patches(">=0.24.0", "patches/0.24.0/cmake.patch", "576c09a2d6a5bec3f04f419c8de8fccac7cc7e2c7d3917075a0aa415176aa706")
+    add_patches(">=0.21.0 <0.24.0", "patches/0.21.0/cmake.patch", "506f7f70d76e092a62e87ada5290410a203241a08ba362eb82afa6200fae0881")
     add_patches(">=0.16.0 <=0.20.0", "patches/0.16.0/cmake.patch", "8dd82f54d52a37487e64aa3529f4dbcedcda671ab46fcb7a8c0f2c521ee0be9b")
 
     add_configs("compiler", {description = "Build compiler", default = false, type = "boolean"})


### PR DESCRIPTION
New version of thrift detected (package version: v0.23.0, last github version: v0.24.0)