### PR TITLE
Fix lsp-framework not building on Ubuntu 22.04 (/bin/sh: 1: lspgen: not found)

### DIFF
--- a/packages/l/lsp-framework/xmake.lua
+++ b/packages/l/lsp-framework/xmake.lua
@@ -40,6 +40,7 @@ package("lsp-framework")
     on_install("windows", "linux", "macosx", "mingw@windows", "bsd", function (package)
         local configs = {}
         if package:version():ge("1.3.0") then
+            io.replace("CMakeLists.txt", "COMMAND%s+lspgen%s+", "COMMAND $<TARGET_FILE:lspgen> ", {plain = false})
             io.replace("CMakeLists.txt", "install(TARGETS lsp EXPORT lsp ARCHIVE LIBRARY)", "install(TARGETS lsp EXPORT lsp RUNTIME ARCHIVE LIBRARY)", {plain = true})
             table.insert(configs, "-DCMAKE_INSTALL_LIBDIR=lib")
         end


### PR DESCRIPTION
The package fails to build on GitHub actions using Ubuntu 22.04 because the binary cannot be found in PATH.

This change fixes the error by specifying the correct location. Tested on Ubuntu 26.04, Windows 11, macOS 15 (GitHub Actions), and Ubuntu 22.04 (GitHub Actions).

Using `TARGET_FILE` as suggested in https://cmake.org/cmake/help/latest/command/add_custom_command.html#:~:text=Use%20the%20TARGET_FILE%20generator%20expression%20to%20refer%20to%20the%20location%20of%20a%20target%20later%20in%20the%20command%20line%20(i.e.%20as%20a%20command%20argument%20rather%20than%20as%20the%20command%20to%20execute).

```
  => install lsp-framework 1.3.1 .. failed

ninja: Entering directory `/home/runner/.xmake/cache/packages/2608/l/lsp-framework/1.3.1/source/build_cd7e4b64'
[1/17] Building CXX object CMakeFiles/lspgen.dir/lsp/json/json.cpp.o
[2/17] Building CXX object CMakeFiles/lspgen.dir/lspgen/lspgen.cpp.o
[3/17] Linking CXX executable lspgen
[4/17] Generating lsp types from meta model...
FAILED: [code=127] generated/lsp/types.h generated/lsp/messages.h generated/lsp/types.cpp /home/runner/.xmake/cache/packages/2608/l/lsp-framework/1.3.1/source/build_cd7e4b64/generated/lsp/types.h /home/runner/.xmake/cache/packages/2608/l/lsp-framework/1.3.1/source/build_cd7e4b64/generated/lsp/messages.h /home/runner/.xmake/cache/packages/2608/l/lsp-framework/1.3.1/source/build_cd7e4b64/generated/lsp/types.cpp 
cd /home/runner/.xmake/cache/packages/2608/l/lsp-framework/1.3.1/source/build_cd7e4b64/generated/lsp && lspgen /home/runner/.xmake/cache/packages/2608/l/lsp-framework/1.3.1/source/lspgen/metaModel.json
/bin/sh: 1: lspgen: not found
ninja: build stopped: subcommand failed.
if you want to get more verbose errors, please see:
  -> /home/runner/.xmake/cache/packages/2608/l/lsp-framework/1.3.1/installdir.failed/logs/install.txt
```