### PR TITLE
Auto-update opentelemetry-cpp to v1.28.0

### DIFF
--- a/packages/o/opentelemetry-cpp/xmake.lua
+++ b/packages/o/opentelemetry-cpp/xmake.lua
@@ -6,6 +6,7 @@ package("opentelemetry-cpp")
     add_urls("https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/open-telemetry/opentelemetry-cpp.git", {submodules = false})
 
+    add_versions("v1.28.0", "8c359919175d77c502515f5a783907d031cc6a172e44426dbe9bee3c1532201e")
     add_versions("v1.27.0", "d09c2e8dd95bbc1d6ee493a89f32a4736879948d0eb59ad58c855022d1f55cc1")
     add_versions("v1.26.0", "8a878777a18a013e0ee6604629d1b5f29b162354c14489ad1dccd370f14ac372")
     add_versions("v1.25.0", "a0c944a9de981fe1874b31d1fe44b830fc30ee030efa27ee23fc73012a3a13e9")


### PR DESCRIPTION
New version of opentelemetry-cpp detected (package version: v1.27.0, last github version: v1.28.0)