### PR TITLE
Auto-update openjph to 0.31.0

### DIFF
--- a/packages/o/openjph/xmake.lua
+++ b/packages/o/openjph/xmake.lua
@@ -6,6 +6,7 @@ package("openjph")
     add_urls("https://github.com/aous72/OpenJPH/archive/refs/tags/$(version).tar.gz",
              "https://github.com/aous72/OpenJPH.git")
 
+    add_versions("0.31.0", "fe169dbbaae71a169a0a6a68dccb346616193252c1ca044217afa0d5d1dc436f")
     add_versions("0.30.1", "fb3ccf71af838ed2a42c6ea669308a2adaba115ae9d5862dfb1e2865b43eb5b8")
     add_versions("0.29.0", "1302a296308996af4c023b7f104133f0d48e89e18b86da999973c476b5e8b584")
     add_versions("0.28.1", "89629a3c0f61d474073076bb6195e9bb1d63fafb2e1c57ab46aee53a62f21819")


### PR DESCRIPTION
New version of openjph detected (package version: 0.30.1, last github version: 0.31.0)