### PR TITLE
Fix homepage `zziplib`

### DIFF
--- a/packages/z/zziplib/xmake.lua
+++ b/packages/z/zziplib/xmake.lua
@@ -1,5 +1,5 @@
 package("zziplib")
-    set_homepage("http://zziplib.sourceforge.net/")
+    set_homepage("https://zziplib.sourceforge.net/")
     set_description("The zziplib library is intentionally lightweight, it offers the ability to easily extract data from files archived in a single zip file.")
     set_license("GPL-2.0")
 


### PR DESCRIPTION
[zziplib](https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/packages/z/zziplib/xmake.lua)	-	Homepage link http://zziplib.sourceforge.net/ is a permanent redirect to its HTTPS counterpart https://zziplib.sourceforge.net/ and should be updated.

Reference: https://repology.org/repository/xrepo/problems?start=zziplib