### PR TITLE
Auto-update iowow to v1.5.1

### DIFF
--- a/packages/i/iowow/xmake.lua
+++ b/packages/i/iowow/xmake.lua
@@ -6,6 +6,7 @@ package("iowow")
     add_urls("https://github.com/Softmotions/iowow/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Softmotions/iowow.git")
 
+    add_versions("v1.5.1", "6a5205f36f502e03528e545c98df4f6996276418670ed0ff175cd71566ffea88")
     add_versions("v1.4.18", "ef4ee56dd77ce326fff25b6f41e7d78303322cca3f11cf5683ce9abfda34faf9")
     add_versions("v1.4.17", "13a851026dbc1f31583fba96986e86e94a7554f9e7d38aa12a9ea5dbebdf328b")
 


### PR DESCRIPTION
New version of iowow detected (package version: v1.4.18, last github version: v1.5.1)