### PR TITLE
[workflow] add Windows support via windows branch

### DIFF
--- a/packages/w/workflow/xmake.lua
+++ b/packages/w/workflow/xmake.lua
@@ -3,13 +3,12 @@ package("workflow")
     set_description("C++ Parallel Computing and Asynchronous Networking Framework")
     set_license("Apache-2.0")
 
+    add_urls("https://github.com/sogou/workflow/archive/refs/tags/$(version).tar.gz",
+             "https://github.com/sogou/workflow.git")
+
     if is_plat("windows") then
-        -- Windows 使用独立 windows 分支（iocp 实现），该分支无 tag，固定 commit 下载
-        add_urls("https://github.com/sogou/workflow/archive/b92ead03ec62609a3cc1293041a9caa58a6b4800.tar.gz")
-        add_versions("v1.0.1", "e560e0ac115a807aa92956355771b1446f2031c8c30d0b4b48a9f77ad285807d")
+        add_versions("v1.0.1", "b92ead03ec62609a3cc1293041a9caa58a6b4800")
     else
-        add_urls("https://github.com/sogou/workflow/archive/refs/tags/$(version).tar.gz",
-                 "https://github.com/sogou/workflow.git")
         add_versions("v1.0.1", "8da09b26e9f138ed98f11e6be7352ae9cc9a1f297135945ccde8a3d997b65508")
         add_versions("v1.0.0", "e163bcdde05e5bf0708d44995a7b8579a947acb8fef9a26e3b6da9b6df63e822")
         add_versions("v0.11.11", "5b526cdd6c2c38c89b1966afca481b54b1342ac1f53b150f2ca0353659ac7efa")
@@ -36,10 +35,7 @@ package("workflow")
     end
 
     on_install("windows", function (package)
-        -- 关闭静态运行时替换，让 workflow 与 xmake 包统一使用动态运行时(/MD)
-        import("package.tools.cmake").install(package, {
-            configs = {WORKFLOW_BUILD_STATIC_RUNTIME = false}
-        })
+        import("package.tools.cmake").install(package, {WORKFLOW_BUILD_STATIC_RUNTIME = "OFF"})
     end)
 
     on_install("linux", "macosx", "android", function (package)

--- a/packages/w/workflow/xmake.lua
+++ b/packages/w/workflow/xmake.lua
@@ -3,32 +3,44 @@ package("workflow")
     set_description("C++ Parallel Computing and Asynchronous Networking Framework")
     set_license("Apache-2.0")
 
-    add_urls("https://github.com/sogou/workflow/archive/refs/tags/$(version).tar.gz",
-             "https://github.com/sogou/workflow.git")
-    
-    add_versions("v1.0.1", "8da09b26e9f138ed98f11e6be7352ae9cc9a1f297135945ccde8a3d997b65508")
-    add_versions("v1.0.0", "e163bcdde05e5bf0708d44995a7b8579a947acb8fef9a26e3b6da9b6df63e822")
-    add_versions("v0.11.11", "5b526cdd6c2c38c89b1966afca481b54b1342ac1f53b150f2ca0353659ac7efa")
-    add_versions("v0.10.6", "5701ef31518a7927e61b26cd6cc1d699cb43393bf1ffc77fa61e73e64d2dd28e")
-    add_versions("v0.10.7", "aa9806983f32174597549db4a129e2ee8a3d1f005923fcbb924906bc70c0e123")
-    add_versions("v0.10.8", "bb5654e8011822d4251a7a433cbe4c5ecfd2c65c8f997a8196685742d24bcaf0")
-    add_versions("v0.10.9", "10f695aeb5da87ae138e3bcd2fa10c18aac782b0da20f11b2fd0b7b091d06767")
-    add_versions("v0.11.1", "06968ed4e43f6676811b620d09eb5c32ac57252305e7e28def6efde8ef1ceb19")
-    add_versions("v0.11.2", "cc2d18ab2b292e2f0163ef67ef6976912e2a21c271396da0e2151ca8cd22abd3")
-    add_versions("v0.11.3", "af7adcdd8151f8e72247599a43c28aa849d61ed39e58058cfa80649d011575bc")
-    add_versions("v0.11.4", "844fd03db120141fa61600b26a4ef35716dc0e75d1e8c8018078eb385cf746a4")
-    add_versions("v0.11.9", "3592c56fd06f08274510c222786ba259e8cce78573d89d22f1e4356bf33fbf77")
+    if is_plat("windows") then
+        -- Windows 使用独立 windows 分支（iocp 实现），该分支无 tag，固定 commit 下载
+        add_urls("https://github.com/sogou/workflow/archive/b92ead03ec62609a3cc1293041a9caa58a6b4800.tar.gz")
+        add_versions("v1.0.1", "e560e0ac115a807aa92956355771b1446f2031c8c30d0b4b48a9f77ad285807d")
+    else
+        add_urls("https://github.com/sogou/workflow/archive/refs/tags/$(version).tar.gz",
+                 "https://github.com/sogou/workflow.git")
+        add_versions("v1.0.1", "8da09b26e9f138ed98f11e6be7352ae9cc9a1f297135945ccde8a3d997b65508")
+        add_versions("v1.0.0", "e163bcdde05e5bf0708d44995a7b8579a947acb8fef9a26e3b6da9b6df63e822")
+        add_versions("v0.11.11", "5b526cdd6c2c38c89b1966afca481b54b1342ac1f53b150f2ca0353659ac7efa")
+        add_versions("v0.10.6", "5701ef31518a7927e61b26cd6cc1d699cb43393bf1ffc77fa61e73e64d2dd28e")
+        add_versions("v0.10.7", "aa9806983f32174597549db4a129e2ee8a3d1f005923fcbb924906bc70c0e123")
+        add_versions("v0.10.8", "bb5654e8011822d4251a7a433cbe4c5ecfd2c65c8f997a8196685742d24bcaf0")
+        add_versions("v0.10.9", "10f695aeb5da87ae138e3bcd2fa10c18aac782b0da20f11b2fd0b7b091d06767")
+        add_versions("v0.11.1", "06968ed4e43f6676811b620d09eb5c32ac57252305e7e28def6efde8ef1ceb19")
+        add_versions("v0.11.2", "cc2d18ab2b292e2f0163ef67ef6976912e2a21c271396da0e2151ca8cd22abd3")
+        add_versions("v0.11.3", "af7adcdd8151f8e72247599a43c28aa849d61ed39e58058cfa80649d011575bc")
+        add_versions("v0.11.4", "844fd03db120141fa61600b26a4ef35716dc0e75d1e8c8018078eb385cf746a4")
+        add_versions("v0.11.9", "3592c56fd06f08274510c222786ba259e8cce78573d89d22f1e4356bf33fbf77")
+    end
 
     add_deps("openssl")
 
     if is_plat("windows") then
         add_deps("cmake")
-        add_syslinks("Mswsock")
+        add_syslinks("ws2_32", "Mswsock")
     end
 
     if is_plat("linux") then
         add_syslinks("pthread", "dl")
     end
+
+    on_install("windows", function (package)
+        -- 关闭静态运行时替换，让 workflow 与 xmake 包统一使用动态运行时(/MD)
+        import("package.tools.cmake").install(package, {
+            configs = {WORKFLOW_BUILD_STATIC_RUNTIME = false}
+        })
+    end)
 
     on_install("linux", "macosx", "android", function (package)
         local configs = {}
@@ -50,5 +62,5 @@ package("workflow")
                 server.stop();
             }
         }
-        ]]}, {configs = {languages = "c++11"}}))
+        ]]}, {configs = {languages = "c++14"}}))
     end)


### PR DESCRIPTION
## Background

workflow's Windows support lives in a separate `windows` branch (iocp-based implementation). That branch has **no tags**, and the master branch's CMake uses GCC flags and does not support MSVC. The current `workflow` package in xmake-repo only supports linux/macosx/android, so it cannot be used on Windows.

## Changes

- On Windows, use the windows branch (pinned commit `b92ead03`, 2026-01-09, maintained by core author Xie Han) + CMake build
- Non-Windows platforms keep the existing master tag logic unchanged (version list and `on_install` untouched)
- Add `ws2_32` system link (Windows socket dependency)
- Disable workflow's default static-runtime substitution (`WORKFLOW_BUILD_STATIC_RUNTIME=OFF`) so it uses the dynamic runtime (/MD) consistently with xmake packages
- `on_test` language standard `c++11` -> `c++14` (windows branch uses `/std:c++14`; c++14 is backward-compatible with master)

## Verification

- Windows (MSVC 2026, x64): compiles; local HTTP server/client round-trip test passes; `go_task` computation task test passes
- Non-Windows platforms: logic unchanged

## Notes

The windows branch has no tags, so the Windows platform pins a commit for download. If the official repo tags the windows branch later, this can be switched to the `$(version)` form.
