### PR TITLE
Update homepage URL for yasm package

### DIFF
--- a/packages/y/yasm/xmake.lua
+++ b/packages/y/yasm/xmake.lua
@@ -1,6 +1,6 @@
 package("yasm")
     set_kind("binary")
-    set_homepage("https://yasm.tortall.net/")
+    set_homepage("https://github.com/yasm/yasm")
     set_description("Modular BSD reimplementation of NASM.")
 
     add_urls("https://www.tortall.net/projects/yasm/releases/yasm-$(version).tar.gz",


### PR DESCRIPTION
[yasm](https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/packages/y/yasm/xmake.lua)	-	Homepage link https://yasm.tortall.net/ is [dead](https://repology.org/link/https://yasm.tortall.net/) (DNS error: no address record) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).