### PR TITLE
mbedtls: added lts 3.x and last 4.x versions

### DIFF
--- a/packages/m/mbedtls/xmake.lua
+++ b/packages/m/mbedtls/xmake.lua
@@ -15,6 +15,9 @@ package("mbedtls")
     end})
     add_urls("https://github.com/Mbed-TLS/mbedtls.git")
 
+    add_versions("v4.2.0", "2bed9d713b4668f76553b097e72b8aa30bc8f112a940d7ae228d524bbde6ffea")
+    add_versions("v4.1.1", "3359a349e23db3d5536fcee032ae7b2ecbfc08972fab643089b5cbf2a375c98c")
+    add_versions("v4.0.0", "2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827")
     add_versions("v3.6.7", "a7e8bcbec0e6f761b4af24f25677626b35f762f68eef79c08677a363212d11f6")
     add_versions("v3.6.1", "fc8bef0991b43629b7e5319de6f34f13359011105e08e3e16eed3a9fe6ffd3a3")
     add_versions("v3.6.0", "3ecf94fcfdaacafb757786a01b7538a61750ebd85c4b024f56ff8ba1490fcd38")
@@ -29,7 +32,13 @@ package("mbedtls")
 
     add_deps("cmake")
 
-    add_links("mbedtls", "mbedx509", "mbedcrypto")
+    on_load(function (package)
+        if package:version() and package:version():ge("4.0.0") then
+            package:add("links", "mbedtls", "mbedx509", "tfpsacrypto")
+        else
+            package:add("links", "mbedtls", "mbedx509", "mbedcrypto")
+        end
+    end)
 
     if is_plat("windows", "mingw") then
         add_syslinks("ws2_32", "advapi32", "bcrypt")
@@ -69,10 +78,8 @@ package("mbedtls")
         assert(package:has_cfuncs("mbedtls_ssl_init", {includes = "mbedtls/ssl.h"}))
         assert(package:check_cxxsnippets({test = [[
             void test() {
-                mbedtls_aes_context ctx;
-
-                unsigned char key[32]; 
-                mbedtls_aes_setkey_enc(&ctx, key, 256);
+                psa_status_t status = psa_crypto_init();
+                (void)status;
             }
-        ]]}, {includes = "mbedtls/aes.h"}))
+        ]]}, {includes = "psa/crypto.h"}))
     end)

--- a/packages/m/mbedtls/xmake.lua
+++ b/packages/m/mbedtls/xmake.lua
@@ -15,6 +15,7 @@ package("mbedtls")
     end})
     add_urls("https://github.com/Mbed-TLS/mbedtls.git")
 
+    add_versions("v3.6.7", "a7e8bcbec0e6f761b4af24f25677626b35f762f68eef79c08677a363212d11f6")
     add_versions("v3.6.1", "fc8bef0991b43629b7e5319de6f34f13359011105e08e3e16eed3a9fe6ffd3a3")
     add_versions("v3.6.0", "3ecf94fcfdaacafb757786a01b7538a61750ebd85c4b024f56ff8ba1490fcd38")
     add_versions("v3.5.1", "959a492721ba036afc21f04d1836d874f93ac124cf47cf62c9bcd3a753e49bdb")

--- a/packages/m/mbedtls/xmake.lua
+++ b/packages/m/mbedtls/xmake.lua
@@ -48,10 +48,27 @@ package("mbedtls")
 
     on_install(function (package)
         if package:config("shared") and package:is_plat("windows") then
-            io.replace("library/constant_time_impl.h", "extern volatile", "__declspec(dllimport) volatile", {plain = true})
+            local constant_time_impl
+            local patch_psa_to_ssl_errors = false
+
+            if package:version() and package:version():ge("4.1.0") and package:version():lt("5.0.0") then
+                constant_time_impl = "tf-psa-crypto/utilities/constant_time_impl.h"
+            elseif package:version() and package:version():ge("4.0.0") and package:version():lt("4.1.0") then
+                constant_time_impl = "tf-psa-crypto/drivers/builtin/src/constant_time_impl.h"
+            elseif package:version() and package:version():lt("4.0.0") then
+                constant_time_impl = "library/constant_time_impl.h"
+                patch_psa_to_ssl_errors = true
+            else
+                raise("package(mbedtls): unsupported version for windows shared dllimport patch: " .. tostring(package:version()))
+            end
+
+            io.replace(constant_time_impl, "extern volatile", "__declspec(dllimport) volatile", {plain = true})
             io.replace("include/mbedtls/x509_crt.h", "extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_suiteb;", "__declspec(dllimport) const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_suiteb;", {plain = true})
             io.replace("include/mbedtls/x509_crt.h", "extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_default;", "__declspec(dllimport) const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_default;", {plain = true})
-            io.replace("library/psa_util_internal.h", "extern const mbedtls_error_pair_t psa_to_ssl_errors[7];", "__declspec(dllimport) const mbedtls_error_pair_t psa_to_ssl_errors[7];", {plain = true})
+
+            if patch_psa_to_ssl_errors then
+                io.replace("library/psa_util_internal.h", "extern const mbedtls_error_pair_t psa_to_ssl_errors[7];", "__declspec(dllimport) const mbedtls_error_pair_t psa_to_ssl_errors[7];", {plain = true})
+            end
         end
 
         local configs = {"-DENABLE_TESTING=OFF", "-DENABLE_PROGRAMS=OFF", "-DMBEDTLS_FATAL_WARNINGS=OFF"}


### PR DESCRIPTION
added 3.6.7 version as the last LTS build for 3.x builds
added several 4.x versions as the latest builds
changed test a little bit so it works fine on both 3.x and 4.x builds