### PR TITLE
Auto-update ftxui to v7.0.3

### DIFF
--- a/packages/f/ftxui/xmake.lua
+++ b/packages/f/ftxui/xmake.lua
@@ -5,6 +5,7 @@ package("ftxui")
 
     add_urls("https://github.com/ArthurSonzogni/FTXUI/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ArthurSonzogni/FTXUI.git")
+    add_versions("v7.0.3", "e7c62ffe19009759821b4f0f8df7f2a6fb83784c3a9f1477d81f56d3ee723c88")
     add_versions("v7.0.1", "80f544bb47fab24d3e57bc561324da228c050b3f2e8683fe806883ca5cd561a2")
     add_versions("v7.0.0", "14bef1f8caff548c49af8eeadfca21910d66e93e68237f0c3d20236b60c01e7e")
     add_versions("v6.1.9", "45819c1e54914783d4a1ca5633885035d74146778a1f74e1213cdb7b76340e71")


### PR DESCRIPTION
New version of ftxui detected (package version: v7.0.1, last github version: v7.0.3)