### PR TITLE
Auto-update iowow to v1.5.2

### DIFF
--- a/packages/i/iowow/xmake.lua
+++ b/packages/i/iowow/xmake.lua
@@ -6,6 +6,7 @@ package("iowow")
     add_urls("https://github.com/Softmotions/iowow/archive/refs/tags/$(version).tar.gz",
              "https://github.com/Softmotions/iowow.git")
 
+    add_versions("v1.5.2", "24b91edcc69a48a752b2a1892a0b935e980afb8a04eb659c699e77d29253ab61")
     add_versions("v1.4.18", "ef4ee56dd77ce326fff25b6f41e7d78303322cca3f11cf5683ce9abfda34faf9")
     add_versions("v1.4.17", "13a851026dbc1f31583fba96986e86e94a7554f9e7d38aa12a9ea5dbebdf328b")
 


### PR DESCRIPTION
New version of iowow detected (package version: v1.4.18, last github version: v1.5.2)