### PR TITLE
Auto-update fast-cdr to v2.4.0

### DIFF
--- a/packages/f/fast-cdr/xmake.lua
+++ b/packages/f/fast-cdr/xmake.lua
@@ -6,6 +6,7 @@ package("fast-cdr")
     add_urls("https://github.com/eProsima/Fast-CDR/archive/refs/tags/$(version).tar.gz",
              "https://github.com/eProsima/Fast-CDR.git")
 
+    add_versions("v2.4.0", "79d8466107dd6b7d1defe961c4aa31735038937cf9dd1175cf6b0da0df2209ab")
     add_versions("v2.3.6", "906b6ca9c6b56ea87ae14a389e30769ee8093be491be748a475550d029749a1c")
     add_versions("v2.3.5", "e0af6cde06c4a43d90fa905c6d15721435520a26f0ba168ed13dfda45d164001")
     add_versions("v2.3.4", "5b96e85680bd105138202eb734e02545b3e0a06bff8eb55f1f06b692087ed9ef")


### PR DESCRIPTION
New version of fast-cdr detected (package version: v2.3.6, last github version: v2.4.0)