### PR TITLE
Auto-update aws-crt-cpp to v0.43.5

### DIFF
--- a/packages/a/aws-crt-cpp/xmake.lua
+++ b/packages/a/aws-crt-cpp/xmake.lua
@@ -6,6 +6,7 @@ package("aws-crt-cpp")
     add_urls("https://github.com/awslabs/aws-crt-cpp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-crt-cpp.git")
 
+    add_versions("v0.43.5", "8c83897fb827527b67377f08a5b349576c50add2406fa1ff372cf2dd16fc00f4")
     add_versions("v0.43.4", "59e508878c5809b446bbe035ac71ea42c6e3b12978bcc2705a01490d1ba62577")
     add_versions("v0.42.1", "bf24fdba415842654f26d36978061812e38d3485e8505d2fabf0a548fcf735c4")
     add_versions("v0.40.1", "697a8fb25167e12e704827e360b4f6b1af8ded48e11ef4d185b9cd72e17479c9")


### PR DESCRIPTION
New version of aws-crt-cpp detected (package version: v0.43.4, last github version: v0.43.5)