### PR TITLE
Auto-update kuba-zip to v0.3.15

### DIFF
--- a/packages/k/kuba-zip/xmake.lua
+++ b/packages/k/kuba-zip/xmake.lua
@@ -6,6 +6,7 @@ package("kuba-zip")
     add_urls("https://github.com/kuba--/zip/archive/refs/tags/$(version).tar.gz",
              "https://github.com/kuba--/zip.git")
 
+    add_versions("v0.3.15", "0d66dd898f570cbb98bf4b2a1bf1bd9d113f7579ec35e65485b7711d0aebdef7")
     add_versions("v0.3.11", "1108abfe18bcdba5ff351eb733376bbaf7ac872933116cd5b5398293a62a7a7c")
     add_versions("v0.3.9", "44404237dc025952faa3d21abcd3696b5f0f1104e97e5c8cf39eeefa80b00e8c")
     add_versions("v0.3.8", "944656c33aa776dc2c882991d1a6a86c8408fec8b8a19bc5305bf7eabdd4d908")


### PR DESCRIPTION
New version of kuba-zip detected (package version: v0.3.11, last github version: v0.3.15)