### PR TITLE
Update homepage URL for ODE package

### DIFF
--- a/packages/o/ode/xmake.lua
+++ b/packages/o/ode/xmake.lua
@@ -1,5 +1,5 @@
 package("ode")
-    set_homepage("http://ode.org/")
+    set_homepage("https://ode.org/")
     set_description("ODE is an open source, high performance library for simulating rigid body dynamics.")
     set_license("BSD-3-Clause")
 

--- a/packages/o/ode/xmake.lua
+++ b/packages/o/ode/xmake.lua
@@ -3,9 +3,15 @@ package("ode")
     set_description("ODE is an open source, high performance library for simulating rigid body dynamics.")
     set_license("BSD-3-Clause")
 
-    add_urls("https://bitbucket.org/odedevs/ode/get/$(version).zip")
-    add_versions("0.16.6", "a6845f79fb401995de1fa1882d067e6803c0cc3a755a5fb0a28874a5182d89d6")
-    add_versions("0.16.2", "000a5cdd0a81811cade2b0409ec06911a95e3c4c0d72a4cce3af6131115d0350")
+    local function parse_version(version)
+        local commits = {
+            ["0.16.6"] = "a5fc0bc282703ab34d7d3d2500bafae7428eeaa9"
+        }
+        return commits[tostring(version)]
+    end
+
+    add_urls("https://bitbucket.org/odedevs/ode/get/$(version).tar.gz", {version = parse_version})
+    add_versions("0.16.6", "05c0a0ea84c58c213d05e220adbc6559c473227505d5668a51493eed21b6c2f8")
 
     add_configs("libccd", {description = "Build with libccd.", default = false, type = "boolean"})
 


### PR DESCRIPTION
[ode](https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/packages/o/ode/xmake.lua)	-	Homepage link http://ode.org/ is a permanent redirect to its HTTPS counterpart https://ode.org/ and should be updated.