### PR TITLE
raylib: Update raylib homepage URL to HTTPS

### DIFF
--- a/packages/r/raylib/xmake.lua
+++ b/packages/r/raylib/xmake.lua
@@ -1,5 +1,5 @@
 package("raylib")
-    set_homepage("http://www.raylib.com")
+    set_homepage("https://www.raylib.com/")
     set_description("A simple and easy-to-use library to enjoy videogames programming.")
     set_license("zlib")
 


### PR DESCRIPTION
[raylib](https://github.com/xmake-io/xmake-repo/blob/dev/packages/r/raylib/xmake.lua)	-	Homepage link http://www.raylib.com/ is a permanent redirect to its HTTPS counterpart https://www.raylib.com/ and should be updated.