### PR TITLE
Update GLEW homepage URL to the official site

### DIFF
--- a/packages/g/glew/xmake.lua
+++ b/packages/g/glew/xmake.lua
@@ -1,6 +1,5 @@
 package("glew")
-
-    set_homepage("http://glew.sourceforge.net/")
+    set_homepage("https://glew.sourceforge.net/")
     set_description("A cross-platform open-source C/C++ extension loading library.")
 
     set_urls("https://github.com/nigels-com/glew/releases/download/glew-$(version)/glew-$(version).zip")


### PR DESCRIPTION
[glew](https://github.com/xmake-io/xmake-repo/tree/dev/packages/g/glew)	-	Homepage link http://glew.sourceforge.net/ is a permanent redirect to its HTTPS counterpart https://glew.sourceforge.net/ and should be updated.