### PR TITLE
Auto-update aws-c-io to v0.27.5

### DIFF
--- a/packages/a/aws-c-io/xmake.lua
+++ b/packages/a/aws-c-io/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-io")
     add_urls("https://github.com/awslabs/aws-c-io/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-io.git")
 
+    add_versions("v0.27.5", "aa132d5a728f18ab8e0a6ea96d3d2f7e66bc8d3fe029d9ed1b05c06aa0c5b900")
     add_versions("v0.27.4", "0f2ce32de3685ca5ba3a8395d461c783253c1718cf70d31378eb6be890db1e3e")
     add_versions("v0.27.2", "42caef5ef624ca8f5046d4e9f21c8dcaf1c4d7d0b2d46d965357b13079f2d2d3")
     add_versions("v0.27.0", "e89a1f784e7c97e4197031ffdcf30f67d66d7c14f8a391edf5764f17dae982ee")


### PR DESCRIPTION
New version of aws-c-io detected (package version: v0.27.4, last github version: v0.27.5)