### PR TITLE
omath: Update homepage URL to use HTTPS

### DIFF
--- a/packages/o/omath/xmake.lua
+++ b/packages/o/omath/xmake.lua
@@ -1,5 +1,5 @@
 package("omath")
-    set_homepage("http://libomath.org")
+    set_homepage("https://libomath.org/")
     set_description("Cross-platform modern general purpose math library written in C++23")
     set_license("zlib")
 


### PR DESCRIPTION
[omath](https://github.com/xmake-io/xmake-repo/blob/dev/packages/o/omath/xmake.lua)	-	Homepage link http://libomath.org/ is a permanent redirect to its HTTPS counterpart https://libomath.org/ and should be updated.