### PR TITLE
libfixmath: update homepage

### DIFF
--- a/packages/l/libfixmath/xmake.lua
+++ b/packages/l/libfixmath/xmake.lua
@@ -1,10 +1,11 @@
 package("libfixmath")
-    set_homepage("https://code.google.com/p/libfixmath/")
+    set_homepage("https://github.com/PetteriAimonen/libfixmath")
     set_description("Cross Platform Fixed Point Maths Library")
     set_license("MIT")
 
     add_urls("https://github.com/PetteriAimonen/libfixmath.git")
 
+    add_versions("2026.07.14", "ed9391c33a56078c126e3e7a811a883c8c87daa2")
     add_versions("2023.08.06", "d308e466e1a09118d03f677c52e5fbf402f6fdd0")
 
     on_install(function (package)


### PR DESCRIPTION
[libfixmath](https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/packages/l/libfixmath/xmake.lua)	-	Homepage link https://code.google.com/p/libfixmath/ points to Google Code which was discontinued. The link should be updated (probably along with download URLs). If this link is still alive, it may point to a new project homepage.