### PR TITLE
Auto-update unity_test to v2.7.0

### DIFF
--- a/packages/u/unity_test/xmake.lua
+++ b/packages/u/unity_test/xmake.lua
@@ -6,6 +6,7 @@ package("unity_test")
     add_urls("https://github.com/ThrowTheSwitch/Unity/archive/refs/tags/$(version).tar.gz",
              "https://github.com/ThrowTheSwitch/Unity.git")
 
+    add_versions("v2.7.0", "e84eb301ca7967831e68b1728f911e87fa2d345d8ddb64f897bc2f2ee24a321c")
     add_versions("v2.6.1", "b41a66d45a6b99758fb3202ace6178177014d52fc524bf1f72687d93e9867292")
     add_versions("v2.6.0", "aa4c9fb1ae5fc5242f914c65f3557e817e40cb37f04a31e5ff76d1ab89dbf674")
     add_versions("v2.5.2", "3786de6c8f389be3894feae4f7d8680a02e70ed4dbcce36109c8f8646da2671a")


### PR DESCRIPTION
New version of unity_test detected (package version: v2.6.1, last github version: v2.7.0)