### PR TITLE
Auto-update upa-url to v2.5.0

### DIFF
--- a/packages/u/upa-url/xmake.lua
+++ b/packages/u/upa-url/xmake.lua
@@ -6,6 +6,7 @@ package("upa-url")
     add_urls("https://github.com/upa-url/upa/archive/refs/tags/$(version).tar.gz",
              "https://github.com/upa-url/upa.git", {submodules = false})
 
+    add_versions("v2.5.0", "3feec2468433831e6c65e31a9fdddc9711d5464759cb54d155bf99c4efbeaa88")
     add_versions("v2.4.0", "97a7ddf56c8b65e8b54027d01acfb4fe7b2f0f1f16ce5023d12ce5a5539718ff")
     add_versions("v2.3.0", "707b487534c1cb2be6bc180249b6c0fd7947758a4bca76754c0afdbda462bdba")
     add_versions("v2.2.0", "7b6d5e5774d0264ef2be0782ec3548e191ef113b34983323791a914a00de0d3a")


### PR DESCRIPTION
New version of upa-url detected (package version: v2.4.0, last github version: v2.5.0)