### PR TITLE
Auto-update jrl-cmakemodules to v2.3.0

### DIFF
--- a/packages/j/jrl-cmakemodules/xmake.lua
+++ b/packages/j/jrl-cmakemodules/xmake.lua
@@ -7,6 +7,7 @@ package("jrl-cmakemodules")
     add_urls("https://github.com/jrl-umi3218/jrl-cmakemodules/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jrl-umi3218/jrl-cmakemodules.git")
 
+    add_versions("v2.3.0", "840cfba922b9589695ee3da4da3f9472ceeefe8fe4bccbb7ed3e885d1ca978cf")
     add_versions("v2.1.0", "a2427360fd3f0d53bc45b1977eb3d578a0edcb3ba899a508abd930d65762bc74")
     add_versions("v1.1.2", "66cc65863d2f40fcf80881ba6053cb6d7b73f673d46e16c7d1a5eee8b158b897")
 


### PR DESCRIPTION
New version of jrl-cmakemodules detected (package version: v2.1.0, last github version: v2.3.0)