### PR TITLE
Auto-update freerdp to 3.30.0

### DIFF
--- a/packages/f/freerdp/xmake.lua
+++ b/packages/f/freerdp/xmake.lua
@@ -6,6 +6,7 @@ package("freerdp")
     add_urls("https://github.com/FreeRDP/FreeRDP/releases/download/$(version)/freerdp-$(version).tar.gz",
              "https://github.com/FreeRDP/FreeRDP.git")
 
+    add_versions("3.30.0", "e2687d02dea6fede004d36391dac1a74ce57a210f8867fd95033171d4909590c")
     add_versions("3.29.0", "01ceccc39421bfb234cf668dac8f05844a908020dc4a9eebfbc706a64212f230")
     add_versions("3.27.1", "a9f8a75b81f67790df015d0d33c69241a50188092bfb658991ad7780604321bf")
     add_versions("3.26.0", "55fa5c3159399886ba4adbe2c8a10d0b1c0484022efdf3827f68adc478b944d5")


### PR DESCRIPTION
New version of freerdp detected (package version: 3.29.0, last github version: 3.30.0)