### PR TITLE
Auto-update kokkos-kernels to 5.2.0

### DIFF
--- a/packages/k/kokkos-kernels/xmake.lua
+++ b/packages/k/kokkos-kernels/xmake.lua
@@ -6,6 +6,7 @@ package("kokkos-kernels")
     add_urls("https://github.com/kokkos/kokkos-kernels/archive/refs/tags/$(version).tar.gz",
              "https://github.com/kokkos/kokkos-kernels.git")
 
+    add_versions("5.2.0", "083da4c4f69f0b4169c4b295c6dd09642aabbab455caff8d9614d178346e750f")
     add_versions("5.1.1", "d45c30388ff4d4e80edf320f905a6674f4f323a1e2c30d959c596de4623c6644")
     add_versions("5.1.0", "19bc02c0d758eaa6656732ac23ae4c729c1728fcbf3d740d7e0d368617dffbbf")
     add_versions("5.0.2", "bd7fc683bbbaa07a3db07419e480d7adcbe691d6ff3f76717e631b11592c0059")


### PR DESCRIPTION
New version of kokkos-kernels detected (package version: 5.1.1, last github version: 5.2.0)