### PR TITLE
Auto-update checkpolicy to 3.11

### DIFF
--- a/packages/c/checkpolicy/xmake.lua
+++ b/packages/c/checkpolicy/xmake.lua
@@ -5,6 +5,7 @@ package("checkpolicy")
     set_license("GPL-2.0")
 
     add_urls("https://github.com/SELinuxProject/selinux/releases/download/$(version)/checkpolicy-$(version).tar.gz")
+    add_versions("3.11", "9b81bfceef7fa9d02f9872e56a786f343dc58ef4b5713dce0d5c416e5b84cefa")
     add_versions("3.10", "2d92951dfcb090d6179e7a23856622e0fcbc32be03bf1e60ace9dc9cbda11e59")
     add_versions("3.9", "dd85b0173ca6e96b22ebf472bcbccf04eb10e1aa07add8f1b7e0e9e8e995e027")
 


### PR DESCRIPTION
New version of checkpolicy detected (package version: 3.10, last github version: 3.11)