### PR TITLE
Fix homepage `alembic`

### DIFF
--- a/packages/a/ace/xmake.lua
+++ b/packages/a/ace/xmake.lua
@@ -1,5 +1,5 @@
 package("ace")
-    set_homepage("https://www.dre.vanderbilt.edu/~schmidt/ACE.html")
+    set_homepage("https://github.com/DOCGroup/ACE_TAO")
     set_description("ACE (ADAPTIVE Communication Environment) is a C++ framework for implementing distributed and networked applications.")
     set_license("DOC")
 

--- a/packages/a/ace/xmake.lua
+++ b/packages/a/ace/xmake.lua
@@ -1,5 +1,5 @@
 package("ace")
-    set_homepage("https://github.com/DOCGroup/ACE_TAO")
+    set_homepage("https://www.dre.vanderbilt.edu/~schmidt/ACE.html")
     set_description("ACE (ADAPTIVE Communication Environment) is a C++ framework for implementing distributed and networked applications.")
     set_license("DOC")
 

--- a/packages/a/alembic/xmake.lua
+++ b/packages/a/alembic/xmake.lua
@@ -1,5 +1,5 @@
 package("alembic")
-    set_homepage("https://alembic.io/")
+    set_homepage("https://www.alembic.io/")
     set_description("Open framework for storing and sharing scene data that includes a C++ library, a file format, and client plugins and applications.")
     set_license("BSD-3-Clause")
 


### PR DESCRIPTION
[alembic](https://github.com/xmake-io/xmake-repo/tree/dev/packages/a/alembic)	-	Homepage link https://alembic.io/ is [dead](https://repology.org/link/https://alembic.io/) (SSL error: certificate issued for different hostname) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).

Reference: https://repology.org/repository/xrepo/problems?end=alembic