### PR TITLE
Auto-update c-blosc2 to v3.2.3

### DIFF
--- a/packages/c/c-blosc2/xmake.lua
+++ b/packages/c/c-blosc2/xmake.lua
@@ -6,6 +6,7 @@ package("c-blosc2")
     add_urls("https://github.com/Blosc/c-blosc2/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Blosc/c-blosc2.git")
 
+    add_versions("v3.2.3", "32977709c21f3fec50befa7a031fa624b963427b69d3ffb69c91aadc9279c887")
     add_versions("v3.2.1", "945cc68d47ba2817279b5d64c0f9b5edce6849a52ac1a46ba8c3ecaedce35769")
     add_versions("v3.0.3", "535f2165906d59cba0783ca8cd286b358a0c23493e2d9c4c2840569498a163d0")
     add_versions("v2.23.1", "3a1a55d1e3794fb2b51a12e722d611b3e577443abb7ff9951666511f576ea3da")

--- a/packages/c/c-blosc2/xmake.lua
+++ b/packages/c/c-blosc2/xmake.lua
@@ -29,7 +29,7 @@ package("c-blosc2")
 
     if is_plat("bsd") then
         -- _XOPEN_SOURCE hides BSD extensions such as flock() on FreeBSD.
-        add_patches("3.2.1", "patches/v3.2.1/freebsd.patch", "608aa28d0a0dd5e7e67badc51b4eda85996efe0da8b933117bdf788e1ad7f0bf")
+        add_patches(">=3.2.1", "patches/v3.2.1/freebsd.patch", "608aa28d0a0dd5e7e67badc51b4eda85996efe0da8b933117bdf788e1ad7f0bf")
     end
 
     if is_plat("wasm") then


### PR DESCRIPTION
New version of c-blosc2 detected (package version: v3.2.1, last github version: v3.2.3)