### PR TITLE
Update homepage URL for freeglut package

### DIFF
--- a/packages/f/freeglut/xmake.lua
+++ b/packages/f/freeglut/xmake.lua
@@ -1,5 +1,5 @@
 package("freeglut")
-    set_homepage("http://freeglut.sourceforge.net")
+    set_homepage("https://freeglut.sourceforge.net/")
     set_description("Free implementation of the OpenGL Utility Toolkit (GLUT)")
     set_license("MIT")
 


### PR DESCRIPTION
[freeglut](https://github.com/xmake-io/xmake-repo/blob/dev/packages/f/freeglut/xmake.lua)	-	Homepage link http://freeglut.sourceforge.net/ is a permanent redirect to its HTTPS counterpart https://freeglut.sourceforge.net/ and should be updated.