### PR TITLE
Auto-update gflags to v2.3.1

### DIFF
--- a/packages/g/gflags/xmake.lua
+++ b/packages/g/gflags/xmake.lua
@@ -5,6 +5,7 @@ package("gflags")
 
     add_urls("https://github.com/gflags/gflags/archive/refs/tags/$(version).tar.gz",
              "https://github.com/gflags/gflags.git")
+    add_versions("v2.3.1", "1b5e0648d7b94021895086e65479b4eaca7935eecfffd7dd9512eb576181c53d")
     add_versions("v2.3.0", "f619a51371f41c0ad6837b2a98af9d4643b3371015d873887f7e8d3237320b2f")
     add_versions("v2.2.2", "34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf")
     add_patches("v2.2.2", "patches/v2.2.2/fix-cmake.patch", "03c256993c42bf8d1f8dfd100d552fda9e0cf000e02f4aee2fd6b33a3563be56")


### PR DESCRIPTION
New version of gflags detected (package version: v2.3.0, last github version: v2.3.1)