### PR TITLE
Update BlueZ homepage URL

### DIFF
--- a/packages/b/bluez/xmake.lua
+++ b/packages/b/bluez/xmake.lua
@@ -1,5 +1,5 @@
 package("bluez")
-    set_homepage("http://www.bluez.org")
+    set_homepage("https://bluez.github.io/")
     set_description("Library for the Bluetooth protocol stack for Linux")
     set_license("GPL-2.0-or-later")
 


### PR DESCRIPTION
[bluez](https://github.com/xmake-io/xmake-repo/tree/dev/packages/b/bluez)	-	Homepage link http://www.bluez.org/ is [dead](https://repology.org/link/http://www.bluez.org/) (server disconnected) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).