### PR TITLE
Update mysql-build-tools homepage URL to HTTPS

### DIFF
--- a/packages/m/mysql-build-tools/xmake.lua
+++ b/packages/m/mysql-build-tools/xmake.lua
@@ -1,6 +1,6 @@
 package("mysql-build-tools")
     set_kind("binary")
-    set_homepage("http://www.mysql.com")
+    set_homepage("https://www.mysql.com/")
     set_description("This package help for mysql corss compilation")
     set_license("GPL-2.0")
 

--- a/packages/m/mysql-build-tools/xmake.lua
+++ b/packages/m/mysql-build-tools/xmake.lua
@@ -12,7 +12,7 @@ package("mysql-build-tools")
     add_configs("debug", {description = "Enable debug symbols.", default = false, readonly = true})
 
     add_deps("cmake")
-    add_deps("zlib", "zstd", "lz4", "openssl", "rapidjson", {host = true, private = true})
+    add_deps("zlib", "zstd", "lz4", "openssl3", "rapidjson", {host = true, private = true})
     if is_plat("linux") then
         add_deps("patchelf")
         add_deps("libedit", {host = true, private = true, configs = {terminal_db = "ncurses"}})


### PR DESCRIPTION
[mysql-build-tools](https://github.com/xmake-io/xmake-repo/blob/dev/packages/m/mysql-build-tools/xmake.lua)	-	Homepage link http://www.mysql.com/ is a permanent redirect to its HTTPS counterpart https://www.mysql.com/ and should be updated.