### PR TITLE
Auto-update aws-c-cal to v1.0.0

### DIFF
--- a/packages/a/aws-c-auth/xmake.lua
+++ b/packages/a/aws-c-auth/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-auth")
     add_urls("https://github.com/awslabs/aws-c-auth/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-auth.git")
 
+    add_versions("v1.0.0", "12a29eb62c61cef4b38c90d4f0dd2657dc585a15c138d60941d6f20c1ad3b12d")
     add_versions("v0.10.4", "6fb567f496a450d4b6d3f5749d735977a0156957e8ccbca9af7a5ee15d1ffda7")
     add_versions("v0.10.3", "20fc5e75529fadd81fd38b25f9d83798b53ab235ebbac92cdfbb716cfcc7593d")
     add_versions("v0.10.2", "832d2ae61ccd408ef001dd14eb909cc9551a5724211a817688bbb898a60457a7")
@@ -23,7 +24,6 @@ package("aws-c-auth")
     add_versions("v0.7.22", "f249a12a6ac319e929c005fb7efd5534c83d3af3a3a53722626ff60a494054bb")
     add_versions("v0.7.18", "c705199655066f1f874bc3758683f32e288024196a22f28360d336231e45406f")
     add_versions("v0.7.17", "8fe380255a71a2d5c9acd4979c135f9842135ce6385010ea562bc0b532bf5b84")
-    add_versions("v0.7.3", "22e334508b76f1beddefbf877f200c8a5ace4e3956c6be6545b7572762afe8c5")
 
     add_configs("assert_lock_help", {description = "Enable ASSERT_SYNCED_DATA_LOCK_HELD for checking thread issue", default = false, type = "boolean"})
 

--- a/packages/a/aws-c-cal/xmake.lua
+++ b/packages/a/aws-c-cal/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-cal")
     add_urls("https://github.com/awslabs/aws-c-cal/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-cal.git")
 
+    add_versions("v1.0.0", "9c6d424d206dd7822aa44fa39ce31575dcbaa83133620abdac8e56e4cea9667c")
     add_versions("v0.9.15", "215dd31c12ea49c4f40aa7882a800f9648e4095cfcb2d6abdd27e957574ad6e2")
     add_versions("v0.9.14", "0e96e0067fa921768e07b5b4ebad82011ccf474903e9286419ef428d68f317ea")
     add_versions("v0.9.13", "80b7c6087b0af461b4483e4c9483aea2e0dac5d9fb2289b057159ea6032409e1")

--- a/packages/a/aws-c-common/xmake.lua
+++ b/packages/a/aws-c-common/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-common")
     add_urls("https://github.com/awslabs/aws-c-common/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-common.git")
 
+    add_versions("v1.0.0", "94de89f65d4917dd7381679ea3297d7304c43338158fa7bec190fa53c218ce90")
     add_versions("v0.14.5", "103273767fea478545b75a0835c7dc60842baee0a191a112c72f904d22693c84")
     add_versions("v0.14.2", "da518accb60eb08e0d56f641f00c3ea856c36a0972394770c978e5ff3bfc3728")
     add_versions("v0.14.1", "85a05209b324ca330085b84fdada4faf6820592c34f252f0ceb61001f76bf04d")
@@ -33,7 +34,6 @@ package("aws-c-common")
     add_versions("v0.9.15", "8f36c7a6a5d2e17365759d15591f800d3e76dcaa34a226389b92647cbd92393a")
     add_versions("v0.9.14", "70b10ebbf40e3b6c1b36d81d5e4b63fe430414a81f76293a65e42dfa5def571e")
     add_versions("v0.9.13", "6d2044fc58e5d7611610976602f3fc2173676726b00eed026526962c599ece1d")
-    add_versions("v0.9.3", "389eaac7f64d7d5a91ca3decad6810429eb5a65bbba54798b9beffcb4d1d1ed6")
 
     if is_plat("wasm") then
         add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})

--- a/packages/a/aws-c-compression/xmake.lua
+++ b/packages/a/aws-c-compression/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-compression")
     add_urls("https://github.com/awslabs/aws-c-compression/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-compression.git")
 
+    add_versions("v1.0.0", "d8e934da2086bfec41f97a0cff749d926f66ccb90f2052f1d70841916c1bf4d7")
     add_versions("v0.3.3", "33a91db709a547f417b1b23fdb76a64727ee8fb7ed88dd1a43be117f402db356")
     add_versions("v0.3.2", "f93f5a5d8b3fee3a6d97b14ba279efacd4d4016ef9cc7dc4be7d43519ecfbe93")
     add_versions("v0.3.1", "d89fca17a37de762dc34f332d2da402343078da8dbd2224c46a11a88adddf754")

--- a/packages/a/aws-c-event-stream/xmake.lua
+++ b/packages/a/aws-c-event-stream/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-event-stream")
     add_urls("https://github.com/awslabs/aws-c-event-stream/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-event-stream.git")
 
+    add_versions("v1.0.0", "c3817ab04bf9c70fa3582a31243666a9a643ebe45f121f58d5fef5ff4787f8e0")
     add_versions("v0.7.1", "334b2abfe0cb5c68d79d52525598fdd5f6052b93a17a78a4b1ada7fa1be252c0")
     add_versions("v0.7.0", "88835b4c78462547917f622fd9dda45c991b7e356d9c07e2f0537d4d97fbd4fb")
     add_versions("v0.6.0", "af3cd291d831b5fd65f789b7b9d34d856c6a3a5f6f5eb03bc23cffd1792d25e9")
@@ -19,7 +20,6 @@ package("aws-c-event-stream")
     add_versions("v0.4.3", "d7d82c38bae68d2287ac59972a76b2b6159e7a3d7c9b7edb1357495aa4d0c0de")
     add_versions("v0.4.2", "c98b8fa05c2ca10aacfce7327b92a84669c2da95ccb8e7d7b3e3285fcec8beee")
     add_versions("v0.4.1", "f8915fba57c86148f8df4c303ca6f31de6c23375de554ba8d6f9aef2a980e93e")
-    add_versions("v0.3.2", "3134b35a45e9f9d974c2b78ee44fd2ea0aebc04df80236b80692aa63bee2092e")
 
     add_configs("asan", {description = "Enable Address Sanitize.", default = false, type = "boolean"})
 

--- a/packages/a/aws-c-http/xmake.lua
+++ b/packages/a/aws-c-http/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-http")
     add_urls("https://github.com/awslabs/aws-c-http/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-http.git")
 
+    add_versions("v1.0.0", "ae992d9f24a88430cdd4b7538fab565e71faedb1f156f38d6a74f2a77269417f")
     add_versions("v0.11.1", "2988843d5c95d92249d40e59480c2a4376533a91d8e38a5106dc4da5a8720ce5")
     add_versions("v0.11.0", "4ccbdd33c798b590288330dec9e93abe2ff6cfb198b7a4db036c9d362f2e6506")
     add_versions("v0.10.15", "37e7f9806b2877671cfa2bde078c50b78a358f35ef5a07f7bd2ca1beab5b5a9f")
@@ -27,7 +28,6 @@ package("aws-c-http")
     add_versions("v0.8.7", "173ed7634c87485c2defbd9a96a246a79ec3f3659b28b235ac38e6e92d67392a")
     add_versions("v0.8.2", "a76ba75e59e1ac169df3ec00c0d1c453db1a4db85ee8acd3282a85ee63d6b31c")
     add_versions("v0.8.1", "83fb47e2d7956469bb328f16dea96663e96f8f20dc60dc4e9676b82804588530")
-    add_versions("v0.7.12", "0f92f295c96e10aa9c1e66ac73c038ee9d9c61e1be7551e721ee0dab9c89fc6f")
 
     add_deps("cmake")
     add_deps("aws-c-compression")

--- a/packages/a/aws-c-io/xmake.lua
+++ b/packages/a/aws-c-io/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-io")
     add_urls("https://github.com/awslabs/aws-c-io/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-io.git")
 
+    add_versions("v1.0.0", "5fecb19c2c0a165687cdd94723943a02ab23a0270deade5661fd935a3cd55e78")
     add_versions("v0.27.6", "2a6890715ccecaa0df6e9d074b186a7156b35360ded9db973064e2e00d45fcc3")
     add_versions("v0.27.5", "aa132d5a728f18ab8e0a6ea96d3d2f7e66bc8d3fe029d9ed1b05c06aa0c5b900")
     add_versions("v0.27.4", "0f2ce32de3685ca5ba3a8395d461c783253c1718cf70d31378eb6be890db1e3e")
@@ -38,7 +39,6 @@ package("aws-c-io")
     add_versions("v0.14.7", "ecf1f660d7d43913aa8a416be6a2027101ce87c3b241344342d608335b4df7d4")
     add_versions("v0.14.6", "bb3af305af748185b1c7b17afa343e54f2d494ccff397402f1b17041b0967865")
     add_versions("v0.14.5", "2700bcde062f7de1c1cbfd236b9fdfc9b24b4aa6dc0fb09bb156e16e07ebd0b6")
-    add_versions("v0.13.32", "2a6b18c544d014ca4f55cb96002dbbc1e52a2120541c809fa974cb0838ea72cc")
 
     add_configs("s2n", {description = "Use s2n-tls as TLS backend.", default = is_plat("macosx") or is_plat("linux"), type = "boolean"})
 

--- a/packages/a/aws-c-mqtt/xmake.lua
+++ b/packages/a/aws-c-mqtt/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-mqtt")
     add_urls("https://github.com/awslabs/aws-c-mqtt/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-mqtt.git")
 
+    add_versions("v1.0.0", "28d9d9edd5f643b5a8db4e4f116c09d0781fd3715341ad3b039da3233a3d7b12")
     add_versions("v0.16.1", "48fd84e6ff51fdce5cdc4250593d7b0f10db91f8592737c0fe69e0177ee48144")
     add_versions("v0.16.0", "9bc044a9c2f0d80c384ae6a6907c8817e0b40f673f75c4615c83b20f83140374")
     add_versions("v0.15.2", "66f3f5edff4ad1f765a86d3342b6017d0f29f950c1c24f8c1edacdc895202edc")
@@ -18,7 +19,6 @@ package("aws-c-mqtt")
     add_versions("v0.10.6", "7579fafc74a8751c15c0196eda6ec93d00a17e7f79fb994f34a8f62ceb66cc62")
     add_versions("v0.10.4", "6a41456f9eee15d71e4e2ee162b354865809f26620f1e6e5acb237f190f77f3f")
     add_versions("v0.10.3", "bb938d794b0757d669b5877526363dc6f6f0e43869ca19fc196ffd0f7a35f5b9")
-    add_versions("v0.9.5", "987289535d3c988fe949f49d81268736c96fe27b27c98c899f0a148577f6627b")
 
     add_configs("asan", {description = "Enable Address Sanitize.", default = false, type = "boolean"})
     add_configs("assert_lock_help", {description = "Enable ASSERT_SYNCED_DATA_LOCK_HELD for checking thread issue", default = false, type = "boolean"})

--- a/packages/a/aws-c-s3/xmake.lua
+++ b/packages/a/aws-c-s3/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-s3")
     add_urls("https://github.com/awslabs/aws-c-s3/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-s3.git")
 
+    add_versions("v1.0.0", "3b76d8ff35201a892a5e9a9c523d1f4d05381b3132d4e60728c634efae142f12")
     add_versions("v0.13.5", "d61313aa30575141afd9dfb207b7594e30d0473885719417c7c8a2a53d3ebb5f")
     add_versions("v0.13.1", "30cd8deec12a6995b8dda32d8f3a53b3c1f2d2dcad56287aab64dfee80eb7630")
     add_versions("v0.12.7", "daa717ccac1136cf73b69cd4057d3d302b4037f0ebfa6552a8f532f79f8032f8")
@@ -36,7 +37,6 @@ package("aws-c-s3")
     add_versions("v0.6.0", "0a29dbb13ea003de3fd0d08a61fa705b1c753db4b35de9c464641432000f13ec")
     add_versions("v0.5.9", "7a337195b295406658d163b6dac64ff81f7556291b8a8e79e58ebaa2d55178ee")
     add_versions("v0.5.7", "2f2eab9bf90a319030fd3525953dc7ac00c8dc8c0d33e3f0338f2a3b554d3b6a")
-    add_versions("v0.3.17", "72fd93a2f9a7d9f205d66890da249944b86f9528216dc0321be153bf19b2ecd5")
 
     add_configs("assert_lock_help", {description = "Enable ASSERT_SYNCED_DATA_LOCK_HELD for checking thread issue", default = false, type = "boolean"})
 

--- a/packages/a/aws-c-sdkutils/xmake.lua
+++ b/packages/a/aws-c-sdkutils/xmake.lua
@@ -6,6 +6,7 @@ package("aws-c-sdkutils")
     add_urls("https://github.com/awslabs/aws-c-sdkutils/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-c-sdkutils.git")
 
+    add_versions("v1.0.0", "ddf9d09ba137ad0697afe1c09f5d778d6b2f1aadb277dffd231ff615ae34bc82")
     add_versions("v0.2.9", "14fe900f80c3b9f5e53a783d9ac0865ed9ba1ae63b67744b9f82a8b3194a4388")
     add_versions("v0.2.7", "802b8c4169da2b4cf5c48f9598fb778faccd3e052e443a482089193411c2b7bb")
     add_versions("v0.2.6", "673e78e9d029f31213f74eea6fb90c3750063cdec73729906e9017b0f8c95f78")

--- a/packages/a/aws-checksums/xmake.lua
+++ b/packages/a/aws-checksums/xmake.lua
@@ -6,6 +6,7 @@ package("aws-checksums")
     add_urls("https://github.com/awslabs/aws-checksums/archive/refs/tags/$(version).tar.gz",
              "https://github.com/awslabs/aws-checksums.git")
 
+    add_versions("v1.0.0", "6c058812f5b537ce58eac1e529f441ff387a652ea62cbe9b844f9188339221b1")
     add_versions("v0.2.11", "6917e18b8d6079c02f36478ac59174eb3c47dc3bf040ea63bd93d127837f873f")
     add_versions("v0.2.10", "cb6509f75e42ee25c372a6d379e8582ce5179e5335183842e808f7d8abb0c314")
     add_versions("v0.2.8", "e624754cc57e0da28e643e89fc76bcc86cb0c359ead0745bae643f910b2bcfa7")


### PR DESCRIPTION
New version of aws-c-cal detected (package version: v0.9.15, last github version: v1.0.0)