### PR TITLE
Auto-update liquid-dsp to v1.8.2

### DIFF
--- a/packages/l/liquid-dsp/xmake.lua
+++ b/packages/l/liquid-dsp/xmake.lua
@@ -6,6 +6,7 @@ package("liquid-dsp")
     add_urls("https://github.com/jgaeddert/liquid-dsp/archive/refs/tags/$(version).tar.gz",
              "https://github.com/jgaeddert/liquid-dsp.git")
 
+    add_versions("v1.8.2", "a0adbc3ec5630d620a55351285573f59948153a14c703fb64b4ad58989bd6e2f")
     add_versions("v1.7.0", "33c42ebc2e6088570421e282c6332e899705d42b4f73ebd1212e6a11da714dd4")
 
     add_configs("simd", {description = "Build SIMD extensions", default = false, type = "boolean"})


### PR DESCRIPTION
New version of liquid-dsp detected (package version: v1.7.0, last github version: v1.8.2)