### PR TITLE
Update x264 homepage URL

### DIFF
--- a/packages/x/x264/xmake.lua
+++ b/packages/x/x264/xmake.lua
@@ -1,5 +1,5 @@
 package("x264")
-    set_homepage("https://www.videolan.org/developers/x264.html")
+    set_homepage("https://x264.org/")
     set_description("A free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format.")
     set_license("GPL-2.0")
 


### PR DESCRIPTION
[x264](https://github.com/xmake-io/xmake-repo/tree/dev/packages/x/x264)	-	Homepage link https://www.videolan.org/developers/x264.html is [dead](https://repology.org/link/https://www.videolan.org/developers/x264.html) (HTTP 418) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).