### PR TITLE
Auto-update metall to v0.33

### DIFF
--- a/packages/m/metall/xmake.lua
+++ b/packages/m/metall/xmake.lua
@@ -6,6 +6,7 @@ package("metall")
     add_urls("https://github.com/LLNL/metall/archive/refs/tags/$(version).tar.gz",
              "https://github.com/LLNL/metall.git")
 
+    add_versions("v0.33", "4e3d33d94f90634b2a08802065092fb684ae20e77a1297ed741db0b60e4a1a9e")
     add_versions("v0.32", "2d373689c56fb41c5e995d786a76845f396099cc5f8bcba0c45a0179a621e235")
     add_versions("v0.31", "d7e1c3d953a31e2fe3adddd7553264e0dc61020d300fa0f0ba409859a68420f3")
     add_versions("v0.30", "d241f45978fceeb83a4b2eda7513466341c45452fa26ec224c5235d00d279d37")


### PR DESCRIPTION
New version of metall detected (package version: v0.32, last github version: v0.33)