### PR TITLE
Auto-update aws-lc to v5.8.0

### DIFF
--- a/packages/a/aws-lc/xmake.lua
+++ b/packages/a/aws-lc/xmake.lua
@@ -6,6 +6,7 @@ package("aws-lc")
     add_urls("https://github.com/aws/aws-lc/archive/refs/tags/$(version).tar.gz",
              "https://github.com/aws/aws-lc.git")
 
+    add_versions("v5.8.0", "04d9aa258641265099a3b1fbd37a21866e942943e16619087bf79c0b6e08f64e")
     add_versions("v5.6.0", "2348c404dcb1166c09034aceb840bef21af440ae469cbc994f11ab57dd043d26")
     add_versions("v5.5.0", "d79a5beb1c2f7fd86a17d91eb230ae12da71dc28bedeb775c179863cf279c650")
     add_versions("v5.3.0", "57a94720571684b824a34cc5746f75d91c7c25617259e24e0d92c935111833e9")


### PR DESCRIPTION
New version of aws-lc detected (package version: v5.6.0, last github version: v5.8.0)