### PR TITLE
ci: stop publishing repology index to gh-pages

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -48,28 +48,3 @@ jobs:
           export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
           xmake l -vD ./scripts/sync.lua
           xmake l -vD ./scripts/automerge.lua
-
-      - name: Build and publish repology_packages_index.json
-        run: |
-          set -e
-          export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
-
-          # 1. Generate the manifest (writes dist/repology_packages_index.json).
-          xmake l scripts/build_index.lua
-
-          # 2. Sanity-check the output before publishing.
-          test -s dist/repology_packages_index.json
-          python3 -c "import json,sys; d=json.load(open('dist/repology_packages_index.json')); assert d['count']>1000, 'too few packages: %d' % d['count']"
-
-          # 3. Publish to gh-pages via SSH (SSH key was installed above).
-          rm -rf gh-pages-work
-          git clone git@github.com:xmake-io/xmake-repo.git gh-pages-work
-          cd gh-pages-work
-          git checkout gh-pages 2>/dev/null || git checkout --orphan gh-pages
-          git rm -rf . 2>/dev/null || true
-          cp ../dist/repology_packages_index.json .
-          git add repology_packages_index.json
-          git diff-index --quiet HEAD -- && echo "no changes to publish" || {
-              git commit -m "autoupdate repology_packages_index.json"
-              git push origin gh-pages
-          }


### PR DESCRIPTION
Repology now consumes the index from https://packages.xmake.io/repology_packages_index.json instead of the gh-pages branch of this repo:

- repology/repology-updater#1631 (merged) — switched the xrepo ruleset URL to packages.xmake.io
- xmake-io/xmake-packages-index#2 — the wrapper that builds and publishes the index

`scripts/build_index.lua` is kept — it is still called by the wrapper from xmake-packages-index.

The `gh-pages` branch of this repo is no longer consumed by anything and can be deleted at your discretion.