### PR TITLE
Auto-update imath to v3.2.3

### DIFF
--- a/packages/i/imath/xmake.lua
+++ b/packages/i/imath/xmake.lua
@@ -6,6 +6,7 @@ package("imath")
     add_urls("https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/$(version).tar.gz",
              "https://github.com/AcademySoftwareFoundation/Imath.git")
 
+    add_versions("v3.2.3", "e10c12b3f21f45bf08e09d4215d9c7691368d747beebd840de0b6fefed2df9f8")
     add_versions("v3.2.2", "b4275d83fb95521510e389b8d13af10298ed5bed1c8e13efd961d91b1105e462")
     add_versions("v3.2.1", "b2c8a44c3e4695b74e9644c76f5f5480767355c6f98cde58ba0e82b4ad8c63ce")
     add_versions("v3.1.12", "8a1bc258f3149b5729c2f4f8ffd337c0e57f09096e4ba9784329f40c4a9035da")


### PR DESCRIPTION
New version of imath detected (package version: v3.2.2, last github version: v3.2.3)