### PR TITLE
Update homepage URL for UASM package

### DIFF
--- a/packages/u/uasm/xmake.lua
+++ b/packages/u/uasm/xmake.lua
@@ -1,6 +1,6 @@
 package("uasm")
     set_kind("binary")
-    set_homepage("http://www.terraspace.co.uk/uasm.html")
+    set_homepage("https://www.terraspace.co.uk/uasm.html")
     set_description("UASM - Macro Assembler")
 
     add_urls("https://github.com/Terraspace/UASM/archive/refs/tags/$(version).tar.gz",


### PR DESCRIPTION
[uasm](https://github.com/xmake-io/xmake-repo/tree/dev/packages/u/uasm)	-	Homepage link http://www.terraspace.co.uk/uasm.html is a permanent redirect to its HTTPS counterpart https://www.terraspace.co.uk/uasm.html and should be updated.