### PR TITLE
blake3: select x86-64 assembly by target platform

### DIFF
--- a/packages/b/blake3/port/xmake.lua
+++ b/packages/b/blake3/port/xmake.lua
@@ -6,7 +6,7 @@ target("blake3")
     add_headerfiles("c/blake3.h")
 
     if is_arch("x86_64", "x64") then
-        if is_subhost("msys", "cygwin") then
+        if is_plat("mingw", "msys", "cygwin") then
             add_files("c/*x86-64_windows_gnu.S")
         elseif is_plat("windows") then
             add_files("c/*x86-64_windows_msvc.asm")


### PR DESCRIPTION
BLAKE3 ships three x86-64 assembly variants and they differ by calling convention, so which one is correct depends on the platform being built for. The port script asked `is_subhost`, which reports the shell xmake is running in.

Building `-p mingw` from PowerShell or cmd therefore fell through to the System V variant and assembled it into a Win64 binary. The two conventions pass arguments in different registers -- `rdi/rsi/rdx/rcx` against `rcx/rdx/r8/r9` -- so `blake3_compress_xof_sse41` takes its first argument from a register holding something else and dereferences it. Compiling and linking report nothing; the first hash faults.

The same test is wrong in the other direction: cross-building for linux from an MSYS2 shell selected the Windows assembly.

```diff
-        if is_subhost("msys", "cygwin") then
+        if is_plat("mingw", "msys", "cygwin") then
```

`mingw`, `msys` and `cygwin` all produce PE binaries using the win64 convention, so all three take the gnu variant. `msys` is listed on purpose: xmake maps the msys subhost onto the `mingw` platform only when `MSYSTEM` contains `mingw`, so a UCRT64 or CLANG64 shell configures as plat `msys` and testing for `mingw` alone would have regressed it.

### Verification

Hashing 8 KiB with blake3 1.8.5 -- enough to reach the SIMD compress paths -- and cross-checking the digest against the same input fed in 97-byte pieces:

| build | before | after |
|---|---|---|
| PowerShell, `-p mingw` | exits with `0xC0000005` | correct digest, both paths agree |
| MSYS2 MINGW64 shell, default | correct digest | correct digest |