### PR TITLE
Auto-update astc-encoder to 5.7.0

### DIFF
--- a/packages/a/astc-encoder/xmake.lua
+++ b/packages/a/astc-encoder/xmake.lua
@@ -6,6 +6,7 @@ package("astc-encoder")
     add_urls("https://github.com/ARM-software/astc-encoder/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ARM-software/astc-encoder.git", {submodules = false})
 
+    add_versions("5.7.0", "7c1b28ece59c9c2737e297123a9910c1c548676c7aed87a09d5734e2fa7bdaf0")
     add_versions("5.3.0", "6bd248f460b90576f90a5499c0f6b8d785b3af3837bcab82607d9a3b5bba77e2")
     add_versions("5.2.0", "1680d440b765c3809490b6b49664a2ba0798624629615da4ff834401c0f1fe23")
     add_versions("4.8.0", "6c12f4656be21a69cbacd9f2c817283405decb514072dc1dcf51fd9a0b659852")


### PR DESCRIPTION
New version of astc-encoder detected (package version: 5.3.0, last github version: 5.7.0)