### PR TITLE
taglib: Update homepage URL to use HTTPS

### DIFF
--- a/packages/t/taglib/xmake.lua
+++ b/packages/t/taglib/xmake.lua
@@ -1,5 +1,5 @@
 package("taglib")
-    set_homepage("http://taglib.org/")
+    set_homepage("https://taglib.org/")
     set_description("TagLib Audio Meta-Data Library")
     set_license("LGPL-2.1")
 


### PR DESCRIPTION
[taglib](https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/packages/t/taglib/xmake.lua)	-	Homepage link http://taglib.org/ is a permanent redirect to its HTTPS counterpart https://taglib.org/ and should be updated.