### PR TITLE
cryptopp: Update homepage URL to GitHub repository

### DIFF
--- a/packages/c/cryptopp/patches/8.9.0/msvc.patch
+++ b/packages/c/cryptopp/patches/8.9.0/msvc.patch
@@ -1,0 +1,33 @@
+diff --git a/integer.cpp b/integer.cpp
+index bf95ac7..8a06279 100644
+--- a/integer.cpp
++++ b/integer.cpp
+@@ -3056,7 +3056,7 @@ Integer::Integer(const byte *encodedInteger, size_t byteCount, Signedness s, Byt
+ 	else
+ 	{
+ 		SecByteBlock block(byteCount);
+-#if (CRYPTOPP_MSC_VERSION >= 1500)
++#if (CRYPTOPP_MSC_VERSION >= 1500) && (CRYPTOPP_MSC_VERSION < 1938)
+ 		std::reverse_copy(encodedInteger, encodedInteger+byteCount,
+ 			stdext::make_checked_array_iterator(block.begin(), block.size()));
+ #else
+diff --git a/zdeflate.cpp b/zdeflate.cpp
+index b3514b5..2121198 100644
+--- a/zdeflate.cpp
++++ b/zdeflate.cpp
+@@ -412,13 +412,8 @@ unsigned int Deflator::LongestMatch(unsigned int &bestMatch) const
+ 		if (scan[bestLength-1] == match[bestLength-1] && scan[bestLength] == match[bestLength] && scan[0] == match[0] && scan[1] == match[1])
+ 		{
+ 			CRYPTOPP_ASSERT(scan[2] == match[2]);
+-			unsigned int len = (unsigned int)(
+-#if defined(_STDEXT_BEGIN) && !(defined(CRYPTOPP_MSC_VERSION) && (CRYPTOPP_MSC_VERSION < 1400 || CRYPTOPP_MSC_VERSION >= 1600)) && !defined(_STLPORT_VERSION)
+-				stdext::unchecked_mismatch
+-#else
+-				std::mismatch
+-#endif
+-#if CRYPTOPP_MSC_VERSION >= 1600
++			unsigned int len = (unsigned int)(std::mismatch
++#if (CRYPTOPP_MSC_VERSION >= 1600) && (CRYPTOPP_MSC_VERSION < 1938)
+ 				(stdext::make_unchecked_array_iterator(scan)+3, stdext::make_unchecked_array_iterator(scanEnd), stdext::make_unchecked_array_iterator(match)+3).first - stdext::make_unchecked_array_iterator(scan));
+ #else
+ 				(scan+3, scanEnd, match+3).first - scan);

--- a/packages/c/cryptopp/xmake.lua
+++ b/packages/c/cryptopp/xmake.lua
@@ -16,6 +16,8 @@ package("cryptopp")
     add_resources("8.5.0", "cryptopp_cmake", "https://github.com/noloader/cryptopp-cmake/archive/CRYPTOPP_8_5_0.tar.gz", "10685209405e676993873fcf638ade5f8f99d7949afa6b2045289ce9cc6d90ac")
     add_resources("8.4.0", "cryptopp_cmake", "https://github.com/noloader/cryptopp-cmake/archive/CRYPTOPP_8_4_0.tar.gz", "b850070141f6724fce640e4e2cfde433ec5b2d99d4386d29ba9255167bc4b4f0")
 
+    add_patches("8.9.0", "patches/8.9.0/msvc.patch", "f2a9f0817e4a8234ea07f8779fd95a70273c025d306788bb155301633a1bc9ba")
+
     if is_plat("mingw") and is_subhost("msys") then
         add_extsources("pacman::crypto++")
     elseif is_plat("linux") then

--- a/packages/c/cryptopp/xmake.lua
+++ b/packages/c/cryptopp/xmake.lua
@@ -1,5 +1,5 @@
 package("cryptopp")
-    set_homepage("https://cryptopp.com/")
+    set_homepage("https://github.com/weidai11/cryptopp")
     set_description("free C++ class library of cryptographic schemes")
 
     add_urls("https://github.com/weidai11/cryptopp.git")


### PR DESCRIPTION
[cryptopp](https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/packages/c/cryptopp/xmake.lua)	-	Homepage link https://cryptopp.com/ is [dead](https://repology.org/link/https://cryptopp.com/) (timeout) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).