### PR TITLE
Auto-update microsoft-gsl to v5.0.0

### DIFF
--- a/packages/m/microsoft-gsl/xmake.lua
+++ b/packages/m/microsoft-gsl/xmake.lua
@@ -7,6 +7,7 @@ package("microsoft-gsl")
     add_urls("https://github.com/microsoft/GSL/archive/refs/tags/$(version).tar.gz",
              "https://github.com/microsoft/GSL.git")
 
+    add_versions("v5.0.0", "e646da6ac00a885cfae33dc935e52bb42bd1d05e41b8437cbc25ca3d74930f35")
     add_versions("v4.2.2", "59e2a0a0ea22e8bcf9db2dc4d4bd21212ac6595748295fc27a7e02cf75eac4b5")
     add_versions("v4.2.1", "d959f1cb8bbb9c94f033ae5db60eaf5f416be1baa744493c32585adca066fe1f")
     add_versions("v4.2.0", "2c717545a073649126cb99ebd493fa2ae23120077968795d2c69cbab821e4ac6")


### PR DESCRIPTION
New version of microsoft-gsl detected (package version: v4.2.2, last github version: v5.0.0)