### PR TITLE
Auto-update snmalloc to 0.7.5

### DIFF
--- a/packages/s/snmalloc/xmake.lua
+++ b/packages/s/snmalloc/xmake.lua
@@ -6,6 +6,7 @@ package("snmalloc")
     add_urls("https://github.com/microsoft/snmalloc/archive/refs/tags/$(version).tar.gz",
              "https://github.com/microsoft/snmalloc.git")
 
+    add_versions("0.7.5", "6efb0daa33fd1c0b406915786041fbce7176562cdfe74aa68baf90a77c451619")
     add_versions("0.7.4", "32e4e457dc69bc3c58ab1793dda3615dc015f46b37156e46d160a74e849acca4")
     add_versions("0.7.3", "a908b604a77213169b526ab96a64a79c222a03a41a87f13ac00adfeff379f0be")
     add_versions("0.7.1", "91824fdf553f03cf6ef8be57f29f1d4f79cd651667455e9fe4af8b7c09e705d3")


### PR DESCRIPTION
New version of snmalloc detected (package version: 0.7.4, last github version: 0.7.5)