### PR TITLE
Add raptor2, lrdf

### DIFF
--- a/packages/l/lrdf/port/xmake.lua
+++ b/packages/l/lrdf/port/xmake.lua
@@ -16,7 +16,7 @@ target("lrdf")
     end
 
     if is_plat("mingw") and is_kind("shared") then
-        add_cxflags("-fvisibility=default")
+        add_shflags("-Wl,--export-all-symbols")
     end
 
     before_build(function(target)

--- a/packages/l/lrdf/port/xmake.lua
+++ b/packages/l/lrdf/port/xmake.lua
@@ -4,6 +4,10 @@ add_requires("raptor2")
 target("lrdf")
     set_kind("$(kind)")
 
+    if not is_plat("windows") then
+        add_defines("HAVE_OPENSSL")
+    end
+
     if is_plat("windows") then
         add_cflags("/D_CRT_SECURE_NO_WARNINGS")
         if is_kind("shared") then
@@ -92,7 +96,7 @@ target("lrdf")
         end
     end)
 
-    add_files("src/lrdf.c", "src/lrdf_multi.c")
+    add_files("src/lrdf.c", "src/lrdf_multi.c", "src/md5.c")
     add_includedirs(".", "src")
     add_headerfiles("lrdf.h", "lrdf_types.h")
 

--- a/packages/l/lrdf/port/xmake.lua
+++ b/packages/l/lrdf/port/xmake.lua
@@ -9,8 +9,8 @@ target("lrdf")
     end
 
     if is_plat("windows", "mingw") then
-        add_cflags("/D_CRT_SECURE_NO_WARNINGS")
-        if is_kind("shared") then
+        add_defines("_CRT_SECURE_NO_WARNINGS")
+        if is_plat("windows") and is_kind("shared") then
             add_rules("utils.symbols.export_all")
         end
     end
@@ -20,8 +20,8 @@ target("lrdf")
     end
 
     before_build(function(target)
-        local srctypes = path.join("lrdf_types.h")
-        local srcmain = path.join("lrdf.h")
+        local srctypes = "lrdf_types.h"
+        local srcmain = "lrdf.h"
         local srclrdf = path.join("src", "lrdf.c")
         local srclmulti = path.join("src", "lrdf_multi.c")
 

--- a/packages/l/lrdf/port/xmake.lua
+++ b/packages/l/lrdf/port/xmake.lua
@@ -4,7 +4,7 @@ add_requires("raptor2")
 target("lrdf")
     set_kind("$(kind)")
 
-    if not is_plat("windows", "mingw") then
+    if not is_plat("windows", "mingw", "wasm") then
         add_defines("HAVE_OPENSSL")
     end
 
@@ -13,6 +13,10 @@ target("lrdf")
         if is_kind("shared") then
             add_rules("utils.symbols.export_all")
         end
+    end
+
+    if is_plat("mingw") and is_kind("shared") then
+        add_cxflags("-fvisibility=default")
     end
 
     before_build(function(target)

--- a/packages/l/lrdf/port/xmake.lua
+++ b/packages/l/lrdf/port/xmake.lua
@@ -1,0 +1,99 @@
+add_rules("mode.debug", "mode.release")
+add_requires("raptor2")
+
+target("lrdf")
+    set_kind("$(kind)")
+
+    if is_plat("windows") then
+        add_cflags("/D_CRT_SECURE_NO_WARNINGS")
+        if is_kind("shared") then
+            add_rules("utils.symbols.export_all")
+        end
+    end
+
+    before_build(function(target)
+        local srctypes = path.join("lrdf_types.h")
+        local srcmain = path.join("lrdf.h")
+        local srclrdf = path.join("src", "lrdf.c")
+        local srclmulti = path.join("src", "lrdf_multi.c")
+
+        if is_plat("windows") then
+            -- lrdf_types.h: add stdint.h for int64_t
+            local content = io.readfile(srctypes)
+            content = content:gsub("#include <sys/types.h>",
+                "#include <stdint.h>\n#include <sys/types.h>")
+            io.writefile(srctypes, content)
+
+            -- lrdf.h: add stdint.h for int64_t
+            content = io.readfile(srcmain)
+            content = content:gsub("#include <sys/types.h>",
+                "#include <stdint.h>\n#include <sys/types.h>")
+            io.writefile(srcmain, content)
+
+            -- src/lrdf.c: wrap POSIX headers, add Windows headers, patch functions
+            content = io.readfile(srclrdf)
+
+            content = content:gsub("#include <unistd.h>",
+                [[#ifndef _WIN32
+#include <unistd.h>
+#endif]])
+            content = content:gsub("#include <sys/time.h>",
+                [[#ifndef _WIN32
+#include <sys/time.h>
+#endif]])
+            content = content:gsub('#include "lrdf.h"',
+                [[#include "lrdf.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <process.h>
+#define strncasecmp _strnicmp
+#endif]])
+            content = content:gsub(
+                [[struct timeval tv;
+
+    world = raptor_new_world%(%);
+    lrdf_more_triples%(%d+%);
+
+    /%* A UID to add to genids to make them safer %*/
+    gettimeofday%(&tv, NULL%);
+    lrdf_uid = %(unsigned int%) getpid%(%);
+    lrdf_uid %^= %(unsigned int%) tv%.tv_usec;]],
+                [[world = raptor_new_world();
+    lrdf_more_triples(256);
+
+    /* A UID to add to genids to make them safer */
+#ifdef _WIN32
+    lrdf_uid = (unsigned int) _getpid();
+    {
+        LARGE_INTEGER freq, counter;
+        QueryPerformanceFrequency(&freq);
+        QueryPerformanceCounter(&counter);
+        lrdf_uid ^= (unsigned int)((counter.QuadPart * 1000000 / freq.QuadPart) %% 1000000);
+    }
+#else
+    {
+        struct timeval tv;
+        gettimeofday(&tv, NULL);
+        lrdf_uid = (unsigned int) getpid();
+        lrdf_uid ^= (unsigned int) tv.tv_usec;
+    }
+#endif]])
+
+            io.writefile(srclrdf, content)
+
+            -- src/lrdf_multi.c: wrap unistd.h
+            content = io.readfile(srclmulti)
+            content = content:gsub("#include <unistd.h>",
+                [[#ifndef _WIN32
+#include <unistd.h>
+#endif]])
+            io.writefile(srclmulti, content)
+        end
+    end)
+
+    add_files("src/lrdf.c", "src/lrdf_multi.c", "src/md5.c")
+    add_includedirs(".", "src")
+    add_headerfiles("lrdf.h", "lrdf_types.h")
+
+    add_packages("raptor2")

--- a/packages/l/lrdf/port/xmake.lua
+++ b/packages/l/lrdf/port/xmake.lua
@@ -92,7 +92,7 @@ target("lrdf")
         end
     end)
 
-    add_files("src/lrdf.c", "src/lrdf_multi.c", "src/md5.c")
+    add_files("src/lrdf.c", "src/lrdf_multi.c")
     add_includedirs(".", "src")
     add_headerfiles("lrdf.h", "lrdf_types.h")
 

--- a/packages/l/lrdf/port/xmake.lua
+++ b/packages/l/lrdf/port/xmake.lua
@@ -4,11 +4,11 @@ add_requires("raptor2")
 target("lrdf")
     set_kind("$(kind)")
 
-    if not is_plat("windows") then
+    if not is_plat("windows", "mingw") then
         add_defines("HAVE_OPENSSL")
     end
 
-    if is_plat("windows") then
+    if is_plat("windows", "mingw") then
         add_cflags("/D_CRT_SECURE_NO_WARNINGS")
         if is_kind("shared") then
             add_rules("utils.symbols.export_all")
@@ -21,7 +21,7 @@ target("lrdf")
         local srclrdf = path.join("src", "lrdf.c")
         local srclmulti = path.join("src", "lrdf_multi.c")
 
-        if is_plat("windows") then
+        if is_plat("windows", "mingw") then
             -- lrdf_types.h: add stdint.h for int64_t
             local content = io.readfile(srctypes)
             content = content:gsub("#include <sys/types.h>",

--- a/packages/l/lrdf/xmake.lua
+++ b/packages/l/lrdf/xmake.lua
@@ -10,7 +10,7 @@ package("lrdf")
 
     add_deps("raptor2")
 
-    on_install(function(package)
+    on_install("!iphoneos", function(package)
         local configs = {}
         configs.kind = package:config("shared") and "shared" or "static"
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")

--- a/packages/l/lrdf/xmake.lua
+++ b/packages/l/lrdf/xmake.lua
@@ -3,7 +3,8 @@ package("lrdf")
     set_description("A lightweight RDF library with extensions for LADSPA")
     set_license("GPL-2.0")
 
-    add_urls("https://github.com/swh/LRDF/archive/refs/tags/v$(version).tar.gz")
+    add_urls("https://github.com/swh/LRDF/archive/refs/tags/v$(version).tar.gz",
+             "https://github.com/swh/LRDF.git")
 
     add_versions("0.6.1", "d579417c477ac3635844cd1b94f273ee2529a8c3b6b21f9b09d15f462b89b1ef")
 

--- a/packages/l/lrdf/xmake.lua
+++ b/packages/l/lrdf/xmake.lua
@@ -1,0 +1,21 @@
+package("lrdf")
+    set_homepage("https://github.com/swh/LRDF")
+    set_description("A lightweight RDF library with extensions for LADSPA")
+    set_license("GPL-2.0")
+
+    add_urls("https://github.com/swh/LRDF/archive/refs/tags/v$(version).tar.gz")
+
+    add_versions("0.6.1", "d579417c477ac3635844cd1b94f273ee2529a8c3b6b21f9b09d15f462b89b1ef")
+
+    add_deps("raptor2")
+
+    on_install(function(package)
+        local configs = {}
+        configs.kind = package:config("shared") and "shared" or "static"
+        os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
+        import("package.tools.xmake").install(package, configs)
+    end)
+
+    on_test(function(package)
+        assert(package:has_cfuncs("lrdf_read_file", {includes = "lrdf.h"}))
+    end)

--- a/packages/l/lrdf/xmake.lua
+++ b/packages/l/lrdf/xmake.lua
@@ -12,7 +12,6 @@ package("lrdf")
 
     on_install("!iphoneos", function(package)
         local configs = {}
-        configs.kind = package:config("shared") and "shared" or "static"
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         import("package.tools.xmake").install(package, configs)
     end)

--- a/packages/r/raptor2/port/xmake.lua
+++ b/packages/r/raptor2/port/xmake.lua
@@ -140,7 +140,7 @@ target("raptor2")
         io.writefile("src/raptor_config.h", template)
 
         -- Windows: add <io.h> and fix access() macro for MSVC
-        if is_plat("windows") then
+        if is_plat("windows", "mingw") then
             local cfg = io.readfile("src/raptor_config.h")
             cfg = cfg:gsub("#ifdef WIN32\n", "#ifdef WIN32\n#include <io.h>\n")
             cfg = cfg:gsub("# +define access%(p,m%)%s+_access%(p,m%)",
@@ -155,7 +155,7 @@ target("raptor2")
         io.writefile("src/raptor_libxml.c", libxml)
 
         -- Windows: add missing <windows.h> include
-        if is_plat("windows") then
+        if is_plat("windows", "mingw") then
             local win32 = io.readfile("src/raptor_win32.c")
             win32 = win32:gsub("#ifdef WIN32\n", "#ifdef WIN32\n#include <windows.h>\n")
             io.writefile("src/raptor_win32.c", win32)

--- a/packages/r/raptor2/port/xmake.lua
+++ b/packages/r/raptor2/port/xmake.lua
@@ -135,9 +135,8 @@ target("raptor2")
             elseif v == false then return "0"
             else return tostring(v) end
         end)
-        local cfg = io.readfile("src/raptor_config.h")
-        cfg = cfg .. "\n#define HAVE_STRINGS_H 1\n"
-        io.writefile("src/raptor_config.h", cfg)
+        template = template .. "\n#define HAVE_STRINGS_H 1\n"
+        io.writefile("src/raptor_config.h", template)
 
         -- Windows: add <io.h> and fix access() macro for MSVC
         if is_plat("windows") then

--- a/packages/r/raptor2/port/xmake.lua
+++ b/packages/r/raptor2/port/xmake.lua
@@ -135,7 +135,9 @@ target("raptor2")
             elseif v == false then return "0"
             else return tostring(v) end
         end)
-        io.writefile("src/raptor_config.h", template)
+        local cfg = io.readfile("src/raptor_config.h")
+        cfg = cfg .. "\n#define HAVE_STRINGS_H 1\n"
+        io.writefile("src/raptor_config.h", cfg)
 
         -- Windows: add <io.h> and fix access() macro for MSVC
         if is_plat("windows") then

--- a/packages/r/raptor2/port/xmake.lua
+++ b/packages/r/raptor2/port/xmake.lua
@@ -1,0 +1,160 @@
+option("libxslt", {default = true})
+
+add_rules("mode.debug", "mode.release")
+
+add_requires("libxml2", "libcurl")
+if has_config("libxslt") then
+    add_requires("libxslt")
+end
+
+set_configvar("RAPTOR_VERSION_DECIMAL", 20016)
+set_configvar("RAPTOR_VERSION_MAJOR", 2)
+set_configvar("RAPTOR_VERSION_MINOR", 0)
+set_configvar("RAPTOR_VERSION_RELEASE", 16)
+set_configvar("VERSION", "2.0.16")
+
+local defines = {
+    HAVE_ERRNO_H = true,
+    HAVE_LIMITS_H = true,
+    HAVE_SETJMP_H = true,
+    HAVE_STDDEF_H = true,
+    HAVE_STDLIB_H = true,
+    HAVE_STRING_H = true,
+    HAVE_XMLCTXTUSEOPTIONS = true,
+    HAVE_XMLSAX2INTERNALSUBSET = true,
+    RAPTOR_LIBXML_HTML_PARSE_NONET = true,
+    RAPTOR_LIBXML_XML_PARSE_NONET = true,
+    RAPTOR_LIBXML_XMLSAXHANDLER_EXTERNALSUBSET = true,
+    RAPTOR_LIBXML_XMLSAXHANDLER_INITIALIZED = true,
+    RAPTOR_LIBXML_ENTITY_ETYPE = true,
+    RAPTOR_LIBXML_ENTITY_NAME_LENGTH = true,
+    HAVE_RAPTOR_PARSE_DATE = true,
+    RAPTOR_PARSER_RDFXML = true,
+    RAPTOR_PARSER_NTRIPLES = true,
+    RAPTOR_PARSER_TURTLE = true,
+    RAPTOR_PARSER_TRIG = true,
+    RAPTOR_PARSER_RSS = true,
+    RAPTOR_PARSER_GUESS = true,
+    RAPTOR_PARSER_RDFA = true,
+    RAPTOR_PARSER_NQUADS = true,
+    RAPTOR_PARSER_GRDDL = has_config("libxslt"),
+    RAPTOR_SERIALIZER_RDFXML = true,
+    RAPTOR_SERIALIZER_NTRIPLES = true,
+    RAPTOR_SERIALIZER_RDFXML_ABBREV = true,
+    RAPTOR_SERIALIZER_TURTLE = true,
+    RAPTOR_SERIALIZER_RSS_1_0 = true,
+    RAPTOR_SERIALIZER_ATOM = true,
+    RAPTOR_SERIALIZER_DOT = true,
+    RAPTOR_SERIALIZER_HTML = true,
+    RAPTOR_SERIALIZER_JSON = true,
+    RAPTOR_SERIALIZER_NQUADS = true,
+    SIZEOF_UNSIGNED_CHAR = 1,
+    SIZEOF_UNSIGNED_SHORT = 2,
+    SIZEOF_UNSIGNED_INT = 4,
+    SIZEOF_UNSIGNED_LONG = is_plat("windows") and 4 or (is_arch("x86_64", "arm64", "x64") and 8 or 4),
+    SIZEOF_UNSIGNED_LONG_LONG = 8,
+    RAPTOR_VERSION_DECIMAL = 20016,
+    RAPTOR_MIN_VERSION_DECIMAL = 20016,
+    RAPTOR_WWW_DEFINE = "RAPTOR_WWW_LIBCURL",
+    RAPTOR_XML_DEFINE = "RAPTOR_XML_LIBXML",
+}
+
+if not is_plat("windows") then
+    defines.HAVE_UNISTD_H = true
+    defines.HAVE_FCNTL_H = true
+    defines.HAVE_SYS_PARAM_H = true
+    defines.HAVE_SYS_STAT_H = true
+    defines.HAVE_SYS_TIME_H = true
+    defines.HAVE_TIME_H = true
+    defines.TIME_WITH_SYS_TIME = true
+    defines.HAVE_GETTIMEOFDAY = true
+    defines.HAVE_SETJMP = true
+    defines.HAVE_STAT = true
+    defines.HAVE_STRCASECMP = true
+    defines.HAVE_STRTOK_R = true
+    defines.HAVE_VASPRINTF = true
+    defines.HAVE_VSNPRINTF = true
+    defines.HAVE_ISASCII = true
+else
+    defines.HAVE___FUNCTION__ = true
+    defines.HAVE_STRICMP = true
+    defines.HAVE__STRICMP = true
+    defines.HAVE_SNPRINTF = true
+    defines.HAVE_VSNPRINTF = true
+    defines.HAVE__ACCESS = true
+end
+
+target("raptor2")
+    set_kind("$(kind)")
+    set_languages("c99")
+    add_defines("RAPTOR_INTERNAL=1", "LIBRDFA_IN_RAPTOR=1", "HAVE_CONFIG_H")
+    if not is_kind("shared") then
+        add_defines("RAPTOR_STATIC")
+    end
+    if is_plat("windows") then
+        add_defines("WIN32")
+    end
+    set_configdir("src")
+    add_configfiles("src/(raptor2.h.in)", {filename = "raptor2.h", pattern = "@([A-Z_]+)@"})
+    add_includedirs("src", "librdfa")
+    add_includedirs("include/raptor2", {public = true})
+    add_headerfiles("include/(raptor2/*.h)")
+
+    add_files("src/*.c", "librdfa/*.c")
+    remove_files("src/raptor_json.c")
+    if not has_config("libxslt") then
+        remove_files("src/raptor_grddl.c")
+    end
+    remove_files("src/raptor_nfc_icu.c", "src/raptor_nfc_test.c",
+                 "src/raptor_permute_test.c", "src/raptor_www_test.c")
+
+    add_packages("libxml2", "libcurl")
+    if has_config("libxslt") then
+        add_packages("libxslt")
+    end
+
+    before_build(function(target)
+        -- Install public headers
+        os.mkdir("include/raptor2")
+        os.cp("src/raptor.h", "include/raptor2/raptor.h")
+        os.cp("src/raptor2.h", "include/raptor2/raptor2.h")
+
+        -- Generate raptor_config.h from cmake template
+        local template = io.readfile("src/raptor_config_cmake.h.in")
+        template = template:gsub("#cmakedefine (%S+)", function(var)
+            if defines[var] then
+                return "#define " .. var .. " 1"
+            else
+                return "#undef " .. var
+            end
+        end)
+        template = template:gsub("@([A-Z_]+)@", function(var)
+            local v = defines[var]
+            if v == true then return "1"
+            elseif v == false then return "0"
+            else return tostring(v) end
+        end)
+        io.writefile("src/raptor_config.h", template)
+
+        -- Windows: add <io.h> and fix access() macro for MSVC
+        if is_plat("windows") then
+            local cfg = io.readfile("src/raptor_config.h")
+            cfg = cfg:gsub("#ifdef WIN32\n", "#ifdef WIN32\n#include <io.h>\n")
+            cfg = cfg:gsub("# +define access%(p,m%)%s+_access%(p,m%)",
+                "#define access(p,m) _access((const char*)(p),m)")
+            io.writefile("src/raptor_config.h", cfg)
+        end
+
+        -- Patch raptor_libxml.c: fix build error with libxml2 >= 2.11
+        local libxml = io.readfile("src/raptor_libxml.c")
+        libxml = libxml:gsub("#if LIBXML_VERSION >= 20627",
+            "#if LIBXML_VERSION >= 20627 && LIBXML_VERSION < 21000")
+        io.writefile("src/raptor_libxml.c", libxml)
+
+        -- Windows: add missing <windows.h> include
+        if is_plat("windows") then
+            local win32 = io.readfile("src/raptor_win32.c")
+            win32 = win32:gsub("#ifdef WIN32\n", "#ifdef WIN32\n#include <windows.h>\n")
+            io.writefile("src/raptor_win32.c", win32)
+        end
+    end)

--- a/packages/r/raptor2/port/xmake.lua
+++ b/packages/r/raptor2/port/xmake.lua
@@ -91,7 +91,7 @@ target("raptor2")
     if not is_kind("shared") then
         add_defines("RAPTOR_STATIC")
     end
-    if is_plat("windows") then
+    if is_plat("windows", "mingw") then
         add_defines("WIN32")
     end
     set_configdir("src")

--- a/packages/r/raptor2/port/xmake.lua
+++ b/packages/r/raptor2/port/xmake.lua
@@ -72,7 +72,6 @@ if not is_plat("windows") then
     defines.HAVE_STAT = true
     defines.HAVE_STRCASECMP = true
     defines.HAVE_STRINGS_H = true
-    defines.HAVE_STRTOK_R = true
     defines.HAVE_VASPRINTF = true
     defines.HAVE_VSNPRINTF = true
     defines.HAVE_ISASCII = true

--- a/packages/r/raptor2/port/xmake.lua
+++ b/packages/r/raptor2/port/xmake.lua
@@ -135,7 +135,9 @@ target("raptor2")
             elseif v == false then return "0"
             else return tostring(v) end
         end)
-        template = template .. "\n#define HAVE_STRINGS_H 1\n"
+        if not is_plat("windows") then
+            template = template .. "\n#define HAVE_STRINGS_H 1\n"
+        end
         io.writefile("src/raptor_config.h", template)
 
         -- Windows: add <io.h> and fix access() macro for MSVC

--- a/packages/r/raptor2/port/xmake.lua
+++ b/packages/r/raptor2/port/xmake.lua
@@ -71,6 +71,7 @@ if not is_plat("windows") then
     defines.HAVE_SETJMP = true
     defines.HAVE_STAT = true
     defines.HAVE_STRCASECMP = true
+    defines.HAVE_STRINGS_H = true
     defines.HAVE_STRTOK_R = true
     defines.HAVE_VASPRINTF = true
     defines.HAVE_VSNPRINTF = true

--- a/packages/r/raptor2/xmake.lua
+++ b/packages/r/raptor2/xmake.lua
@@ -22,7 +22,7 @@ package("raptor2")
         end
     end)
 
-    on_install(function(package)
+    on_install("!iphoneos", function(package)
         local configs = {}
         configs.kind = package:config("shared") and "shared" or "static"
         configs.libxslt = package:config("libxslt")

--- a/packages/r/raptor2/xmake.lua
+++ b/packages/r/raptor2/xmake.lua
@@ -1,0 +1,32 @@
+package("raptor2")
+    set_homepage("https://librdf.org/raptor/")
+    set_description("A library that provides a set of parsers and serializers that generate Resource Description Framework (RDF) triples by parsing syntaxes or serialize the triples into a syntax.")
+    set_license("LGPL-2.1-or-later")
+
+    add_urls("https://download.librdf.org/source/raptor2-$(version).tar.gz")
+
+    add_versions("2.0.16", "089db78d7ac982354bdbf39d973baf09581e6904ac4c92a98c5caadb3de44680")
+
+    add_configs("libxslt", {description = "Enable GRDDL parser", default = true, type = "boolean"})
+
+    add_deps("libxml2", "libcurl")
+    add_links("raptor2")
+    add_includedirs("include/raptor2", {public = true})
+
+    on_load(function(package)
+        if package:config("libxslt") then
+            package:add("deps", "libxslt")
+        end
+    end)
+
+    on_install(function(package)
+        local configs = {}
+        configs.kind = package:config("shared") and "shared" or "static"
+        configs.libxslt = package:config("libxslt")
+        os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
+        import("package.tools.xmake").install(package, configs)
+    end)
+
+    on_test(function(package)
+        assert(package:has_cfuncs("raptor_world_open", {includes = "raptor2.h"}))
+    end)

--- a/packages/r/raptor2/xmake.lua
+++ b/packages/r/raptor2/xmake.lua
@@ -10,8 +10,7 @@ package("raptor2")
     add_configs("libxslt", {description = "Enable GRDDL parser", default = true, type = "boolean"})
 
     add_deps("libxml2", "libcurl")
-    add_links("raptor2")
-    add_includedirs("include/raptor2", {public = true})
+    add_includedirs("include/raptor2")
 
     on_load(function(package)
         if package:config("libxslt") then
@@ -24,7 +23,6 @@ package("raptor2")
 
     on_install("!iphoneos", function(package)
         local configs = {}
-        configs.kind = package:config("shared") and "shared" or "static"
         configs.libxslt = package:config("libxslt")
         os.cp(path.join(package:scriptdir(), "port", "xmake.lua"), "xmake.lua")
         import("package.tools.xmake").install(package, configs)

--- a/packages/r/raptor2/xmake.lua
+++ b/packages/r/raptor2/xmake.lua
@@ -17,6 +17,9 @@ package("raptor2")
         if package:config("libxslt") then
             package:add("deps", "libxslt")
         end
+        if not package:config("shared") then
+            package:add("defines", "RAPTOR_STATIC", {public = true})
+        end
     end)
 
     on_install(function(package)


### PR DESCRIPTION
Adds raptor2 2.0.16 and lrdf 0.6.1. Makes use of custom xmake build scripts, patches both to build on windows.
The .git link for raptor is https://github.com/dajobe/raptor , but would've required additional build tools, so it wasn't added.

Closes #9850 .