### PR TITLE
Auto-update libraqm to v0.11.0

### DIFF
--- a/packages/l/libraqm/xmake.lua
+++ b/packages/l/libraqm/xmake.lua
@@ -6,6 +6,7 @@ package("libraqm")
     add_urls("https://github.com/HOST-Oman/libraqm/archive/refs/tags/$(version).tar.gz",
              "https://github.com/HOST-Oman/libraqm.git")
 
+    add_versions("v0.11.0", "2ba3521d3f24e9696185a67a16f1a9643429d6c897d89d83dfb2aad3a398732a")
     add_versions("v0.10.5", "7f3dd21b4b3bd28a36f2c911d31d91a9d69341697713923ef1aac65d56ebcafd")
     add_versions("v0.10.4", "6b583fb0eb159a3727a1e8c653bb0294173a14af8eb60195a775879de72320a3")
     add_versions("v0.10.3", "fe1fe28b32f97ef97b325ca5d2defb0704da1ef048372ec20e85e1f587e20965")


### PR DESCRIPTION
New version of libraqm detected (package version: v0.10.5, last github version: v0.11.0)