### PR TITLE
h2o: add missing uv define

### DIFF
--- a/packages/h/h2o/xmake.lua
+++ b/packages/h/h2o/xmake.lua
@@ -44,6 +44,8 @@ package("h2o")
         if package:config("zstd") then
             package:add("deps", "zstd")
         end
+
+        package:add("defines", "H2O_USE_LIBUV=" .. (package:config("uv") and "1" or "0"))
     end)
 
     on_install("linux", function (package)


### PR DESCRIPTION
The defines `H2O_USE_LIBUV` is used in several include files of h2o.
Not defining it breaks some includes.