### PR TITLE
Auto-update highs to v1.15.1

### DIFF
--- a/packages/h/highs/xmake.lua
+++ b/packages/h/highs/xmake.lua
@@ -6,6 +6,7 @@ package("highs")
     add_urls("https://github.com/ERGO-Code/HiGHS/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ERGO-Code/HiGHS.git")
 
+    add_versions("v1.15.1", "a840d269dff2fafb371dd247df13ad5e026d7ce3b35ad3dc1eedd59bf0c2fb16")
     add_versions("v1.14.0", "05931e8dd8c8cac514da8297003c31a206a0004d542b7da500810b85c87c20b9")
     add_versions("v1.13.1", "d491448e585dbf08cd8945ca5dcbbe3b784d73b9c68eea4e7456274619d56164")
     add_versions("v1.12.0", "cd0daddaca57e66b55524588d715dc62dcee06b5ab9ad186412dc23bc71ae342")


### PR DESCRIPTION
New version of highs detected (package version: v1.14.0, last github version: v1.15.1)