### PR TITLE
Auto-update orc to v2.3.1

### DIFF
--- a/packages/o/orc/xmake.lua
+++ b/packages/o/orc/xmake.lua
@@ -6,6 +6,7 @@ package("orc")
     add_urls("https://github.com/apache/orc/archive/refs/tags/$(version).tar.gz",
              "https://github.com/apache/orc.git")
 
+    add_versions("v2.3.1", "5c5fb4bf752a880da08c8a10a17e1a98a4422b25eaa2391f5286e509b1ae43fa")
     add_versions("v2.3.0", "d38b871c3989304d79c28c291bc80819b4585d7cea88d16243f74842a7e2a953")
     add_versions("v2.2.2", "ff952b23f0a7078153ce56ef1f3fa47fefa2bbcb17a2cf305cc36fad6b0a6316")
     add_versions("v2.2.1", "f826086e43512982d377469c35b6794cfdf59d41b91c9bd04ebfac4cbb19f20a")


### PR DESCRIPTION
New version of orc detected (package version: v2.3.0, last github version: v2.3.1)