### PR TITLE
Fix homepage URL in rapidxml package

### DIFF
--- a/packages/r/rapidxml/xmake.lua
+++ b/packages/r/rapidxml/xmake.lua
@@ -1,6 +1,6 @@
 package("rapidxml")
     set_kind("library", {headeronly = true})
-    set_homepage("https://sourceforge.net/projects/rapidxml")
+    set_homepage("https://sourceforge.net/projects/rapidxml/")
     set_description("An attempt to create the fastest XML parser possible")
     set_license("MIT")
 


### PR DESCRIPTION
[rapidxml](https://github.com/xmake-io/xmake-repo/tree/dev/packages/r/rapidxml)	-	Homepage link https://sourceforge.net/projects/rapidxml needs a trailing slash added, otherwise there's a javascript redirect.

https://github.com/xmake-io/xmake/pull/7758