### PR TITLE
Auto-update onednn to v3.13.1

### DIFF
--- a/packages/o/onednn/xmake.lua
+++ b/packages/o/onednn/xmake.lua
@@ -6,6 +6,7 @@ package("onednn")
 
     add_urls("https://github.com/oneapi-src/oneDNN/archive/refs/tags/$(version).tar.gz",
              "https://github.com/oneapi-src/oneDNN.git")
+    add_versions("v3.13.1", "911275081f9cc3406cb3e7754a0f7a8200adcbff09439d6cde0a1e543f343c5b")
     add_versions("v3.12.1", "e1db6e9c3771ba137a6e9292c31870471362977760d0ca00adef2fd39e23840b")
     add_versions("v3.11.3", "7293a85e146c2710dcf4f7257fdebb91020004cf1627c8de684b814c2498c81a")
     add_versions("v3.11", "04df98b18300daf6c3aa7cc2d5e7ce8a8f430fed1787151daed0254d8dd4e64e")


### PR DESCRIPTION
New version of onednn detected (package version: v3.12.1, last github version: v3.13.1)