### PR TITLE
Auto-update aws-checksums to v0.2.11

### DIFF
--- a/packages/a/aws-checksums/xmake.lua
+++ b/packages/a/aws-checksums/xmake.lua
@@ -6,6 +6,7 @@ package("aws-checksums")
     add_urls("https://github.com/awslabs/aws-checksums/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-checksums.git")
 
+    add_versions("v0.2.11", "6917e18b8d6079c02f36478ac59174eb3c47dc3bf040ea63bd93d127837f873f")
     add_versions("v0.2.10", "cb6509f75e42ee25c372a6d379e8582ce5179e5335183842e808f7d8abb0c314")
     add_versions("v0.2.8", "e624754cc57e0da28e643e89fc76bcc86cb0c359ead0745bae643f910b2bcfa7")
     add_versions("v0.2.7", "178e8398d98111f29150f7813a70c20ad97ab30be0de02525440355fe84ccb1d")


### PR DESCRIPTION
New version of aws-checksums detected (package version: v0.2.10, last github version: v0.2.11)