### PR TITLE
Auto-update libgit2 to v1.9.6

### DIFF
--- a/packages/l/libgit2/xmake.lua
+++ b/packages/l/libgit2/xmake.lua
@@ -6,6 +6,7 @@ package("libgit2")
     set_urls("https://github.com/libgit2/libgit2/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libgit2/libgit2.git")
 
+    add_versions("v1.9.6", "a88a42a4ea9bdab7aa8686eead3bf7d9c6dd74529caca16ab22eaa92433d31d9")
     add_versions("v1.9.4", "824b73bd13647800fe4b566a1008ae77fea0e3e3424edab632fcfd8c0b14ba8b")
     add_versions("v1.9.3", "d532172d7ab24d2a25944e2434212d63ee85f3650e97b5f7579e7f201a78ad64")
     add_versions("v1.9.2", "6f097c82fc06ece4f40539fb17e9d41baf1a5a2fc26b1b8562d21b89bc355fe6")

--- a/packages/l/llhttp/xmake.lua
+++ b/packages/l/llhttp/xmake.lua
@@ -13,10 +13,6 @@ package("llhttp")
     add_versions("v8.1.0", "9da0d23453e8e242cf3b2bc5d6fb70b1517b8a70520065fcbad6be787e86638e")
     add_versions("v3.0.0", "02931556e69f8d075edb5896127099e70a093c104a994a57b4d72c85b48d25b0")
 
-    if is_plat("wasm") then
-        add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
-    end
-
     on_load(function (package)
         if package:version():ge("9.2.1") then
             package:add("deps", "cmake")
@@ -24,6 +20,11 @@ package("llhttp")
     end)
 
     on_install(function (package)
+        if package:is_plat("wasm") then
+            -- Only llhttp's standalone WASI wrapper supplies these callback imports.
+            io.replace("src/api.c", "#if defined(__wasm__)",
+                       "#if defined(__wasm__) && !defined(__EMSCRIPTEN__)", {plain = true})
+        end
         io.replace("include/llhttp.h", "__wasm__", "__GNUC__", {plain = true})
         io.replace("include/llhttp.h", "_WIN32", "_MSC_VER", {plain = true})
         if not package:config("shared") then


### PR DESCRIPTION
New version of libgit2 detected (package version: v1.9.4, last github version: v1.9.6)