### PR TITLE
Update homepage URL for zstd package

### DIFF
--- a/packages/z/zstd/xmake.lua
+++ b/packages/z/zstd/xmake.lua
@@ -1,5 +1,5 @@
 package("zstd")
-    set_homepage("https://www.zstd.net/")
+    set_homepage("https://facebook.github.io/zstd/")
     set_description("Zstandard - Fast real-time compression algorithm")
     set_license("BSD-3-Clause")
 


### PR DESCRIPTION
[zstd](https://github.com/xmake-io/xmake-repo/blob/dev/packages/z/zstd/xmake.lua)	-	Homepage link https://www.zstd.net/ is [dead](https://repology.org/link/https://www.zstd.net/) (connection reset by peer) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).