### PR TITLE
Update UnZip homepage URL to HTTPS

### DIFF
--- a/packages/u/unzip/xmake.lua
+++ b/packages/u/unzip/xmake.lua
@@ -1,6 +1,6 @@
 package("unzip")
     set_kind("binary")
-    set_homepage("http://infozip.sourceforge.net/UnZip.html")
+    set_homepage("https://infozip.sourceforge.net/UnZip.html")
     set_description("UnZip is an extraction utility for archives compressed in .zip format.")
 
     add_urls("https://github.com/LuaDist/unzip/archive/refs/tags/$(version).zip")


### PR DESCRIPTION
[unzip](https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/packages/u/unzip/xmake.lua)	-	Homepage link http://infozip.sourceforge.net/UnZip.html is a permanent redirect to its HTTPS counterpart https://infozip.sourceforge.net/UnZip.html and should be updated.

Reference: https://repology.org/repository/xrepo/problems