### PR TITLE
Auto-update libgit2 to v1.9.7

### DIFF
--- a/packages/l/libgit2/xmake.lua
+++ b/packages/l/libgit2/xmake.lua
@@ -6,6 +6,7 @@ package("libgit2")
     set_urls("https://github.com/libgit2/libgit2/archive/refs/tags/$(version).tar.gz",
              "https://github.com/libgit2/libgit2.git")
 
+    add_versions("v1.9.7", "1a4fbe7589e814777ae76b64734ad80f4ecad22cd33a22682a2aaea4ae5375e7")
     add_versions("v1.9.6", "a88a42a4ea9bdab7aa8686eead3bf7d9c6dd74529caca16ab22eaa92433d31d9")
     add_versions("v1.9.4", "824b73bd13647800fe4b566a1008ae77fea0e3e3424edab632fcfd8c0b14ba8b")
     add_versions("v1.9.3", "d532172d7ab24d2a25944e2434212d63ee85f3650e97b5f7579e7f201a78ad64")


### PR DESCRIPTION
New version of libgit2 detected (package version: v1.9.6, last github version: v1.9.7)