### PR TITLE
feat(eui-neo): sync v0.5.8 package recipe

### DIFF
--- a/packages/e/eui-neo/port/xmake.lua
+++ b/packages/e/eui-neo/port/xmake.lua
@@ -1,14 +1,47 @@
 set_project("EUI-NEO")
-set_version("0.5.5")
+set_version("0.5.8")
 set_xmakever("2.9.0")
 set_languages("c99", "cxx17")
 
 option("window_backend", {default = "glfw", values = {"glfw", "sdl2"}, description = "Window backend: glfw or sdl2"})
 option("render_backend", {default = "opengl", values = {"auto", "opengl", "vulkan"}, description = "Render backend: auto, opengl, or vulkan"})
+option("app_runner", {default = false, description = "Build the EUI application runner (defines main)."})
 option("shared", {default = false, description = "Build eui_neo as a shared library instead of a static library."})
 option("modules", {default = true, description = "Build optional EUI-NEO modules when their directories are present."})
 option("markdown", {default = true, description = "Enable MD4C Markdown parsing support."})
+option("tray", {default = false, description = "Enable the system tray backend."})
 option("vulkan_low_latency", {default = false, description = "Prefer low-latency Vulkan presentation when available."})
+
+function eui_discover_macos_vulkan_sdk()
+    if not is_plat("macosx") then
+        return
+    end
+    if (os.getenv("VULKAN_SDK") or "") ~= "" or (os.getenv("VK_SDK_PATH") or "") ~= "" then
+        return
+    end
+
+    import("lib.detect.find_tool")
+    local brew = find_tool("brew")
+    if not brew then
+        return
+    end
+    local prefix = try {function()
+        return os.iorunv(brew.program, {"--prefix"}):trim()
+    end}
+    if not prefix or prefix == "" then
+        return
+    end
+
+    local header = path.join(prefix, "include", "vulkan", "vulkan.h")
+    local library = path.join(prefix, "lib", "libvulkan.dylib")
+    if os.isfile(header) and os.isfile(library) then
+        os.setenv("VULKAN_SDK", prefix)
+        os.setenv("VK_SDK_PATH", prefix)
+        print("Vulkan SDK: using Homebrew prefix %s", prefix)
+    end
+end
+
+eui_discover_macos_vulkan_sdk()
 
 local render_backend = get_config("render_backend") or "opengl"
 if render_backend == "auto" then
@@ -24,32 +57,107 @@ local window_backend = get_config("window_backend") or "glfw"
 local build_shared  = get_config("shared") and true or false
 local build_modules = get_config("modules") and true or false
 local enable_markdown = get_config("markdown") and true or false
+local enable_tray = get_config("tray") and true or false
 local vk_low_latency  = get_config("vulkan_low_latency") and true or false
+local configured_platform = get_config("plat")
+local target_is_windows = is_plat("windows") or is_plat("mingw")
+    or configured_platform == "windows" or configured_platform == "mingw"
+    or (not configured_platform and os.host() == "windows")
+local target_is_linux = is_plat("linux") or configured_platform == "linux"
+    or (not configured_platform and os.host() == "linux")
+local target_is_macos = is_plat("macosx") or configured_platform == "macosx"
+    or (not configured_platform and os.host() == "macosx")
 
 print("EUI render backend: requested=%s, resolved=%s", get_config("render_backend") or "opengl", render_backend)
 print("EUI window backend: %s", window_backend)
 
-add_requires("freetype", {configs = {png = true, zlib = true, bzip2 = false, harfbuzz = false, brotli = false}})
-add_requires("libpng", "zlib")
-
-if window_backend == "glfw" then
-    add_requires("glfw", {configs = {shared = false}})
-end
 if window_backend == "sdl2" then
-    add_requires("sdl2", {configs = {shared = false}})
+    add_requires("libsdl2", {configs = {shared = false}})
 end
 if render_backend == "vulkan" then
-    add_requires("vulkan")
+    add_requires("vulkansdk", {system = true})
 end
-if not is_plat("windows") then
+if not target_is_windows then
     add_requires("libcurl", {configs = {shared = false}})
+end
+
+target("eui_zlib")
+    set_kind("static")
+    add_files("3rd/zlib-1.3.1/adler32.c", "3rd/zlib-1.3.1/compress.c", "3rd/zlib-1.3.1/crc32.c", "3rd/zlib-1.3.1/deflate.c", "3rd/zlib-1.3.1/gzclose.c", "3rd/zlib-1.3.1/gzlib.c", "3rd/zlib-1.3.1/gzread.c", "3rd/zlib-1.3.1/gzwrite.c", "3rd/zlib-1.3.1/inflate.c", "3rd/zlib-1.3.1/infback.c", "3rd/zlib-1.3.1/inffast.c", "3rd/zlib-1.3.1/inftrees.c", "3rd/zlib-1.3.1/trees.c", "3rd/zlib-1.3.1/uncompr.c", "3rd/zlib-1.3.1/zutil.c", {sourcekind = "cc"})
+    add_includedirs("3rd/zlib-1.3.1", {public = true})
+    if not target_is_windows then add_defines("HAVE_UNISTD_H") else add_defines("_CRT_SECURE_NO_WARNINGS") end
+target_end()
+
+target("eui_libpng")
+    set_kind("static")
+    add_files("3rd/libpng-1.6.43/png.c", "3rd/libpng-1.6.43/pngerror.c", "3rd/libpng-1.6.43/pngget.c", "3rd/libpng-1.6.43/pngmem.c", "3rd/libpng-1.6.43/pngpread.c", "3rd/libpng-1.6.43/pngread.c", "3rd/libpng-1.6.43/pngrio.c", "3rd/libpng-1.6.43/pngrtran.c", "3rd/libpng-1.6.43/pngrutil.c", "3rd/libpng-1.6.43/pngset.c", "3rd/libpng-1.6.43/pngtrans.c", "3rd/libpng-1.6.43/pngwio.c", "3rd/libpng-1.6.43/pngwrite.c", "3rd/libpng-1.6.43/pngwtran.c", "3rd/libpng-1.6.43/pngwutil.c", {sourcekind = "cc"})
+    add_includedirs("3rd/libpng-1.6.43", "3rd/libpng-1.6.43/scripts", {public = true})
+    add_deps("eui_zlib", {public = true})
+    if is_arch("arm64", "aarch64") then
+        add_files(
+            "3rd/libpng-1.6.43/arm/arm_init.c",
+            "3rd/libpng-1.6.43/arm/filter_neon_intrinsics.c",
+            "3rd/libpng-1.6.43/arm/palette_neon_intrinsics.c",
+            {sourcekind = "cc"}
+        )
+    end
+    on_load(function(target)
+        local generated_header = path.join(target:autogendir(), "pnglibconf.h")
+        os.mkdir(path.directory(generated_header))
+        os.cp("3rd/libpng-1.6.43/scripts/pnglibconf.h.prebuilt", generated_header)
+        target:add("includedirs", target:autogendir(), {public = true})
+    end)
+target_end()
+
+target("eui_freetype")
+    set_kind("static")
+    add_files("3rd/freetype/src/autofit/autofit.c", "3rd/freetype/src/base/ftbase.c", "3rd/freetype/src/base/ftbbox.c", "3rd/freetype/src/base/ftbdf.c", "3rd/freetype/src/base/ftbitmap.c", "3rd/freetype/src/base/ftcid.c", "3rd/freetype/src/base/ftfstype.c", "3rd/freetype/src/base/ftgasp.c", "3rd/freetype/src/base/ftglyph.c", "3rd/freetype/src/base/ftgxval.c", "3rd/freetype/src/base/ftinit.c", "3rd/freetype/src/base/ftmm.c", "3rd/freetype/src/base/ftotval.c", "3rd/freetype/src/base/ftpatent.c", "3rd/freetype/src/base/ftpfr.c", "3rd/freetype/src/base/ftstroke.c", "3rd/freetype/src/base/ftsynth.c", "3rd/freetype/src/base/fttype1.c", "3rd/freetype/src/base/ftwinfnt.c", "3rd/freetype/src/bdf/bdf.c", "3rd/freetype/src/bzip2/ftbzip2.c", "3rd/freetype/src/cache/ftcache.c", "3rd/freetype/src/cff/cff.c", "3rd/freetype/src/cid/type1cid.c", "3rd/freetype/src/gzip/ftgzip.c", "3rd/freetype/src/lzw/ftlzw.c", "3rd/freetype/src/pcf/pcf.c", "3rd/freetype/src/pfr/pfr.c", "3rd/freetype/src/psaux/psaux.c", "3rd/freetype/src/pshinter/pshinter.c", "3rd/freetype/src/psnames/psnames.c", "3rd/freetype/src/raster/raster.c", "3rd/freetype/src/sdf/sdf.c", "3rd/freetype/src/sfnt/sfnt.c", "3rd/freetype/src/smooth/smooth.c", "3rd/freetype/src/svg/svg.c", "3rd/freetype/src/truetype/truetype.c", "3rd/freetype/src/type1/type1.c", "3rd/freetype/src/type42/type42.c", "3rd/freetype/src/winfonts/winfnt.c", {sourcekind = "cc"})
+    if target_is_windows then
+        add_files("3rd/freetype/builds/windows/ftsystem.c", "3rd/freetype/builds/windows/ftdebug.c", {sourcekind = "cc"})
+    elseif target_is_linux or target_is_macos then
+        add_files("3rd/freetype/builds/unix/ftsystem.c", "3rd/freetype/src/base/ftdebug.c", {sourcekind = "cc"})
+        add_defines("HAVE_UNISTD_H", "HAVE_FCNTL_H")
+    else
+        add_files("3rd/freetype/src/base/ftsystem.c", "3rd/freetype/src/base/ftdebug.c", {sourcekind = "cc"})
+    end
+    add_includedirs("3rd/freetype/include", {public = true})
+    add_includedirs("3rd/libpng-1.6.43", "3rd/libpng-1.6.43/scripts")
+    add_defines("FT2_BUILD_LIBRARY", "FT_CONFIG_OPTION_USE_PNG")
+    add_deps("eui_libpng", {public = true})
+target_end()
+
+if window_backend == "glfw" then
+    target("eui_glfw")
+        set_kind("static")
+        add_files("3rd/glfw/src/context.c", "3rd/glfw/src/init.c", "3rd/glfw/src/input.c", "3rd/glfw/src/monitor.c", "3rd/glfw/src/platform.c", "3rd/glfw/src/vulkan.c", "3rd/glfw/src/window.c", "3rd/glfw/src/egl_context.c", "3rd/glfw/src/osmesa_context.c", "3rd/glfw/src/null_init.c", "3rd/glfw/src/null_monitor.c", "3rd/glfw/src/null_window.c", "3rd/glfw/src/null_joystick.c", {sourcekind = "cc"})
+        add_includedirs("3rd/glfw/include", {public = true})
+        add_includedirs("3rd/glfw/src")
+        if target_is_windows then
+            add_files("3rd/glfw/src/win32_module.c", "3rd/glfw/src/win32_time.c", "3rd/glfw/src/win32_thread.c", "3rd/glfw/src/win32_init.c", "3rd/glfw/src/win32_joystick.c", "3rd/glfw/src/win32_monitor.c", "3rd/glfw/src/win32_window.c", "3rd/glfw/src/wgl_context.c", {sourcekind = "cc"})
+            add_defines("_GLFW_WIN32", "UNICODE", "_UNICODE")
+            add_syslinks("gdi32", {public = true})
+            if is_plat("mingw") or configured_platform == "mingw" then
+                add_defines("WINVER=0x0501")
+                add_includedirs("3rd/glfw/deps/mingw")
+            end
+        elseif target_is_macos then
+            add_files("3rd/glfw/src/posix_module.c", "3rd/glfw/src/cocoa_time.c", "3rd/glfw/src/posix_thread.c", {sourcekind = "cc"})
+            add_files("3rd/glfw/src/cocoa_init.m", "3rd/glfw/src/cocoa_joystick.m", "3rd/glfw/src/cocoa_monitor.m", "3rd/glfw/src/cocoa_window.m", "3rd/glfw/src/nsgl_context.m", {sourcekind = "mm"})
+            add_defines("_GLFW_COCOA")
+            add_mflags("-fno-objc-arc")
+            add_frameworks("Cocoa", "IOKit", "CoreFoundation", {public = true})
+        elseif target_is_linux then
+            add_files("3rd/glfw/src/posix_module.c", "3rd/glfw/src/posix_time.c", "3rd/glfw/src/posix_thread.c", "3rd/glfw/src/posix_poll.c", "3rd/glfw/src/linux_joystick.c", "3rd/glfw/src/x11_init.c", "3rd/glfw/src/x11_monitor.c", "3rd/glfw/src/x11_window.c", "3rd/glfw/src/xkb_unicode.c", "3rd/glfw/src/glx_context.c", {sourcekind = "cc"})
+            add_defines("_GLFW_X11", "_DEFAULT_SOURCE")
+            add_syslinks("X11", "Xrandr", "Xinerama", "Xi", "Xcursor", "Xext", "dl", "m", "rt", {public = true})
+        end
+    target_end()
 end
 
 if render_backend == "opengl" then
     target("eui_glad")
         set_kind("static")
-        add_files("3rd/glad/src/glad.c",
-            {force = {cxflags = {is_plat("windows") and "/TC" or ""}}})
+        add_files("3rd/glad/src/glad.c", {sourcekind = "cc"})
         add_includedirs("3rd/glad/include", {public = true})
     target_end()
 end
@@ -57,8 +165,7 @@ end
 if enable_markdown then
     target("eui_md4c")
         set_kind("static")
-        add_files("3rd/md4c/src/md4c.c",
-            {force = {cxflags = {is_plat("windows") and "/TC" or ""}}})
+        add_files("3rd/md4c/src/md4c.c", {sourcekind = "cc"})
         add_includedirs("3rd/md4c/src", {public = true})
     target_end()
 end
@@ -74,6 +181,7 @@ target("eui_neo")
         "core/platform/performance_stats.cpp",
         "core/platform/platform.cpp",
         "core/render/image.cpp",
+        "core/render/image_stream.cpp",
         "core/render/image_facade.cpp",
         "core/render/image_source.cpp",
         "core/render/primitive.cpp",
@@ -83,13 +191,13 @@ target("eui_neo")
         "core/render/shadertoy_primitive.cpp",
         "core/render/stb_image_impl.cpp",
         "core/render/text.cpp",
-        "core/window/window_backend.cpp"
+        "core/window/window_backend.cpp",
+        "core/window/window_input_backend.cpp"
     )
 
+    -- GCC/MinGW already treats .c files as C.  Do not pass MSVC's /TC
+    -- switch when the target platform is Windows with a MinGW toolchain.
     local c_flags = {}
-    if is_plat("windows") then
-        table.insert(c_flags, "/TC")
-    end
 
     local bridge_flags = table.copy(c_flags)
     if is_plat("macosx") then
@@ -97,9 +205,9 @@ target("eui_neo")
         table.insert(bridge_flags, "objective-c")
     end
 
-    add_files("3rd/yyjson-0.12.0/src/yyjson.c", {force = {cxflags = c_flags}})
+    add_files("3rd/yyjson-0.12.0/src/yyjson.c", {sourcekind = "cc", force = {cxflags = c_flags}})
     add_files("core/platform/native_bridge.c", "core/platform/tray_bridge.c",
-        {force = {cxflags = bridge_flags}})
+        {sourcekind = "cc", force = {cxflags = bridge_flags}})
 
     if render_backend == "opengl" then
         add_files(
@@ -123,7 +231,7 @@ target("eui_neo")
 
     if window_backend == "glfw" then
         add_files("core/platform/ime_bridge.c",
-            {force = {cxflags = bridge_flags}})
+            {sourcekind = "cc", force = {cxflags = bridge_flags}})
     end
 
     add_includedirs("include", ".", "3rd/tray", {public = true})
@@ -152,12 +260,39 @@ target("eui_neo")
         add_syslinks("objc", {public = true})
     end
 
+    on_load(function (target)
+        if not is_plat("linux") or not enable_tray then
+            return
+        end
+        import("package.manager.find_package")
+        local function apply(result, define)
+            target:add("defines", define, {public = true})
+            if result.includedirs then target:add("includedirs", result.includedirs, {public = true}) end
+            if result.linkdirs then target:add("linkdirs", result.linkdirs, {public = true}) end
+            if result.links then target:add("links", result.links, {public = true}) end
+        end
+        local gio = find_package("pkgconfig::gio-2.0")
+        if gio then
+            apply(gio, "EUI_TRAY_SNI=1")
+            return
+        end
+        local appindicator = find_package("pkgconfig::appindicator3-0.1")
+        if appindicator then
+            apply(appindicator, "EUI_TRAY_APPINDICATOR=1")
+            return
+        end
+        os.raise("Linux tray support requires glib/gio (gio-2.0, preferred, SNI backend) " ..
+                 "or GTK3 + libappindicator (legacy fallback), detected via pkg-config, " ..
+                 "but none of them were found. Install your distribution's glib2 development " ..
+                 "package, or configure with --tray=n to build without tray support.")
+    end)
+
     if enable_markdown then
         add_defines("EUI_HAS_MD4C=1", {public = true})
         add_deps("eui_md4c")
     end
 
-    add_packages("freetype", "libpng", "zlib", {public = true})
+    add_deps("eui_freetype", {public = true})
     if render_backend == "opengl" then
         add_deps("eui_glad")
         if is_plat("windows") then
@@ -168,19 +303,19 @@ target("eui_neo")
             add_frameworks("OpenGL", {public = true})
         end
     elseif render_backend == "vulkan" then
-        add_packages("vulkan", {public = true})
+        add_packages("vulkansdk", {public = true})
     end
     if window_backend == "glfw" then
-        add_packages("glfw", {public = true})
+        add_deps("eui_glfw", {public = true})
     elseif window_backend == "sdl2" then
-        add_packages("sdl2", {public = true})
+        add_packages("libsdl2", {public = true})
     end
     add_packages("libcurl", {public = true, optional = true})
-    if not is_plat("windows", "mingw") and has_package("libcurl") then
+    if not target_is_windows and has_package("libcurl") then
         add_defines("EUI_HAS_CURL=1", {public = true})
     end
 
-    if not is_plat("windows", "mingw") then
+    if not target_is_windows then
         add_syslinks("pthread", {public = true})
     end
 
@@ -196,17 +331,28 @@ target("eui_neo")
         add_installfiles("3rd/md4c/src/md4c.h", {prefixdir = "include"})
     end
 
-    if is_plat("windows") then
-        add_cxflags("/utf-8")
-        if not is_mode("debug") then
-            add_cxflags("/O1", "/GS-", "/sdl-", "/wd4819")
-        end
-    else
-        if not is_mode("debug") then
-            add_cxxflags("-Os", "-fno-exceptions", "-fno-rtti")
-        end
+    if not is_mode("debug") then
+        add_cxxflags("-Os", "-fno-exceptions", "-fno-rtti")
     end
 target_end()
+
+if get_config("app_runner") then
+    local app_main_source
+    if window_backend == "sdl2" then
+        app_main_source = "core/app/sdl2_app_main.cpp"
+    else
+        app_main_source = "core/app/glfw_app_main.cpp"
+    end
+
+    target("eui_app")
+        set_kind("static")
+        set_group("framework")
+        add_files(app_main_source)
+        add_includedirs("include", ".")
+        add_deps("eui_neo", {public = true})
+        add_defines("EUI_APP_RUNNER_LIBRARY=1")
+    target_end()
+end
 
 if build_modules then
     if os.exists("modules/keyboard/keyboard.h") then
@@ -234,15 +380,8 @@ if build_modules then
             add_files("modules/serial/serial.cpp")
             add_includedirs("modules/serial", {public = true})
             add_deps("eui_neo")
-            if is_plat("windows") then
-                add_cxflags("/utf-8")
-                if not is_mode("debug") then
-                    add_cxflags("/O1", "/GS-", "/sdl-", "/wd4819")
-                end
-            else
-                if not is_mode("debug") then
-                    add_cxxflags("-Os", "-fno-exceptions", "-fno-rtti")
-                end
+            if not is_mode("debug") then
+                add_cxxflags("-Os", "-fno-exceptions", "-fno-rtti")
             end
         target_end()
     end

--- a/packages/e/eui-neo/xmake.lua
+++ b/packages/e/eui-neo/xmake.lua
@@ -6,7 +6,7 @@ package("eui-neo")
     add_urls("https://github.com/sudoevolve/EUI-NEO/archive/refs/tags/$(version).tar.gz")
     add_urls("https://github.com/sudoevolve/EUI-NEO.git", {alias = "git", submodules = false})
 
-    add_versions("v0.5.8", "274dad0018d42e20223391654f612625d4b1fa4f649d5c9c7ac498773b904c95")
+    add_versions("v0.5.8", "004d46f34d986030b1351080b381bcc48053eb24ebbdf52602b78364f285cd38")
     add_versions("v0.5.7", "2d3ec0a36e34b98d13dbdaf67afa4fe178cb4b52841eb17529517cb48be43551")
     add_versions("v0.5.6", "0df8d79897a480566b0989060f206431d12c4a83eb7aef50b8e5d21f1676abf8")
     add_versions("v0.5.5", "cf0da91d7544fe406b704922137fd4d55ed080b3e647501e0ca5303abb00eb98")

--- a/packages/e/eui-neo/xmake.lua
+++ b/packages/e/eui-neo/xmake.lua
@@ -6,7 +6,7 @@ package("eui-neo")
     add_urls("https://github.com/sudoevolve/EUI-NEO/archive/refs/tags/$(version).tar.gz")
     add_urls("https://github.com/sudoevolve/EUI-NEO.git", {alias = "git", submodules = false})
 
-    add_versions("v0.5.8", "2c511fd76a488fac6e39c2f2fd7f40ece40df0dd66a4e76c8d4358c255facc28")
+    add_versions("v0.5.8", "274dad0018d42e20223391654f612625d4b1fa4f649d5c9c7ac498773b904c95")
     add_versions("v0.5.7", "2d3ec0a36e34b98d13dbdaf67afa4fe178cb4b52841eb17529517cb48be43551")
     add_versions("v0.5.6", "0df8d79897a480566b0989060f206431d12c4a83eb7aef50b8e5d21f1676abf8")
     add_versions("v0.5.5", "cf0da91d7544fe406b704922137fd4d55ed080b3e647501e0ca5303abb00eb98")

--- a/packages/e/eui-neo/xmake.lua
+++ b/packages/e/eui-neo/xmake.lua
@@ -3,48 +3,93 @@ package("eui-neo")
     set_description("Cross-platform, high-performance, low-overhead C++17 GPUI framework")
     set_license("Apache-2.0")
 
-    add_urls("https://github.com/sudoevolve/EUI-NEO/archive/refs/tags/$(version).tar.gz",
-             "https://github.com/sudoevolve/EUI-NEO.git")
+    add_urls("https://github.com/sudoevolve/EUI-NEO/archive/refs/tags/$(version).tar.gz")
+    add_urls("https://github.com/sudoevolve/EUI-NEO.git", {alias = "git", submodules = false})
 
+    add_versions("v0.5.8", "2c511fd76a488fac6e39c2f2fd7f40ece40df0dd66a4e76c8d4358c255facc28")
     add_versions("v0.5.7", "2d3ec0a36e34b98d13dbdaf67afa4fe178cb4b52841eb17529517cb48be43551")
     add_versions("v0.5.6", "0df8d79897a480566b0989060f206431d12c4a83eb7aef50b8e5d21f1676abf8")
     add_versions("v0.5.5", "cf0da91d7544fe406b704922137fd4d55ed080b3e647501e0ca5303abb00eb98")
 
     add_configs("window_backend", {description = "Window backend", default = "glfw", values = {"glfw", "sdl2"}})
     add_configs("render_backend", {description = "Render backend", default = "opengl", values = {"auto", "opengl", "vulkan"}})
+    add_configs("app_runner", {description = "Build the EUI application runner (defines main)", default = false, type = "boolean"})
     add_configs("markdown", {description = "Enable MD4C Markdown parsing support", default = true, type = "boolean"})
+    add_configs("tray", {description = "Enable the system tray backend", default = false, type = "boolean"})
     add_configs("vulkan_low_latency", {description = "Prefer low-latency Vulkan presentation", default = false, type = "boolean"})
+    add_configs("port_revision", {description = "Internal package port revision", default = "13", values = {"13"}, readonly = true})
 
-    add_deps("freetype", "libpng", "zlib")
-
-    if is_plat("windows", "mingw") then
-        add_syslinks("imm32", "urlmon", "comdlg32")
+    if is_plat("windows") or is_plat("mingw") then
+        add_syslinks("winmm", "urlmon", "shell32", "user32", "imm32", "pdh", "comdlg32", "gdi32")
     end
 
     on_load(function(package)
-        if package:config("window_backend") == "glfw" then
-            package:add("deps", "glfw")
+        if package:is_plat("macosx") and
+            (os.getenv("VULKAN_SDK") or "") == "" and
+            (os.getenv("VK_SDK_PATH") or "") == "" then
+            import("lib.detect.find_tool")
+            local brew = find_tool("brew")
+            if brew then
+                local prefix = try {function()
+                    return os.iorunv(brew.program, {"--prefix"}):trim()
+                end}
+                if prefix and prefix ~= "" and
+                    os.isfile(path.join(prefix, "include", "vulkan", "vulkan.h")) and
+                    os.isfile(path.join(prefix, "lib", "libvulkan.dylib")) then
+                    os.setenv("VULKAN_SDK", prefix)
+                    os.setenv("VK_SDK_PATH", prefix)
+                    print("Vulkan SDK: using Homebrew prefix %s", prefix)
+                end
+            end
+        end
+        if package:is_plat("macosx") then
+            package:add("frameworks", "Cocoa", "IOKit", "CoreFoundation")
+            package:add("syslinks", "objc")
         end
         if package:config("window_backend") == "sdl2" then
-            package:add("deps", "sdl2")
+            package:add("deps", "libsdl2")
         end
         if package:config("render_backend") == "opengl" then
-            package:add("deps", "glad")
+            package:add("links", "eui_glad")
         end
         if package:config("render_backend") == "vulkan" then
-            package:add("deps", "vulkan")
+            package:add("deps", "vulkansdk", {system = true})
         end
         if not package:is_plat("windows", "mingw") then
             package:add("deps", "libcurl")
         end
+        if package:config("app_runner") then package:add("links", "eui_app") end
+        package:add("links", "eui_neo", "eui_freetype", "eui_libpng", "eui_zlib")
+        if package:config("window_backend") == "glfw" then package:add("links", "eui_glfw") end
+        if package:config("markdown") then package:add("links", "eui_md4c") end
+        if package:config("render_backend") == "opengl" then
+            if package:is_plat("windows") or package:is_plat("mingw") then
+                package:add("syslinks", "opengl32")
+            elseif package:is_plat("linux") then
+                package:add("syslinks", "GL")
+            elseif package:is_plat("macosx") then
+                package:add("frameworks", "OpenGL")
+            end
+        end
+        if package:config("window_backend") == "glfw" and package:is_plat("linux") then
+            package:add("syslinks", "X11", "Xrandr", "Xinerama", "Xi", "Xcursor", "Xext", "dl", "m", "rt")
+        end
+        if package:config("app_runner") then package:add("defines", "EUI_APP_RUNNER=1") end
     end)
 
     on_install("windows", "mingw", "linux", "macosx", function(package)
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
+        if package:is_plat("windows") then
+            local empty_plugins = path.join(package:builddir(), "empty-bfd-plugins")
+            os.mkdir(empty_plugins)
+            os.setenv("BFD_PLUGIN_PATH", empty_plugins)
+        end
         local configs = {}
         configs.window_backend = package:config("window_backend")
         configs.render_backend = package:config("render_backend")
+        configs.app_runner = package:config("app_runner")
         configs.markdown = package:config("markdown")
+        configs.tray = package:config("tray")
         configs.vulkan_low_latency = package:config("vulkan_low_latency")
         import("package.tools.xmake").install(package, configs)
     end)


### PR DESCRIPTION
同步 EUI-NEO v0.5.8 发布包配方与 port。\n\n变更包括：\n- 更新 v0.5.8 release checksum\n- 同步 bundled GLFW/glad/FreeType/libpng/zlib 构建\n- 支持 app_runner、GLFW/SDL2、OpenGL/Vulkan 配置\n- 包含 Windows MinGW、macOS Cocoa/Vulkan、Linux GLFW/tray 修复\n- 保持包版本为 v0.5.8，不引入开发分支源码