### PR TITLE
sqlite3: always build the shell

### DIFF
--- a/packages/s/sqlite3/xmake.lua
+++ b/packages/s/sqlite3/xmake.lua
@@ -112,19 +112,22 @@ package("sqlite3")
                 if is_kind("shared") and is_plat("windows") then
                     add_defines("SQLITE_API=__declspec(dllexport)")
                 end
-                if is_plat("macosx", "linux", "bsd") then
+                if is_plat("cross", "macosx", "linux", "bsd") then
                     add_syslinks("pthread", "dl")
                 end
         ]]
-        if package:is_plat(os.host()) and (package:is_arch(os.arch()) or package:is_plat("windows")) then
-            xmake_lua = xmake_lua .. [[
-                target("sqlite3_shell")
-                    set_kind("binary")
-                    set_basename("sqlite3")
-                    add_files("shell.c")
-                    add_deps("sqlite3")
-            ]]
-        end
+        xmake_lua = xmake_lua .. [[
+            target("sqlite3_shell")
+                set_kind("binary")
+                set_basename("sqlite3")
+                add_files("shell.c")
+                add_deps("sqlite3")
+
+                -- system() api is unavailable in the apple embedded sdks.
+                if is_plat("iphoneos", "watchos", "appletvos", "applexros") then
+                    add_defines("SQLITE_NOHAVE_SYSTEM")
+                end
+        ]]
         io.writefile("xmake.lua", xmake_lua)
 
         local configs = {}


### PR DESCRIPTION
# sqlite3: always build the shell

The shell is gated on a condition that no commit has ever explained:

```lua
if package:is_plat(os.host()) and (package:is_arch(os.arch()) or package:is_plat("windows")) then
```

## The problem

A `mingw` target on a Windows host does not get `sqlite3.exe`, even though what it produces is a native binary that runs on the machine that just built it. It fails both halves of the test:

| | package | host |
|---|---|---|
| plat | `mingw` | `windows` |
| arch | `x86_64` | `x64` |

The `or package:is_plat("windows")` escape does not help either — it keys on the platform name, and mingw is not called windows.

The failure is silent. The target is simply not emitted: the package installs, its `on_test` passes, and nothing in the manifest or the install tree records that the shell was skipped — the package just has no `bin/`. Whatever expects that file discovers the omission wherever the file is first used, which is usually far from the package and long after the install reported success.

## Where the condition came from

The line has been touched exactly twice, and neither commit explains it. There is no comment in the code either.

| Date | Commit | PR | Change |
|---|---|---|---|
| 2022-08-18 | `5f12d3e60` | #1412 *update libtiff, libdeflate, nlohmann_json, simage* | introduced the shell with `if is_plat(os.host()) and is_arch(os.arch())` |
| 2022-08-19 | `e33511f5b` | #1420 *add proj* | changed it to `package:is_plat(...)` and added `or package:is_plat("windows")` |

It arrived inside a five-in-one batch update whose only note on the subject is the line `* add sqlite3 shell`.

The second commit is the more telling one. It came from an unrelated "add proj" PR and what it actually fixed was a **scope** bug: `is_plat()` is the project-scope global, so inside a package script it asks about the platform of the project being built, not about the package's target platform. The condition was asking the wrong object on the day it was written; a drive-by fix corrected the scope a day later, kept the model, and tacked the windows escape on at the same time.

## Why remove it rather than make it more accurate

`shell.c` is an ordinary C file linking a static library. It has no platform-specific dependency and cross compiles exactly as readily as the library does, and the result is valid for the target it was built for. In terms of *can this be built*, the condition has no basis.

What it actually asks is whether the shell can run **on the build machine** — and that is the consumer's question, not the package's. xmake already has a way to say it:

```lua
add_deps("sqlite3", {host = true})
```

Twenty-nine packages in this repository use that mechanism (`aubio` on `pkgconf`, `aui` on `aui-toolbox`, `adaptive_cpp` on `llvm`, …). Having the dependency decide this for every consumer costs the ones who are cross compiling a perfectly valid artifact.

So the gate goes, and the shell is built like anything else the package produces.

## An omission the gate was hiding

Building the shell everywhere brings out an inconsistency that has been there all along:

```lua
-- package level
if is_plat("cross", "macosx", "linux", "bsd") then    -- has cross
    add_syslinks("pthread", "dl")

-- inside the generated project
if is_plat("macosx", "linux", "bsd") then             -- no cross
    add_syslinks("pthread", "dl")
```

Under `cross`, the generated `sqlite3` target does not get `pthread`/`dl`. A static library does not link, so the omission never surfaced; a binary does. This PR makes the two lists agree.

## Behaviour change

Cross builds now produce the shell as well: a few seconds of build time and one extra file. In exchange the behaviour is predictable, and a consumer that cannot have the shell finds out at install time instead of receiving a confusing error several steps later.

If an explicit opt-out is preferred, this can be `add_configs("shell"...)` instead. I have not proposed it because it invites an argument about what the default should be, and consumers who do not want the shell can simply not use `bin/`.

## Testing

Built from scratch on a Windows host targeting `mingw` (`x86_64`, msys2 gcc): `sqlite3.exe` is produced, links, and packages correctly.
