### PR TITLE
Fix homepage `libpqxx`

### DIFF
--- a/packages/l/libpqxx/xmake.lua
+++ b/packages/l/libpqxx/xmake.lua
@@ -1,5 +1,5 @@
 package("libpqxx")
-    set_homepage("http://pqxx.org/libpqxx/")
+    set_homepage("https://pqxx.org/libpqxx/")
     set_description("The official C++ client API for PostgreSQL.")
     set_license("BSD-3-Clause")
 


### PR DESCRIPTION
[libpqxx](https://github.com/xmake-io/xmake-repo/blob/dev/packages/l/libpqxx/xmake.lua)	-	Homepage link http://pqxx.org/libpqxx/ is a permanent redirect to its HTTPS counterpart https://pqxx.org/libpqxx/ and should be updated.