### PR TITLE
Auto-update cppcheck to 2.21.1

### DIFF
--- a/packages/c/cppcheck/xmake.lua
+++ b/packages/c/cppcheck/xmake.lua
@@ -4,6 +4,7 @@ package("cppcheck")
     set_description("A static analysis tool for C/C++ code")
 
     add_urls("https://github.com/danmar/cppcheck/archive/refs/tags/$(version).tar.gz")
+    add_versions("2.21.1", "ba750bd872ad7c01f951ff2d9dc8c68ea5852654545ec7a62a4c318d690c8e22")
     add_versions("2.20.1", "97634b598b8adf23e6cbd75aec5a8ac2d8b5f49f53e6a145b1c8380525c48a91")
     add_versions("2.20.0", "7be7992439339017edb551d8e7d2315f9bb57c402da50c2cee9cd0e2724600a1")
     add_versions("2.19.1", "49bdf1d7826d60053575b78d3192d81d54970dbfb356590f7476de250b1a4234")


### PR DESCRIPTION
New version of cppcheck detected (package version: 2.20.1, last github version: 2.21.1)