### PR TITLE
Auto-update gdal to 3.13.2

### DIFF
--- a/packages/g/gdal/xmake.lua
+++ b/packages/g/gdal/xmake.lua
@@ -4,6 +4,7 @@ package("gdal")
     set_license("MIT")
 
     add_urls("https://github.com/OSGeo/gdal/releases/download/v$(version)/gdal-$(version).tar.gz")
+    add_versions("3.13.2", "1051c33db1d9e6a05907ac07cd06f5ce8ac0658f317c3229774cc2198a6c1252")
     add_versions("3.13.1", "e04e9813bd215b56753d5554330c53be25f3df2d7ed7e6413a19e6b66751c675")
     add_versions("3.12.3", "1fdfe51181d08b9b83037b611da4de4a7cf1fca69e6564945ac99d3f7d0367dd")
     add_versions("3.12.2", "458a899feea38000258144517fedc6662ebba255971669d2901ba77e9e8fbf79")


### PR DESCRIPTION
New version of gdal detected (package version: 3.13.1, last github version: 3.13.2)