### PR TITLE
fast-cdr: Update homepage URL to GitHub repository

### DIFF
--- a/packages/f/fast-cdr/xmake.lua
+++ b/packages/f/fast-cdr/xmake.lua
@@ -1,5 +1,5 @@
 package("fast-cdr")
-    set_homepage("https://www.eprosima.com")
+    set_homepage("https://github.com/eProsima/Fast-CDR")
     set_description("eProsima FastCDR library provides two serialization mechanisms. One is the standard CDR serialization mechanism, while the other is a faster implementation of it.")
     set_license("Apache-2.0")
 


### PR DESCRIPTION
[fast-cdr](https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/packages/f/fast-cdr/xmake.lua)	-	Homepage link https://www.eprosima.com/ is [dead](https://repology.org/link/https://www.eprosima.com/) (HTTP 403) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).