### PR TITLE
Update homepage URL for libgd package

### DIFF
--- a/packages/l/libgd/xmake.lua
+++ b/packages/l/libgd/xmake.lua
@@ -1,6 +1,5 @@
 package("libgd")
-
-    set_homepage("http://libgd.org/")
+    set_homepage("https://libgd.github.io/")
     set_description("GD is an open source code library for the dynamic creation of images by programmers.")
 
     add_urls("https://github.com/libgd/libgd/archive/refs/tags/gd-$(version).tar.gz")


### PR DESCRIPTION
[libgd](https://github.com/xmake-io/xmake-repo/tree/dev/packages/l/libgd)	-	Homepage link http://libgd.org/ is a permanent redirect to its HTTPS counterpart https://libgd.org/ and should be updated.