### PR TITLE
Update homepage URL for unity_test package

### DIFF
--- a/packages/u/unity_test/xmake.lua
+++ b/packages/u/unity_test/xmake.lua
@@ -1,5 +1,5 @@
 package("unity_test")
-    set_homepage("http://www.throwtheswitch.org/unity")
+    set_homepage("https://www.throwtheswitch.org/unity")
     set_description("Simple Unit Testing for C")
     set_license("MIT")
 


### PR DESCRIPTION
[unity_test](https://github.com/xmake-io/xmake-repo/blob/dev/packages/u/unity_test/xmake.lua)	-	Homepage link http://www.throwtheswitch.org/unity is a permanent redirect to its HTTPS counterpart https://www.throwtheswitch.org/unity and should be updated.