### PR TITLE
freetype: patch .pc file when building debug

### DIFF
--- a/packages/f/freetype/xmake.lua
+++ b/packages/f/freetype/xmake.lua
@@ -119,6 +119,10 @@ package("freetype")
         add_dep({conf = "harfbuzz", pkg = "harfbuzz", cmakewith = "HARFBUZZ", cmakedisable = "HarfBuzz", cmakeinclude = "HarfBuzz_INCLUDE_DIR", cmakelib = "HarfBuzz_LIBRARY"})
 
         import("package.tools.cmake").install(package, configs)
+        if package:is_plat("windows") and package:debug() then
+            io.replace(package:installdir("lib/pkgconfig/freetype2.pc"),
+                       "%-lfreetype(\r?\n)", "-lfreetyped%1")
+        end
     end)
 
     on_test(function (package)


### PR DESCRIPTION
The mismatch (freetype.lib / freetyped.lib) in the .pc file would also cause fontconfig to fail when building it as debug. I don't know if this is a concerns for non-windows platforms.

Closes #10543 .