### PR TITLE
Auto-update aws-c-mqtt to v0.16.1

### DIFF
--- a/packages/a/aws-c-mqtt/xmake.lua
+++ b/packages/a/aws-c-mqtt/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-mqtt")
     add_urls("https://github.com/awslabs/aws-c-mqtt/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-mqtt.git")
 
+    add_versions("v0.16.1", "48fd84e6ff51fdce5cdc4250593d7b0f10db91f8592737c0fe69e0177ee48144")
     add_versions("v0.16.0", "9bc044a9c2f0d80c384ae6a6907c8817e0b40f673f75c4615c83b20f83140374")
     add_versions("v0.15.2", "66f3f5edff4ad1f765a86d3342b6017d0f29f950c1c24f8c1edacdc895202edc")
     add_versions("v0.13.3", "1dfc11d6b3dc1a6d408df64073e8238739b4c50374078d36d3f2d30491d15527")


### PR DESCRIPTION
New version of aws-c-mqtt detected (package version: v0.16.0, last github version: v0.16.1)