### PR TITLE
Auto-update safetyhook to v0.7.0

### DIFF
--- a/packages/s/safetyhook/xmake.lua
+++ b/packages/s/safetyhook/xmake.lua
@@ -6,6 +6,7 @@ package("safetyhook")
     add_urls("https://github.com/cursey/safetyhook/archive/refs/tags/$(version).tar.gz",
              "https://github.com/cursey/safetyhook.git")
 
+    add_versions("v0.7.0", "72a738986c73f7b78bf1eb41680e8aacf5df5664fe23c8d96d7c018f170282ab")
     add_versions("v0.6.10", "e30b8ec44a2eeb26ebe1a8006f03649de0686e5bbf1f5a9d29d98670a6c10f92")
     add_versions("v0.6.9", "2cd773fbcec62945e8fae4b1858ecc77e7cfa84d55df694cb38676d440dd47d2")
     add_versions("v0.6.7", "05e66f9a1ac85249f590149a146e74fd946950cfe0c82917e5a4ec178e9e212a")


### PR DESCRIPTION
New version of safetyhook detected (package version: v0.6.10, last github version: v0.7.0)