### PR TITLE
x265: Update homepage URL to use HTTPS

### DIFF
--- a/packages/x/x265/xmake.lua
+++ b/packages/x/x265/xmake.lua
@@ -1,5 +1,5 @@
 package("x265")
-    set_homepage("http://x265.org")
+    set_homepage("https://www.x265.org/")
     set_description("A free software library and application for encoding video streams into the H.265/MPEG-H HEVC compression format.")
     set_license("GPL-2.0")
 


### PR DESCRIPTION
[x265](https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/packages/x/x265/xmake.lua)	-	Homepage link http://x265.org/ is [dead](https://repology.org/link/http://x265.org/) (HTTP 429) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).