### PR TITLE
Update homepage URL for OpenJPEG package

### DIFF
--- a/packages/o/openjpeg/xmake.lua
+++ b/packages/o/openjpeg/xmake.lua
@@ -1,5 +1,5 @@
 package("openjpeg")
-    set_homepage("http://www.openjpeg.org/")
+    set_homepage("https://www.openjpeg.org/")
     set_description("OpenJPEG is an open-source JPEG 2000 codec written in C language.")
     set_license("BSD-2-Clause")
 


### PR DESCRIPTION
[openjpeg](https://github.com/xmake-io/xmake-repo/tree/dev/packages/o/openjpeg)	-	Homepage link http://www.openjpeg.org/ is a permanent redirect to its HTTPS counterpart https://www.openjpeg.org/ and should be updated.

Reference - https://repology.org/repository/xrepo/problems