### PR TITLE
Auto-update simsimd to v7.7.1

### DIFF
--- a/packages/s/simsimd/xmake.lua
+++ b/packages/s/simsimd/xmake.lua
@@ -7,6 +7,7 @@ package("simsimd")
     add_urls("https://github.com/ashvardanian/SimSIMD/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ashvardanian/SimSIMD.git")
 
+    add_versions("v7.7.1", "ad4f9d1bebda21cf56eb3da1f2d9a1818d86fb07b8170cab91568c57178dc4e1")
     add_versions("v6.5.16", "26af59c8d39d65cc3cb526cc8275211fe6e19580eeec2aab708e4ffc27f78f45")
     add_versions("v6.5.12", "f14519635ec45ecb0b4da9a9a5f51f95f77f220bda4e51a5972afd8176a11121")
     add_versions("v6.5.9", "c816934db339c5cf6e7ba6c127c16d082b58bec5f5657a62cb505bf70994e1b8")


### PR DESCRIPTION
New version of simsimd detected (package version: v6.5.16, last github version: v7.7.1)