### PR TITLE
Auto-update vcpkg to 2026.07.29

### DIFF
--- a/packages/l/libcurl/xmake.lua
+++ b/packages/l/libcurl/xmake.lua
@@ -38,12 +38,14 @@ package("libcurl")
 
     -- we init all configurations in on_load, because package("curl") need it.
     on_load(function (package)
-        if package:is_plat("linux", "bsd", "android", "cross") then
+        local version = package:version()
+        local needs_openssl_on_apple = package:is_plat("macosx", "iphoneos") and version and version:ge("8.15.0")
+        if package:is_plat("linux", "bsd", "android", "cross") or needs_openssl_on_apple then
             -- if no TLS backend has been enabled nor disabled, prefer openssl3 on modern systems
             if package:config("openssl") == nil and package:config("openssl3") == nil and package:config("mbedtls") == nil then
-                -- Default to OpenSSL 3.0+ on Linux systems (Ubuntu 22.04+, Fedora 36+, etc.)
-                -- This helps avoid conflicts with other packages like libgit2 that use OpenSSL 3.0+
-                if package:is_plat("linux") or (package:version() and package:version():ge("8.18.0")) then
+                -- Prefer OpenSSL 3 on Linux and curl 8.18+.
+                -- This also avoids conflicts with packages such as libgit2 that use OpenSSL 3.
+                if package:is_plat("linux") or (version and version:ge("8.18.0")) then
                     package:config_set("openssl3", true)
                 else
                     package:config_set("openssl", true)
@@ -135,7 +137,8 @@ package("libcurl")
         if package:is_plat("windows", "mingw") then
             table.insert(configs, (version:ge("7.80") and "-DCURL_USE_SCHANNEL=ON" or "-DCMAKE_USE_SCHANNEL=ON"))
         end
-        if package:is_plat("macosx", "iphoneos") then
+        -- Secure Transport was removed in curl 8.15.0.
+        if package:is_plat("macosx", "iphoneos") and version:lt("8.15.0") then
             table.insert(configs, (version:ge("7.65") and "-DCURL_USE_SECTRANSP=ON" or "-DCMAKE_USE_DARWINSSL=ON"))
         end
         if package:is_plat("windows") then

--- a/packages/v/vcpkg/xmake.lua
+++ b/packages/v/vcpkg/xmake.lua
@@ -5,6 +5,7 @@ package("vcpkg")
     set_license("MIT")
 
     add_urls("https://github.com/microsoft/vcpkg/archive/refs/tags/$(version).tar.gz")
+    add_versions("2026.07.29", "6b1a5b0170fda8e585b258fa416e4251197bba4633414d2ac00f02625c78194e")
     add_versions("2026.06.01", "d394626f9205790915c70e1281eb08554e8d72ac0677334893e32636ae08ec3d")
     add_versions("2026.04.27", "d16031ddc44ca990052a6cee0e76aa240fa01397930dbc5eb054852d1816d860")
     add_versions("2026.03.18", "96bd7fa4745c8b42c16f585c47ddf09d5eef3fc35714654f755de379294f5245")


### PR DESCRIPTION
New version of vcpkg detected (package version: 2026.06.01, last github version: 2026.07.29)