### PR TITLE
libmill: Update homepage URL to use HTTPS

### DIFF
--- a/packages/l/libmill/xmake.lua
+++ b/packages/l/libmill/xmake.lua
@@ -1,5 +1,5 @@
 package("libmill")
-    set_homepage("http://libmill.org")
+    set_homepage("https://libmill.org/")
     set_description("Go-style concurrency in C")
 
     set_urls("https://github.com/sustrik/libmill.git")


### PR DESCRIPTION
[libmill](https://github.com/xmake-io/xmake-repo/blob/dev/packages/l/libmill/xmake.lua)	-	Homepage link http://libmill.org/ is a permanent redirect to its HTTPS counterpart https://libmill.org/ and should be updated.