### PR TITLE
Update homepage URL for sentry-native package

### DIFF
--- a/packages/s/sentry-native/xmake.lua
+++ b/packages/s/sentry-native/xmake.lua
@@ -1,5 +1,5 @@
 package("sentry-native")
-    set_homepage("https://sentry.io/")
+    set_homepage("https://docs.sentry.io/")
     set_description("Sentry SDK for C, C++ and native applications.")
     set_license("MIT")
 

--- a/packages/s/sentry-native/xmake.lua
+++ b/packages/s/sentry-native/xmake.lua
@@ -1,5 +1,5 @@
 package("sentry-native")
-    set_homepage("https://sentry.io/welcome/")
+    set_homepage("https://sentry.io/")
     set_description("Sentry SDK for C, C++ and native applications.")
     set_license("MIT")
 


### PR DESCRIPTION
[sentry-native](https://github.com/xmake-io/xmake-repo/blob/dev/packages/s/sentry-native/xmake.lua)	-	Homepage link https://sentry.io/welcome/ is [dead](https://repology.org/link/https://sentry.io/welcome/) (HTTP 403) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).

Reference: https://repology.org/repository/xrepo/problems?start=sentry-native
I do not know why this is marked as that but Ill update to vcpkg's homepage that anyway would redirect to that welcome webpage.

https://repology.org/repository/vcpkg/problems mentions that is not either solution, so I would try to `https://docs.sentry.io/`