### PR TITLE
Auto-update p11-kit to 0.26.5

### DIFF
--- a/packages/p/p11-kit/xmake.lua
+++ b/packages/p/p11-kit/xmake.lua
@@ -6,6 +6,7 @@ package("p11-kit")
     add_urls("https://github.com/p11-glue/p11-kit/releases/download/$(version)/p11-kit-$(version).tar.xz",
              "https://github.com/p11-glue/p11-kit.git")
 
+    add_versions("0.26.5", "f2cc09111e44bf3fea58f023180b33acea90aa82d042d6fbb623fbc5ba033bb7")
     add_versions("0.26.4", "89c3ffb10e076ee036e14732bf6547a1e1c4fb48699a5dee7ceb5ce4f7c0c462")
     add_versions("0.26.2", "09fd9f44da4813a3141e73d5e7cf7008e5660d0405f13d56c15e1da9dcecf828")
     add_versions("0.26.1", "4769f81483a28040cce1dac09a99599f787a8e0dc239a3089d4b0f676b7c4561")


### PR DESCRIPTION
New version of p11-kit detected (package version: 0.26.4, last github version: 0.26.5)