### PR TITLE
Auto-update raylib-cpp to v6.0.3

### DIFF
--- a/packages/r/raylib-cpp/xmake.lua
+++ b/packages/r/raylib-cpp/xmake.lua
@@ -7,6 +7,7 @@ package("raylib-cpp")
     add_urls("https://github.com/RobLoach/raylib-cpp/archive/refs/tags/$(version).tar.gz", 
              "https://github.com/RobLoach/raylib-cpp.git")
 
+    add_versions("v6.0.3", "7eacb90823449ff4d8785807c6cd08d852492be9bf6b1d85113724e0e85f2cc4")
     add_versions("v6.0.2", "66f9e4f41d916f75ee2efef5d24a1d73a26af9e84fe3d874f9952bb71beb1696")
     add_versions("v6.0.1", "ebfa63c4a9a25ac81efb54189f03622249bdfcd736da28cfdc7c15340608de8d")
     add_versions("v6.0.0", "42e1378a56a8440b6ca048640e75763b64afd51a8a0ca3a5baff032761338300")


### PR DESCRIPTION
New version of raylib-cpp detected (package version: v6.0.2, last github version: v6.0.3)