### PR TITLE
Update homepage URL for angelscript package

### DIFF
--- a/packages/a/angelscript/xmake.lua
+++ b/packages/a/angelscript/xmake.lua
@@ -1,5 +1,5 @@
 package("angelscript")
-    set_homepage("http://angelcode.com/angelscript/")
+    set_homepage("https://angelcode.com/angelscript/")
     set_description("Extremely flexible cross-platform scripting library designed to allow applications to extend their functionality through external scripts")
     set_license("zlib")
 


### PR DESCRIPTION
[angelscript](https://github.com/xmake-io/xmake-repo/tree/dev/packages/a/angelscript)	-	Homepage link http://angelcode.com/angelscript/ is a permanent redirect to its HTTPS counterpart https://angelcode.com/angelscript/ and should be updated.