### PR TITLE
Auto-update hiredis to v1.4.1

### DIFF
--- a/packages/h/hiredis/xmake.lua
+++ b/packages/h/hiredis/xmake.lua
@@ -5,6 +5,7 @@ package("hiredis")
 
     add_urls("https://github.com/redis/hiredis/archive/refs/tags/$(version).tar.gz",
              "https://github.com/redis/hiredis.git")
+    add_versions("v1.4.1", "ca3180359a8b1275838a45415851f8cd5c411e27bdbf18f4823012e45507d2e4")
     add_versions("v1.4.0", "5fa6e719e59cd4f8ae435c52a18ac4035d135251f9ee54e7a045bccf59107ed8")
     add_versions("v1.3.0", "25cee4500f359cf5cad3b51ed62059aadfc0939b05150c1f19c7e2829123631c")
     add_versions("v1.0.2", "e0ab696e2f07deb4252dda45b703d09854e53b9703c7d52182ce5a22616c3819")


### PR DESCRIPTION
New version of hiredis detected (package version: v1.4.0, last github version: v1.4.1)