### PR TITLE
usd: Update homepage URL for usd package

### DIFF
--- a/packages/u/usd/xmake.lua
+++ b/packages/u/usd/xmake.lua
@@ -1,5 +1,5 @@
 package("usd")
-    set_homepage("http://www.openusd.org")
+    set_homepage("https://www.openusd.org/")
     set_description("Universal Scene Description")
     set_license("Apache-2.0")
 


### PR DESCRIPTION
[usd](https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/packages/u/usd/xmake.lua)	-	Homepage link http://www.openusd.org/ is a permanent redirect to its HTTPS counterpart https://www.openusd.org/ and should be updated.