### PR TITLE
Auto-update jsoncons to v1.8.1

### DIFF
--- a/packages/j/jsoncons/xmake.lua
+++ b/packages/j/jsoncons/xmake.lua
@@ -7,6 +7,7 @@ package("jsoncons")
     set_urls("https://github.com/danielaparker/jsoncons/archive/refs/tags/$(version).tar.gz",
              "https://github.com/danielaparker/jsoncons.git")
 
+    add_versions("v1.8.1", "05657792d92f55be3e6494036c414e9d94237e3959fa46b073fdc712f4a9e56d")
     add_versions("v1.5.0", "956021e44e50639be766a4ad71aff9a95168da188005fc6bfa23ee5d6a53eb32")
     add_versions("v1.4.3", "6cc79df3bf10f3ecd5fbdd0a64deaaad35beda2767f8697e261e1af11e1e3526")
     add_versions("v1.3.2", "f22fb163df1a12c2f9ee5f95cad9fc37c6cfbefe0ae6f30aba7440832ef70fbe")


### PR DESCRIPTION
New version of jsoncons detected (package version: v1.5.0, last github version: v1.8.1)