### PR TITLE
Auto-update sentry-native to 0.16.5

### DIFF
--- a/packages/s/sentry-native/xmake.lua
+++ b/packages/s/sentry-native/xmake.lua
@@ -6,6 +6,7 @@ package("sentry-native")
     set_urls("https://github.com/getsentry/sentry-native/releases/download/$(version)/sentry-native.zip",
              "https://github.com/getsentry/sentry-native.git")
 
+    add_versions("0.16.5", "802ec0643df32e53c1268f5b544cb289b8880a8506f83ad58f753dc69bd803de")
     add_versions("0.16.1", "8cd6daa3f896186f2f559129ec6badf7eecf44e5fa1a444c175b75b4b866fea0")
     add_versions("0.15.3", "5feccee8b53167352e234cdee217f050c5f23679b6d661e829f77dfee023327c")
     add_versions("0.15.2", "ead664dc2ec5fa09692ce512611eecf3c29e15eaa892b72492480ca938e3651f")


### PR DESCRIPTION
New version of sentry-native detected (package version: 0.16.1, last github version: 0.16.5)