### PR TITLE
update homepage urls flagged by repology (batch 1: avisynthplus, bento4, cello, ck, libraw, libuv, lua, mujs, pcg-cpp)

### DIFF
--- a/packages/a/avisynthplus/xmake.lua
+++ b/packages/a/avisynthplus/xmake.lua
@@ -1,5 +1,5 @@
 package("avisynthplus")
-    set_homepage("http://avs-plus.net")
+    set_homepage("https://avs-plus.net/")
     set_description("AviSynth with improvements")
     set_license("GPL-2.0")
 

--- a/packages/b/bento4/xmake.lua
+++ b/packages/b/bento4/xmake.lua
@@ -1,5 +1,5 @@
 package("bento4")
-    set_homepage("http://www.bento4.com")
+    set_homepage("https://www.bento4.com/")
     set_description("Full-featured MP4 format, MPEG DASH, HLS, CMAF SDK and tools")
 
     add_urls("https://github.com/axiomatic-systems/Bento4.git")

--- a/packages/c/cello/xmake.lua
+++ b/packages/c/cello/xmake.lua
@@ -1,5 +1,5 @@
 package("cello")
-    set_homepage("http://libcello.org/")
+    set_homepage("https://libcello.org/")
     set_description("Higher level programming in C")
 
     add_urls("https://github.com/orangeduck/Cello/archive/refs/tags/$(version).tar.gz",

--- a/packages/c/ck/xmake.lua
+++ b/packages/c/ck/xmake.lua
@@ -1,5 +1,5 @@
 package("ck")
-    set_homepage("http://concurrencykit.org/")
+    set_homepage("https://concurrencykit.org/")
     set_description("Concurrency primitives, safe memory reclamation mechanisms and non-blocking (including lock-free) data structures designed to aid in the research, design and implementation of high performance concurrent systems developed in C99+.")
 
     add_urls("https://github.com/concurrencykit/ck/archive/refs/tags/$(version).tar.gz",

--- a/packages/l/libraw/xmake.lua
+++ b/packages/l/libraw/xmake.lua
@@ -1,5 +1,5 @@
 package("libraw")
-    set_homepage("http://www.libraw.org")
+    set_homepage("https://www.libraw.org/")
     set_description("LibRaw is a library for reading RAW files from digital cameras.")
     set_license("LGPL-2.1")
 

--- a/packages/l/libuv/xmake.lua
+++ b/packages/l/libuv/xmake.lua
@@ -1,5 +1,5 @@
 package("libuv")
-    set_homepage("http://libuv.org/")
+    set_homepage("https://libuv.org/")
     set_description("A multi-platform support library with a focus on asynchronous I/O.")
     set_license("MIT")
 

--- a/packages/l/lua/xmake.lua
+++ b/packages/l/lua/xmake.lua
@@ -1,6 +1,6 @@
 package("lua")
 
-    set_homepage("http://lua.org")
+    set_homepage("https://lua.org/")
     set_description("A powerful, efficient, lightweight, embeddable scripting language.")
 
     add_urls("https://www.lua.org/ftp/lua-$(version).tar.gz", {version = function (version)

--- a/packages/m/mujs/xmake.lua
+++ b/packages/m/mujs/xmake.lua
@@ -1,5 +1,5 @@
 package("mujs")
-    set_homepage("http://mujs.com/")
+    set_homepage("https://mujs.com/")
     set_description("An embeddable Javascript interpreter in C.")
     set_license("ISC")
 

--- a/packages/p/pcg-cpp/xmake.lua
+++ b/packages/p/pcg-cpp/xmake.lua
@@ -1,6 +1,6 @@
 package("pcg-cpp")
     set_kind("library", {headeronly = true})
-    set_homepage("http://www.pcg-random.org")
+    set_homepage("https://www.pcg-random.org/")
     set_description("PCG — C++ Implementation")
     set_license("Apache-2.0")
 


### PR DESCRIPTION
Follow-up to #10763, split into small batches as requested there. This is batch 1 of ~5: nine packages, one `set_homepage` line each — http → https, targets verified live (HTTP 200). All nine packages built successfully in the CI runs of #10763.

Next batches will follow one at a time as the previous one lands, keeping known-problematic packages (pre-existing build failures like e2fsprogs on macOS or pqp with modern GCC) isolated in their own batches.