### PR TITLE
Auto-update mongoose to 7.23

### DIFF
--- a/packages/m/mongoose/xmake.lua
+++ b/packages/m/mongoose/xmake.lua
@@ -8,6 +8,7 @@ package("mongoose")
     add_urls("https://github.com/cesanta/mongoose/archive/refs/tags/$(version).tar.gz",
              "https://github.com/cesanta/mongoose.git")
 
+    add_versions("7.23", "93208f164038b05d156935b8b725063e1afb3984a362dbcf3a9ea37b6f1f2255")
     add_versions("7.22", "87727cd2c240ff559b16e9710d44b61ba3513dbee50428bd8ee1596d7c58460a")
     add_versions("7.21", "d4ddbd12c12f223abefcc0a74417a638ae5c118d7cf10ba546553c6b0e0b5ada")
     add_versions("7.20", "ede2371ff4e41e95fd7b2de83a7df727388307a64d3706046ead320defe35e7e")


### PR DESCRIPTION
New version of mongoose detected (package version: 7.22, last github version: 7.23)