### PR TITLE
Update homepage URL for unicorn package

### DIFF
--- a/packages/u/unicorn/xmake.lua
+++ b/packages/u/unicorn/xmake.lua
@@ -1,5 +1,5 @@
 package("unicorn")
-    set_homepage("http://www.unicorn-engine.org")
+    set_homepage("https://www.unicorn-engine.org/")
     set_description("Unicorn CPU emulator framework (ARM, AArch64, M68K, Mips, Sparc, PowerPC, RiscV, S390x, TriCore, X86)")
     set_license("GPL-2.0")
 


### PR DESCRIPTION
[unicorn](https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/packages/u/unicorn/xmake.lua)	-	Homepage link http://www.unicorn-engine.org/ is a permanent redirect to its HTTPS counterpart https://www.unicorn-engine.org/ and should be updated.

