### PR TITLE
soxr: Fix homepage

### DIFF
--- a/packages/s/soxr/xmake.lua
+++ b/packages/s/soxr/xmake.lua
@@ -1,5 +1,5 @@
 package("soxr")
-    set_homepage("https://sourceforge.net/projects/soxr")
+    set_homepage("https://sourceforge.net/projects/soxr/")
     set_description("The SoX Resampler library libsoxr performs fast, high-quality one-dimensional sample rate conversion.")
     set_license("LGPL-2.1")
 


### PR DESCRIPTION
[soxr](https://github.com/xmake-io/xmake-repo/tree/dev/packages/s/soxr)	-	Homepage link https://sourceforge.net/projects/soxr needs a trailing slash added, otherwise there's a javascript redirect.