### PR TITLE
Update nanobind to v3.0.1

### DIFF
--- a/packages/n/nanobind/port/xmake.lua
+++ b/packages/n/nanobind/port/xmake.lua
@@ -27,23 +27,27 @@
 
 add_rules("mode.debug", "mode.release")
 
-add_requires("robin-map", "python >=3.8")
+-- The package recipe selects a version-compatible Python dependency, and
+-- package.tools.xmake forwards that resolved version into this port.
+add_requires("robin-map", "python")
 
 set_languages("c++17")
 
 target("nanobind")
     set_kind("$(kind)")
-    add_files("src/*.cpp|nb_combined.cpp")
+    -- nb_backend.cpp is a standalone split-mode backend module and requires
+    -- NB_BACKEND_NAME; it is not part of the regular nanobind core library.
+    add_files("src/*.cpp|nb_combined.cpp|nb_backend.cpp")
     add_includedirs("include", {public = true})
 
     add_packages("robin-map", "python")
+    add_defines("NB_BUILD")
 
     if is_mode("release") then
         add_defines("NB_COMPACT_ASSERTIONS")
     end
 
     if is_kind("shared") then
-        add_defines("NB_BUILD")
         add_defines("NB_SHARED", {public = true})
 
         if is_plat("macosx") then
@@ -51,6 +55,10 @@ target("nanobind")
         elseif not is_plat("windows") then
             add_shflags("-Wl,-s", {public = true})
         end
+    end
+
+    if not is_plat("windows") then
+        add_cxflags("-fno-strict-aliasing")
     end
 
     add_headerfiles("include/(nanobind/**.h)")

--- a/packages/n/nanobind/xmake.lua
+++ b/packages/n/nanobind/xmake.lua
@@ -6,6 +6,11 @@ package("nanobind")
     set_urls("https://github.com/wjakob/nanobind/archive/refs/tags/$(version).tar.gz",
              "https://github.com/wjakob/nanobind.git", {submodules = false})
 
+    add_versions("v3.0.1", "34ded7cf2292f08a92c45490a095e76334a57751bbae03a8c83241803bf19623")
+    add_versions("v3.0.0", "1e6d9c2b2e746301b5cca1eec9a83338f3412cdec4ffae169fb7a2b2b2a9c734")
+    add_versions("v2.15.0", "36c8760b3acb25643cd89d549782d8c67bd82ce54c6238608787c22a34fd490f")
+    add_versions("v2.14.0", "937b08801b9b61c98192d9ec5ddb712256961fbe8ccc1122d6ee3d574600287c")
+    add_versions("v2.13.0", "cb25a582ccade4b6067bc73c78b84ad9dbd0bbe0e537320711d18015ccafc4ef")
     add_versions("v2.12.0", "01f1f0cd0398743c18f33d07ae36ad410bd7f4a1e90683b508504de897d6e629")
     add_versions("v2.11.0", "62ba05e5f720c76c510d6ab2a77f8ccc17a76c5cea951bea47355a7dfa460449")
     add_versions("v2.10.2", "5bb7f866f6c9c64405308b69de7e7681d8f779323e345bd71a00199c1eaec073")
@@ -15,8 +20,18 @@ package("nanobind")
     add_versions("v2.6.1", "519c6dd56581ad6db9aab814105c2666a0491096487cb384dd20216f80d1a291")
     add_versions("v2.2.0", "bfbfc7e5759f1669e4ddb48752b1ddc5647d1430e94614d6f8626df1d508e65a")
 
-    add_deps("cmake")
-    add_deps("robin-map", "python >=3.8")
+    add_deps("cmake", "robin-map")
+
+    on_load(function (package)
+        local version = package:version()
+        if not version or version:major() >= 3 then
+            package:add("deps", "python >=3.10")
+        elseif version:ge("2.10.0") then
+            package:add("deps", "python >=3.9")
+        else
+            package:add("deps", "python >=3.8")
+        end
+    end)
 
     on_install("windows|x64", "linux", "macosx", "bsd", function (package)
         local builddir = path.join(os.curdir(), "build")


### PR DESCRIPTION
## Summary

- add nanobind releases v2.13.0 through v3.0.1
- select the Python dependency floor required by each nanobind release line
- align the XMake port with the upstream core-library source set and compile definitions

## Testing

- built and imported a minimal extension with all 13 registered nanobind versions on Linux x86_64
- used XMake v3.1.1+HEAD.3ba37a0 and Python 3.12.3
- verified `git diff --check`